### PR TITLE
상품 prisma 모델링 추가

### DIFF
--- a/libs/prisma-orm/prisma/migrations/20210824074940_/migration.sql
+++ b/libs/prisma-orm/prisma/migrations/20210824074940_/migration.sql
@@ -1,0 +1,69 @@
+-- CreateTable
+CREATE TABLE `Goods` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `sellerId` INTEGER NOT NULL,
+    `goods_name` VARCHAR(191) NOT NULL,
+    `summary` VARCHAR(191) NOT NULL,
+    `goods_status` ENUM('normal', 'runout', 'purchasing', 'unsold') NOT NULL DEFAULT 'normal',
+    `cancel_type` VARCHAR(191) NOT NULL DEFAULT '0',
+    `contents` LONGTEXT,
+    `contents_mobile` LONGTEXT,
+    `common_contents` LONGTEXT NOT NULL,
+    `shipping_policy` ENUM('shop', 'goods') NOT NULL DEFAULT 'shop',
+    `goods_shipping_policy` ENUM('unlimit', 'limit') NOT NULL DEFAULT 'unlimit',
+    `unlimit_shipping_price` INTEGER UNSIGNED,
+    `limit_shipping_ea` TINYINT UNSIGNED,
+    `limit_shipping_price` INTEGER UNSIGNED,
+    `limit_shipping_subprice` TINYINT UNSIGNED,
+    `shipping_weight_policy` ENUM('shop', 'goods') NOT NULL DEFAULT 'shop',
+    `min_purchase_limit` ENUM('unlimit', 'limit') NOT NULL DEFAULT 'unlimit',
+    `min_purchase_ea` MEDIUMINT UNSIGNED,
+    `max_purchase_limit` ENUM('unlimit', 'limit') NOT NULL DEFAULT 'unlimit',
+    `max_purchase_ea` MEDIUMINT UNSIGNED,
+    `max_urchase_order_limit` MEDIUMINT UNSIGNED,
+    `admin_memo` TEXT,
+    `option_use` VARCHAR(191) NOT NULL DEFAULT '0',
+    `option_view_type` ENUM('divide', 'join') NOT NULL DEFAULT 'divide',
+    `option_suboption_use` VARCHAR(191) NOT NULL DEFAULT '0',
+    `member_input_use` VARCHAR(191) NOT NULL DEFAULT '0',
+    `image` VARCHAR(191) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `GoodsOptions` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `goodsId` INTEGER NOT NULL,
+    `default_option` ENUM('y', 'n') NOT NULL DEFAULT 'n',
+    `option_type` VARCHAR(191) NOT NULL DEFAULT 'direct',
+    `option_title` VARCHAR(191),
+    `option_code` VARCHAR(191),
+    `consumer_price` DECIMAL(10, 2) NOT NULL,
+    `price` DECIMAL(10, 2) NOT NULL,
+    `color` VARCHAR(10),
+    `weight` DOUBLE,
+    `option_view` ENUM('Y', 'N') NOT NULL DEFAULT 'Y',
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `GoodsOptionsSupplies` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `goodsOptionsId` INTEGER NOT NULL,
+    `stock` INTEGER UNSIGNED NOT NULL,
+    `badstock` INTEGER UNSIGNED,
+    `safe_stock` INTEGER DEFAULT 0,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `Goods` ADD FOREIGN KEY (`sellerId`) REFERENCES `Seller`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `GoodsOptions` ADD FOREIGN KEY (`goodsId`) REFERENCES `Goods`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `GoodsOptionsSupplies` ADD FOREIGN KEY (`goodsOptionsId`) REFERENCES `GoodsOptions`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/libs/prisma-orm/prisma/migrations/20210824084727_/migration.sql
+++ b/libs/prisma-orm/prisma/migrations/20210824084727_/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE `GoodsConfirmation` (
+    `id` INTEGER NOT NULL,
+    `goodsId` INTEGER NOT NULL,
+    `status` ENUM('waiting', 'confirmed', 'rejected') NOT NULL DEFAULT 'waiting',
+
+    UNIQUE INDEX `GoodsConfirmation_goodsId_unique`(`goodsId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `GoodsConfirmation` ADD FOREIGN KEY (`goodsId`) REFERENCES `Goods`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/libs/prisma-orm/prisma/migrations/20210825010538_/migration.sql
+++ b/libs/prisma-orm/prisma/migrations/20210825010538_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `GoodsConfirmation` ADD COLUMN `firstmallGoodsConnectionId` INTEGER;

--- a/libs/prisma-orm/prisma/schema.prisma
+++ b/libs/prisma-orm/prisma/schema.prisma
@@ -79,17 +79,18 @@ model Goods {
 
 // 상품 검수 정보
 model GoodsConfirmation {
-  id      Int                       @id
-  goodsId Int
-  goods   Goods                     @relation(fields: [goodsId], references: [id])
-  status  GoodsConfirmationStatuses @default(waiting)
+  id                         Int                       @id
+  goodsId                    Int
+  goods                      Goods                     @relation(fields: [goodsId], references: [id])
+  status                     GoodsConfirmationStatuses @default(waiting) // 검수 상태
+  firstmallGoodsConnectionId Int? // 퍼스트몰 상품 고유 ID (fm_goods.goods_seq)
 }
 
 // 상품 검수 상태 정보
 enum GoodsConfirmationStatuses {
-  waiting
-  confirmed
-  rejected
+  waiting // 대기
+  confirmed // 승인
+  rejected // 거절
 }
 
 // 상품 옵션 - fm_goods_option

--- a/libs/prisma-orm/prisma/schema.prisma
+++ b/libs/prisma-orm/prisma/schema.prisma
@@ -44,36 +44,52 @@ model SellerSocialAccount {
 // * firstmall과 동일한 상품 정보 (컬럼명도 동일하게 가져갑니다.)
 // 상품 - fm_goods
 model Goods {
-  id                      Int            @id @default(autoincrement())
+  id                      Int                @id @default(autoincrement())
   sellerId                Int
-  seller                  Seller         @relation(fields: [sellerId], references: [id])
+  seller                  Seller             @relation(fields: [sellerId], references: [id])
   options                 GoodsOptions[]
+  confirmation            GoodsConfirmation? // 상품 검수
   // 여기서부터는 퍼스트몰 컬럼과 동일한 컬럼
   goods_name              String // 상품명
   summary                 String // 간략 설명
-  goods_status            GoodsStatus    @default(normal) // 상품 상태
-  cancel_type             String         @default("0") // 청약철회 가능 여부, "0" or "1"
-  contents                String?        @db.LongText // 상세 설명 PC 화면
-  contents_mobile         String?        @db.LongText // 상세 설명 Mobile 화면
-  common_contents         String         @db.LongText // 상품 공통 정보
-  shipping_policy         ShopOrGoods    @default(shop) // 배송 정책 선택
-  goods_shipping_policy   LimitOrUnlimit @default(unlimit) // 개별 배송비 선택
-  unlimit_shipping_price  Int?           @db.UnsignedInt // 배송비
-  limit_shipping_ea       Int?           @db.UnsignedTinyInt // 개별 배송 포장 단위
-  limit_shipping_price    Int?           @db.UnsignedInt // 개별 배송 단위별 배송비
-  limit_shipping_subprice Int?           @db.UnsignedTinyInt // 개별 배송 추가 배송비
-  shipping_weight_policy  ShopOrGoods    @default(shop) // 해외 배송 중량 정책
-  min_purchase_limit      LimitOrUnlimit @default(unlimit) // 최소 구매 수량 사용 여부
-  min_purchase_ea         Int?           @db.UnsignedMediumInt // 최소 구매 수량
-  max_purchase_limit      LimitOrUnlimit @default(unlimit) // 최대 구매 수량 사용 여부
-  max_purchase_ea         Int?           @db.UnsignedMediumInt // 최대 구매 수량
-  max_urchase_order_limit Int?           @db.UnsignedMediumInt // 최대 구매 수량 주문 횟수
-  admin_memo              String?        @db.Text // 관리자 메모
-  option_use              String         @default("0") // 옵션 사용 여부 "0" or "1"
-  option_view_type        OptionViewType @default(divide) // 필수옵션-분리/합체형 구분
-  option_suboption_use    String         @default("0") // 추가 옵션 사용 여부 "0" or "1"
-  member_input_use        String         @default("0") // 추가 구성 옵션 사용 여부 "0" or "1"
+  goods_status            GoodsStatus        @default(normal) // 상품 상태
+  cancel_type             String             @default("0") // 청약철회 가능 여부, "0" or "1"
+  contents                String?            @db.LongText // 상세 설명 PC 화면
+  contents_mobile         String?            @db.LongText // 상세 설명 Mobile 화면
+  common_contents         String             @db.LongText // 상품 공통 정보
+  shipping_policy         ShopOrGoods        @default(shop) // 배송 정책 선택
+  goods_shipping_policy   LimitOrUnlimit     @default(unlimit) // 개별 배송비 선택
+  unlimit_shipping_price  Int?               @db.UnsignedInt // 배송비
+  limit_shipping_ea       Int?               @db.UnsignedTinyInt // 개별 배송 포장 단위
+  limit_shipping_price    Int?               @db.UnsignedInt // 개별 배송 단위별 배송비
+  limit_shipping_subprice Int?               @db.UnsignedTinyInt // 개별 배송 추가 배송비
+  shipping_weight_policy  ShopOrGoods        @default(shop) // 해외 배송 중량 정책
+  min_purchase_limit      LimitOrUnlimit     @default(unlimit) // 최소 구매 수량 사용 여부
+  min_purchase_ea         Int?               @db.UnsignedMediumInt // 최소 구매 수량
+  max_purchase_limit      LimitOrUnlimit     @default(unlimit) // 최대 구매 수량 사용 여부
+  max_purchase_ea         Int?               @db.UnsignedMediumInt // 최대 구매 수량
+  max_urchase_order_limit Int?               @db.UnsignedMediumInt // 최대 구매 수량 주문 횟수
+  admin_memo              String?            @db.Text // 관리자 메모
+  option_use              String             @default("0") // 옵션 사용 여부 "0" or "1"
+  option_view_type        OptionViewType     @default(divide) // 필수옵션-분리/합체형 구분
+  option_suboption_use    String             @default("0") // 추가 옵션 사용 여부 "0" or "1"
+  member_input_use        String             @default("0") // 추가 구성 옵션 사용 여부 "0" or "1"
   image                   String // 상품 이미지 - fm_goods_image
+}
+
+// 상품 검수 정보
+model GoodsConfirmation {
+  id      Int                       @id
+  goodsId Int
+  goods   Goods                     @relation(fields: [goodsId], references: [id])
+  status  GoodsConfirmationStatuses @default(waiting)
+}
+
+// 상품 검수 상태 정보
+enum GoodsConfirmationStatuses {
+  waiting
+  confirmed
+  rejected
 }
 
 // 상품 옵션 - fm_goods_option
@@ -134,11 +150,13 @@ enum OptionViewType {
   join
 }
 
+// * 옵션 필수 여부
 enum YesOrNo {
   y
   n
 }
 
+// * 옵션 노출 여부
 enum YesOrNo_UPPERCASE {
   Y
   N

--- a/libs/prisma-orm/prisma/schema.prisma
+++ b/libs/prisma-orm/prisma/schema.prisma
@@ -17,6 +17,7 @@ model Seller {
   name           String?
   password       String? // 소셜로그인으로 로그인하는 경우, 비밀번호가 없을 수 있다.
   socialAccounts SellerSocialAccount[]
+  goods          Goods[]
 }
 
 model MailVerificationCode {
@@ -37,4 +38,108 @@ model SellerSocialAccount {
   /// @onDelete(CASCADE)
   seller       Seller   @relation(fields: [sellerId], references: [id])
   sellerId     Int
+}
+
+// ****************************
+// * firstmall과 동일한 상품 정보 (컬럼명도 동일하게 가져갑니다.)
+// 상품 - fm_goods
+model Goods {
+  id                      Int            @id @default(autoincrement())
+  sellerId                Int
+  seller                  Seller         @relation(fields: [sellerId], references: [id])
+  options                 GoodsOptions[]
+  // 여기서부터는 퍼스트몰 컬럼과 동일한 컬럼
+  goods_name              String // 상품명
+  summary                 String // 간략 설명
+  goods_status            GoodsStatus    @default(normal) // 상품 상태
+  cancel_type             String         @default("0") // 청약철회 가능 여부, "0" or "1"
+  contents                String?        @db.LongText // 상세 설명 PC 화면
+  contents_mobile         String?        @db.LongText // 상세 설명 Mobile 화면
+  common_contents         String         @db.LongText // 상품 공통 정보
+  shipping_policy         ShopOrGoods    @default(shop) // 배송 정책 선택
+  goods_shipping_policy   LimitOrUnlimit @default(unlimit) // 개별 배송비 선택
+  unlimit_shipping_price  Int?           @db.UnsignedInt // 배송비
+  limit_shipping_ea       Int?           @db.UnsignedTinyInt // 개별 배송 포장 단위
+  limit_shipping_price    Int?           @db.UnsignedInt // 개별 배송 단위별 배송비
+  limit_shipping_subprice Int?           @db.UnsignedTinyInt // 개별 배송 추가 배송비
+  shipping_weight_policy  ShopOrGoods    @default(shop) // 해외 배송 중량 정책
+  min_purchase_limit      LimitOrUnlimit @default(unlimit) // 최소 구매 수량 사용 여부
+  min_purchase_ea         Int?           @db.UnsignedMediumInt // 최소 구매 수량
+  max_purchase_limit      LimitOrUnlimit @default(unlimit) // 최대 구매 수량 사용 여부
+  max_purchase_ea         Int?           @db.UnsignedMediumInt // 최대 구매 수량
+  max_urchase_order_limit Int?           @db.UnsignedMediumInt // 최대 구매 수량 주문 횟수
+  admin_memo              String?        @db.Text // 관리자 메모
+  option_use              String         @default("0") // 옵션 사용 여부 "0" or "1"
+  option_view_type        OptionViewType @default(divide) // 필수옵션-분리/합체형 구분
+  option_suboption_use    String         @default("0") // 추가 옵션 사용 여부 "0" or "1"
+  member_input_use        String         @default("0") // 추가 구성 옵션 사용 여부 "0" or "1"
+  image                   String // 상품 이미지 - fm_goods_image
+}
+
+// 상품 옵션 - fm_goods_option
+model GoodsOptions {
+  id             Int                    @id @default(autoincrement())
+  goods          Goods                  @relation(fields: [goodsId], references: [id])
+  goodsId        Int
+  supply         GoodsOptionsSupplies[]
+  // 여기서부터는 퍼스트몰 컬럼과 동일한 컬럼
+  default_option YesOrNo                @default(n) // 옵션 필수 여부
+  option_type    String                 @default("direct") // 기본값인듯? 설명도 direct
+  option_title   String? // 옵션명
+  option_code    String? // 옵션코드
+  consumer_price Decimal                @db.Decimal(10, 2) // 소비자가 (미할인가)
+  price          Decimal                @db.Decimal(10, 2) // 판매가 (할인가)
+  color          String?                @db.VarChar(10) // 컬러 hex값
+  weight         Float? //옵션 개당 무게 (단위 kg)
+  option_view    YesOrNo_UPPERCASE      @default(Y) // 옵션 노출 여부
+}
+
+// 상품 옵션 재고 - fm_goods_suply
+model GoodsOptionsSupplies {
+  id             Int          @id @default(autoincrement())
+  goodsOptions   GoodsOptions @relation(fields: [goodsOptionsId], references: [id])
+  goodsOptionsId Int
+  // 여기서부터는 퍼스트몰 컬럼과 동일한 컬럼
+  stock          Int          @db.UnsignedInt // 재고
+  badstock       Int?         @db.UnsignedInt // 불량재고
+  safe_stock     Int?         @default(0) // 각 매장의 옵션별 안전 재고
+}
+
+// * 상품 - 상태
+enum GoodsStatus {
+  normal
+  runout
+  purchasing
+  unsold
+}
+
+// * 상품 - 배송 정책 선택
+// * 상품 - 헤외 배송 중량 정책
+enum ShopOrGoods {
+  shop
+  goods
+}
+
+// * 상품 - 개별 배송비 선택
+// * 상품 - 최소 구매 수량 사용 여부
+// * 상품 - 최대 구매 수량 사용 여부
+enum LimitOrUnlimit {
+  unlimit
+  limit
+}
+
+// * 상품 - 필수옵션-분리/합체형 구분
+enum OptionViewType {
+  divide
+  join
+}
+
+enum YesOrNo {
+  y
+  n
+}
+
+enum YesOrNo_UPPERCASE {
+  Y
+  N
 }


### PR DESCRIPTION
- 상품 등록 일감 중, 모델링 부분만 진행
- 따로 먼저 진행하는 이유는 주문목록을 조회할 때, 본인 상품이 연결되어 있는 주문만 가져올 수 있도록 추가해야 해서.

문제점
- fm DB 상의 상품번호(goods_seq) 값을 알지 못한다..
    => 관리자가 업로드시 입력하도록 한다?