### PR TITLE
[Infra Update] test(dev) 환경의 서버간 통신을 위한 환경변수 처리

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -19,7 +19,9 @@ async function bootstrap(): Promise<void> {
   const port = process.env.PORT || 3000;
 
   await app.listen(port, () => {
-    Logger.log(`Listening at http://localhost:${port}`);
+    if (!['production', 'test'].includes(process.env.NODE_ENV)) {
+      Logger.log(`Server Listening at http://localhost:${port}`);
+    }
   });
 }
 

--- a/apps/api/src/settings/appSetting.ts
+++ b/apps/api/src/settings/appSetting.ts
@@ -12,6 +12,7 @@ export class AppSetting {
       'http://localhost:4200',
       'http://localhost:3011',
       'https://project-lc.vercel.app',
+      'https://dev-project-lc.vercel.app',
     ],
     credentials: true,
   };

--- a/libs/hooks/src/axios.ts
+++ b/libs/hooks/src/axios.ts
@@ -1,7 +1,4 @@
 import axios from 'axios';
-import dotenv from 'dotenv';
-
-dotenv.config();
 
 export const cancelToken = axios.CancelToken;
 export const { isCancel } = axios;

--- a/libs/hooks/src/axios.ts
+++ b/libs/hooks/src/axios.ts
@@ -1,10 +1,13 @@
 import axios from 'axios';
+import dotenv from 'dotenv';
+
+dotenv.config();
 
 export const cancelToken = axios.CancelToken;
 export const { isCancel } = axios;
 const axiosInstance = axios.create({
   withCredentials: true,
-  baseURL: 'http://localhost:3000',
+  baseURL: process.env.NEXT_PUBLIC_API_HOST || 'http://localhost:3000',
 });
 
 export default axiosInstance;


### PR DESCRIPTION
현재 코드에서는 host명이 고정되어 있어 테스트 환경에서 (localhost) 통신에 대한 테스트를 올바르게 진행할 수 없다.

# 할일

- [x]  vercel 테스트용 도메인 구성
- [x]  환경에 따라 동적으로 host명 부여 (환경변수)

    환경변수 추가 `API_HOST`

    - 테스트 환경
        - [x]  API 서버 → 테스트용 ALB 엔드포인트
        - [x]  Web 서버 → 테스트용 Vercel 엔드포인트

# 테스트 항목

- [x]  project-lc.vercel.app에서 api 서버로 올바르게 요청할 수 있다.
- [x]  dev-project-lc.vercel.app에서 에서 api 서버로 올바르게 요청할 수 있다.