### PR TITLE
[Fix] 시연회 수정 필요사항 추가

### DIFF
--- a/libs/components/src/lib/BusinessRegistrationDialog.tsx
+++ b/libs/components/src/lib/BusinessRegistrationDialog.tsx
@@ -102,7 +102,6 @@ export function BusinessRegistrationDialog(props: BusinessRegistrationDialogProp
       isOpen={isOpen}
       size="3xl"
       onClose={useClose}
-      closeOnOverlayClick={false}
       closeOnEsc={false}
       initialFocusRef={inputRef}
     >

--- a/libs/components/src/lib/BusinessRegistrationForm.tsx
+++ b/libs/components/src/lib/BusinessRegistrationForm.tsx
@@ -196,7 +196,6 @@ function BusinessRegistrationFormTag(props: BusinessRegistrationFormProps) {
         <FormControl isInvalid={!!errors.taxInvoiceMail}>
           <Input
             id="taxInvoiceMail"
-            type="email"
             m={[1, 3, 3, 3]}
             variant="flushed"
             placeholder="계산서를 받을 이메일을 입력해주세요."

--- a/libs/components/src/lib/LoginForm.tsx
+++ b/libs/components/src/lib/LoginForm.tsx
@@ -48,7 +48,7 @@ export function LoginForm({ enableShadow = false }: LoginFormProps): JSX.Element
   const onSubmit = useCallback(
     async (data: LoginSellerDto) => {
       const seller = await login.mutateAsync(data).catch((err) => {
-        setFormError(getMessage(err?.response.data?.statusCode));
+        setFormError(getMessage(err?.response.data?.status));
       });
       if (seller) {
         router.push('/');

--- a/libs/components/src/lib/SettlementAccountDialog.tsx
+++ b/libs/components/src/lib/SettlementAccountDialog.tsx
@@ -66,13 +66,7 @@ export function SettlementAccountDialog(props: SettlementAccountDtoDialogProps) 
   }
 
   return (
-    <Modal
-      isOpen={isOpen}
-      size="3xl"
-      onClose={useClose}
-      closeOnOverlayClick={false}
-      closeOnEsc={false}
-    >
+    <Modal isOpen={isOpen} size="3xl" onClose={useClose} closeOnEsc={false}>
       <ModalOverlay />
       <ModalContent as="form" onSubmit={handleSubmit(regist)}>
         <ModalHeader>정산 계좌 등록</ModalHeader>


### PR DESCRIPTION
#### 단 두 줄의 수정
- 사업자 등록증 이메일 입력시 에러 핸들링을 react-hook-form으로 통일
- error의 status code의 조회방법 수정
- ~사업자 등록증 주소 입력 구현 도중, 모달창의 크기, 상세 주소 입력등 필요 수정이 많을 것으로 보고 추 후로 미룸~