### PR TITLE
[상품 옵션] 재고 기능 임시 제거

### DIFF
--- a/libs/components/src/lib/GoodsDetailOptionsInfo.tsx
+++ b/libs/components/src/lib/GoodsDetailOptionsInfo.tsx
@@ -62,7 +62,8 @@ export function GoodsDetailOptionsInfo({
                   <Text fontWeight="bold">옵션노출여부</Text>
                   <Text>{option.option_view === 'Y' ? '노출' : '미노출'}</Text>
                 </Box>
-                <Box>
+                {/* [상품 옵션] 재고 기능 임시 제거 */}
+                {/* <Box>
                   <Text fontWeight="bold">총 재고</Text>
                   <Text>{option.supply.stock}</Text>
                 </Box>
@@ -75,7 +76,7 @@ export function GoodsDetailOptionsInfo({
                 <Box>
                   <Text fontWeight="bold">가용재고</Text>
                   <Text>{option.supply.stock - (option.supply.badstock || 0)}</Text>
-                </Box>
+                </Box> */}
               </SimpleGrid>
             </Box>
           ))}
@@ -95,9 +96,10 @@ export function GoodsDetailOptionsInfo({
               <Th>소비자가</Th>
               <Th>정가</Th>
               <Th>옵션노출여부</Th>
-              <Th>총 재고</Th>
+              {/* [상품 옵션] 재고 기능 임시 제거 */}
+              {/* <Th>총 재고</Th>
               <Th>불량재고</Th>
-              <Th>가용재고</Th>
+              <Th>가용재고</Th> */}
             </Tr>
           </Thead>
           <Tbody>
@@ -123,11 +125,12 @@ export function GoodsDetailOptionsInfo({
                   <Td borderBottom="none">
                     {option.option_view === 'Y' ? '노출' : '미노출'}
                   </Td>
-                  <Td borderBottom="none">{option.supply.stock}</Td>
+                  {/* [상품 옵션] 재고 기능 임시 제거 */}
+                  {/* <Td borderBottom="none">{option.supply.stock}</Td>
                   <Td borderBottom="none">{option.supply.badstock}</Td>
                   <Td borderBottom="none">
                     {option.supply.stock - (option.supply.badstock || 0)}
-                  </Td>
+                  </Td> */}
                 </Tr>
               ))}
           </Tbody>

--- a/libs/components/src/lib/GoodsRegistDataOptions.tsx
+++ b/libs/components/src/lib/GoodsRegistDataOptions.tsx
@@ -58,7 +58,9 @@ function NoOptionInput(): JSX.Element {
           }),
         }}
       />
-      <GoodsOptionInput
+
+      {/* [상품 옵션] 재고 기능 임시 제거 */}
+      {/* <GoodsOptionInput
         label="재고"
         inputProps={{
           type: 'number',
@@ -66,7 +68,8 @@ function NoOptionInput(): JSX.Element {
             valueAsNumber: true,
           }),
         }}
-      />
+      /> */}
+      {/* [상품 옵션] 재고 기능 임시 제거 */}
     </Stack>
   );
 }
@@ -132,6 +135,7 @@ function UseOptionInput(): JSX.Element {
           spacing={1}
           flexWrap="wrap"
         >
+          {/* 옵션값 */}
           <HStack mb={1}>
             <CloseButton onClick={() => remove(index)} />
             <HStack>
@@ -146,7 +150,10 @@ function UseOptionInput(): JSX.Element {
               />
             </HStack>
           </HStack>
+          {/* 옵션값 */}
+
           <HStack mb={1}>
+            {/* 정가 */}
             <HStack>
               <Text minWidth="40px">정가</Text>
               <Input
@@ -157,6 +164,9 @@ function UseOptionInput(): JSX.Element {
                 size="sm"
               />
             </HStack>
+            {/* 정가 */}
+
+            {/* 판매가 */}
             <HStack mb={1}>
               <Text minWidth="40px">판매가</Text>
               <Input
@@ -167,9 +177,12 @@ function UseOptionInput(): JSX.Element {
                 size="sm"
               />
             </HStack>
+            {/* 판매가 */}
           </HStack>
+
           <HStack>
-            <HStack>
+            {/* [상품 옵션] 재고 기능 임시 제거 */}
+            {/* <HStack>
               <Text minWidth="40px">재고</Text>
               <Input
                 {...register(`options.${index}.supply.stock` as const, {
@@ -178,7 +191,9 @@ function UseOptionInput(): JSX.Element {
                 width={inputWidth}
                 size="sm"
               />
-            </HStack>
+            </HStack> */}
+            {/* [상품 옵션] 재고 기능 임시 제거 */}
+
             {/* 노출 */}
             <RadioGroup
               mb={1}
@@ -194,6 +209,7 @@ function UseOptionInput(): JSX.Element {
                 </Radio>
               </HStack>
             </RadioGroup>
+            {/* 노출 */}
           </HStack>
         </Stack>
       ))}

--- a/libs/components/src/lib/SellerGoodsList.tsx
+++ b/libs/components/src/lib/SellerGoodsList.tsx
@@ -1,43 +1,33 @@
-import NextLink from 'next/link';
 import {
   Badge,
   Box,
   Button,
   ButtonGroup,
+  Flex,
+  Link,
   Select,
   Stack,
   Text,
-  Link,
-  useDisclosure,
   useColorModeValue,
-  UnorderedList,
-  ListItem,
-  Flex,
+  useDisclosure,
 } from '@chakra-ui/react';
-import { useProfile, useSellerGoodsList } from '@project-lc/hooks';
-import { GridColumns, GridSelectionModel } from '@material-ui/data-grid';
-import dayjs from 'dayjs';
-import {
-  GoodsConfirmationStatuses,
-  GoodsStatus,
-  GoodsView,
-  RunoutPolicy,
-} from '@prisma/client';
-import { useSellerGoodsListPanelStore } from '@project-lc/stores';
-import { SellerGoodsSortColumn } from '@project-lc/shared-types';
 import { makeStyles } from '@material-ui/core/styles';
+import { GridColumns, GridSelectionModel } from '@material-ui/data-grid';
+import { GoodsConfirmationStatuses, GoodsStatus, GoodsView } from '@prisma/client';
+import { useProfile, useSellerGoodsList } from '@project-lc/hooks';
+import { SellerGoodsSortColumn } from '@project-lc/shared-types';
+import { useSellerGoodsListPanelStore } from '@project-lc/stores';
+import dayjs from 'dayjs';
+import NextLink from 'next/link';
 import { useState } from 'react';
-import { ChakraDataGrid } from './ChakraDataGrid';
 import {
-  RUNOUT_POLICY,
+  GOODS_CONFIRMATION_STATUS,
   GOODS_STATUS,
   GOODS_VIEW,
-  GOODS_CONFIRMATION_STATUS,
 } from '../constants/goodsStatus';
-import { GoodsExposeSwitch } from './GoodsExposeSwitch';
-import TextWithPopperButton from './TextWithPopperButton';
-import StockInfoButton, { ExampleStockDescription } from './StockInfoButton';
+import { ChakraDataGrid } from './ChakraDataGrid';
 import DeleteGoodsAlertDialog from './DeleteGoodsAlertDialog';
+import { GoodsExposeSwitch } from './GoodsExposeSwitch';
 import { ShippingGroupDetailModal } from './GoodsRegistShippingPolicy';
 
 function formatPrice(price: number): string {

--- a/libs/components/src/lib/SellerGoodsList.tsx
+++ b/libs/components/src/lib/SellerGoodsList.tsx
@@ -113,73 +113,74 @@ const columns: GridColumns = [
     valueFormatter: ({ row }) => formatPrice(Number(row.default_consumer_price)),
     sortable: false,
   },
-  {
-    field: 'stock',
-    headerName: '재고/가용',
-    minWidth: 110,
-    renderHeader: () => {
-      return (
-        <TextWithPopperButton
-          title="재고/가용"
-          iconAriaLabel="재고/가용 설명"
-          iconColor="black"
-          portalBody
-        >
-          <ExampleStockDescription />
-        </TextWithPopperButton>
-      );
-    },
-    renderCell: ({ row }) => {
-      const { a_stock_count, b_stock_count, a_rstock, b_rstock, a_stock, b_stock } = row;
-      const goodsName = row.goods_name;
-      const goodsId = row.id;
-      const confirmedGoodsId = row.confirmation?.firstmallGoodsConnectionId;
-      return (
-        <Box position="relative" width="100%">
-          <Text
-            height="20px"
-            color="blue.500"
-          >{`[${a_stock_count}] ${a_stock} / ${a_rstock}`}</Text>
-          <Text color="red.500">{`[${b_stock_count}] ${b_stock} / ${b_rstock}`}</Text>
-          <StockInfoButton
-            goodsId={goodsId}
-            confirmedGoodsId={confirmedGoodsId}
-            goodsName={goodsName}
-            iconColor="black"
-          />
-        </Box>
-      );
-    },
-    sortable: false,
-  },
-  {
-    field: 'runout_policy',
-    headerName: '재고판매',
-    align: 'center',
-    valueGetter: ({ row }) => {
-      return RUNOUT_POLICY[row.runout_policy as RunoutPolicy];
-    },
-    renderHeader: () => {
-      return (
-        <TextWithPopperButton
-          title="재고판매"
-          iconAriaLabel="재고판매 설명"
-          iconColor="black"
-          portalBody
-        >
-          <Text mb={2} fontWeight="bold">
-            재고(옵션 기준)에 따른 상품 판매 설정에 따라 아래와 같이 3가지로 표기됩니다.
-          </Text>
-          <UnorderedList spacing={1}>
-            <ListItem>재고가 있으면 판매 : 재고</ListItem>
-            <ListItem>가용 재고가 있으면 판매 : 가용 재고</ListItem>
-            <ListItem>재고 상관없이 주문 가능 : 무제한</ListItem>
-          </UnorderedList>
-        </TextWithPopperButton>
-      );
-    },
-    sortable: false,
-  },
+  /* [상품 옵션] 재고 기능 임시 제거 */
+  // {
+  //   field: 'stock',
+  //   headerName: '재고/가용',
+  //   minWidth: 110,
+  //   renderHeader: () => {
+  //     return (
+  //       <TextWithPopperButton
+  //         title="재고/가용"
+  //         iconAriaLabel="재고/가용 설명"
+  //         iconColor="black"
+  //         portalBody
+  //       >
+  //         <ExampleStockDescription />
+  //       </TextWithPopperButton>
+  //     );
+  //   },
+  //   renderCell: ({ row }) => {
+  //     const { a_stock_count, b_stock_count, a_rstock, b_rstock, a_stock, b_stock } = row;
+  //     const goodsName = row.goods_name;
+  //     const goodsId = row.id;
+  //     const confirmedGoodsId = row.confirmation?.firstmallGoodsConnectionId;
+  //     return (
+  //       <Box position="relative" width="100%">
+  //         <Text
+  //           height="20px"
+  //           color="blue.500"
+  //         >{`[${a_stock_count}] ${a_stock} / ${a_rstock}`}</Text>
+  //         <Text color="red.500">{`[${b_stock_count}] ${b_stock} / ${b_rstock}`}</Text>
+  //         <StockInfoButton
+  //           goodsId={goodsId}
+  //           confirmedGoodsId={confirmedGoodsId}
+  //           goodsName={goodsName}
+  //           iconColor="black"
+  //         />
+  //       </Box>
+  //     );
+  //   },
+  //   sortable: false,
+  // },
+  // {
+  //   field: 'runout_policy',
+  //   headerName: '재고판매',
+  //   align: 'center',
+  //   valueGetter: ({ row }) => {
+  //     return RUNOUT_POLICY[row.runout_policy as RunoutPolicy];
+  //   },
+  //   renderHeader: () => {
+  //     return (
+  //       <TextWithPopperButton
+  //         title="재고판매"
+  //         iconAriaLabel="재고판매 설명"
+  //         iconColor="black"
+  //         portalBody
+  //       >
+  //         <Text mb={2} fontWeight="bold">
+  //           재고(옵션 기준)에 따른 상품 판매 설정에 따라 아래와 같이 3가지로 표기됩니다.
+  //         </Text>
+  //         <UnorderedList spacing={1}>
+  //           <ListItem>재고가 있으면 판매 : 재고</ListItem>
+  //           <ListItem>가용 재고가 있으면 판매 : 가용 재고</ListItem>
+  //           <ListItem>재고 상관없이 주문 가능 : 무제한</ListItem>
+  //         </UnorderedList>
+  //       </TextWithPopperButton>
+  //     );
+  //   },
+  //   sortable: false,
+  // },
   {
     field: 'shippingGroup',
     headerName: '배송비',

--- a/libs/components/src/lib/StockInfoButton.tsx
+++ b/libs/components/src/lib/StockInfoButton.tsx
@@ -78,9 +78,9 @@ export function StockInfoButton({
                   <Th>소비자가</Th>
                   <Th>정가</Th>
                   <Th>옵션노출여부</Th>
-                  <Th>총 재고</Th>
-                  {/* <Th>불량재고</Th> */}
-                  <Th>가용재고</Th>
+                  {/* <Th>총 재고</Th>
+                  <Th>불량재고</Th>
+                  <Th>가용재고</Th> */}
                 </Tr>
               </Thead>
               <Tbody>
@@ -93,9 +93,9 @@ export function StockInfoButton({
                       <Td>{Number(option.consumer_price).toLocaleString()}</Td>
                       <Td>{Number(option.price).toLocaleString()}</Td>
                       <Td>{option.option_view === 'Y' ? '노출' : '미노출'}</Td>
-                      <Td>{option.stock}</Td>
-                      {/* <Td>{option.badstock}</Td> */}
-                      <Td>{option.rstock}</Td>
+                      {/* <Td>{option.stock}</Td>
+                      <Td>{option.badstock}</Td>
+                      <Td>{option.rstock}</Td> */}
                     </Tr>
                   ))}
               </Tbody>


### PR DESCRIPTION
프론트단에서 재고 부분이 보여지는 코드만 주석처리함 (서버, db관련 코드는 수정하지 않음)

상품 목록 페이지 /mypage/goods
 -  '재고/가용', '재고판매' 컬럼 주석처리
 
상품 상세 페이지(판매자, 관리자 페이지 공통 컴포넌트 사용) /mypage/goods/:id, admin/goods/:id
- 옵션 표에서 재고, 불량재고, 가용재고 컬럼 주석처리

상품 등록 페이지 /mypage/goods/regist
- 판매옵션에서 '재고'입력칸 주석처리 (원래 값을 입력받지 않아도 db에는 재고 0으로 저장됨)


## 테스트케이스

상품 등록 페이지

- [x]  판매옵션에서 '재고' 입력칸이 보이지 않는다
![판매옵션 사용](https://user-images.githubusercontent.com/18395475/136304114-98695358-4332-4fae-b53e-2dccd00147a8.png)
![판매옵션 사용안함](https://user-images.githubusercontent.com/18395475/136304122-99ce6f05-66b3-4044-8e30-5bfb14bd61bd.png)

상품 목록 페이지

- [x]  상품목록에서 '재고/가용', '재고판매' 컬럼이 보이지 않는다
![목록](https://user-images.githubusercontent.com/18395475/136304134-051b7c19-6326-454a-8dd3-f500cd25ff92.png)

상품 상세 페이지(판매자, 관리자 공통)

- [x]  옵션 표에서 재고, 불량재고, 가용재고 컬럼이 보이지 않는다
![상세](https://user-images.githubusercontent.com/18395475/136304143-99b1a6a5-163e-43ae-81b6-b984e34006aa.png)

