### PR TITLE
[기능 추가] 사업자 등록정보 등록시 통신판매업 신고 정보 등록 구현

### DIFF
--- a/libs/components/src/lib/BusinessRegistrationDialog.tsx
+++ b/libs/components/src/lib/BusinessRegistrationDialog.tsx
@@ -96,7 +96,11 @@ export function BusinessRegistrationDialog(
         companyName,
       });
 
-      if (!savedBusinessRegistrationImageName || !savedMailOrderSalesImageName) {
+      // 통신판매업 신고증의 경우, 선택이기 때문에 파일은 존재하나, 이미지 저장후의 이름이 존재하지 않는경우에만 에러
+      if (
+        !savedBusinessRegistrationImageName ||
+        (mailOrderSalesImageName && !savedMailOrderSalesImageName)
+      ) {
         throw new Error('S3 ERROR');
       }
 
@@ -104,8 +108,11 @@ export function BusinessRegistrationDialog(
       await mutation.mutateAsync({
         ...data,
         businessRegistrationImageName: savedBusinessRegistrationImageName,
-        mailOrderSalesImageName: savedMailOrderSalesImageName,
+        mailOrderSalesImageName: savedMailOrderSalesImageName
+          ? mailOrderSalesImageName
+          : '',
       });
+
       toast({
         title: '사업자 등록정보 등록 완료',
         status: 'success',

--- a/libs/components/src/lib/BusinessRegistrationForm.tsx
+++ b/libs/components/src/lib/BusinessRegistrationForm.tsx
@@ -19,6 +19,7 @@ import {
 import { ImageInput, ImageInputErrorTypes } from './ImageInput';
 import { BusinessRegistrationFormDto } from './BusinessRegistrationDialog';
 import { useDialogHeaderConfig, useDialogValueConfig } from './GridTableItem';
+import { BusinessRegistrationMailOrderNumerSection } from './BusinessRegistrationMailOrderNumerSection';
 
 export interface BusinessRegistrationFormProps {
   inputRef: MutableRefObject<null>;
@@ -35,8 +36,8 @@ function BusinessRegistrationFormTag(props: BusinessRegistrationFormProps): JSX.
 
   function handleSuccess(fileName: string, file: File): void {
     setvalue('businessRegistrationImage', file);
-    setvalue('imageName', fileName);
-    clearErrors(['businessRegistrationImage', 'imageName']);
+    setvalue('businessRegistrationImageName', fileName);
+    clearErrors(['businessRegistrationImage', 'businessRegistrationImageName']);
   }
 
   function handleError(errorType?: ImageInputErrorTypes): void {
@@ -58,15 +59,15 @@ function BusinessRegistrationFormTag(props: BusinessRegistrationFormProps): JSX.
       default: {
         // only chrome
         setvalue('businessRegistrationImage', null);
-        setvalue('imageName', null);
-        clearErrors(['businessRegistrationImage', 'imageName']);
+        setvalue('businessRegistrationImageName', null);
+        clearErrors(['businessRegistrationImage', 'businessRegistrationImageName']);
       }
     }
   }
 
   return (
     <Grid templateColumns="2fr 3fr" borderTopColor="gray.100" borderTopWidth={1.5}>
-      <GridItem {...useDialogHeaderConfig(useColorModeValue)}>회사명</GridItem>
+      <GridItem {...useDialogHeaderConfig(useColorModeValue)}>회사명*</GridItem>
       <GridItem {...useDialogValueConfig(useColorModeValue)}>
         <FormControl isInvalid={!!errors.companyName}>
           <Input
@@ -87,7 +88,7 @@ function BusinessRegistrationFormTag(props: BusinessRegistrationFormProps): JSX.
           </FormErrorMessage>
         </FormControl>
       </GridItem>
-      <GridItem {...useDialogHeaderConfig(useColorModeValue)}>사업자등록번호</GridItem>
+      <GridItem {...useDialogHeaderConfig(useColorModeValue)}>사업자등록번호*</GridItem>
       <GridItem {...useDialogValueConfig(useColorModeValue)}>
         <FormControl isInvalid={!!errors.businessRegistrationNumber}>
           <Input
@@ -112,7 +113,18 @@ function BusinessRegistrationFormTag(props: BusinessRegistrationFormProps): JSX.
           </FormErrorMessage>
         </FormControl>
       </GridItem>
-      <GridItem {...useDialogHeaderConfig(useColorModeValue)}>대표자명</GridItem>
+      <GridItem {...useDialogHeaderConfig(useColorModeValue)}>
+        사업자 등록증 이미지 업로드*
+      </GridItem>
+      <GridItem {...useDialogValueConfig(useColorModeValue)}>
+        <FormControl isInvalid={!!errors.businessRegistrationImage}>
+          <ImageInput handleSuccess={handleSuccess} handleError={handleError} />
+          <FormErrorMessage ml={3} mt={0}>
+            {errors.businessRegistrationImage && errors.businessRegistrationImage.message}
+          </FormErrorMessage>
+        </FormControl>
+      </GridItem>
+      <GridItem {...useDialogHeaderConfig(useColorModeValue)}>대표자명*</GridItem>
       <GridItem {...useDialogValueConfig(useColorModeValue)}>
         <FormControl isInvalid={!!errors.representativeName}>
           <Input
@@ -132,7 +144,7 @@ function BusinessRegistrationFormTag(props: BusinessRegistrationFormProps): JSX.
           </FormErrorMessage>
         </FormControl>
       </GridItem>
-      <GridItem {...useDialogHeaderConfig(useColorModeValue)}>업태/종목</GridItem>
+      <GridItem {...useDialogHeaderConfig(useColorModeValue)}>업태/종목*</GridItem>
       <GridItem {...useDialogValueConfig(useColorModeValue)}>
         <Flex direction="row">
           <FormControl isInvalid={!!errors.businessType} mr={1}>
@@ -169,7 +181,7 @@ function BusinessRegistrationFormTag(props: BusinessRegistrationFormProps): JSX.
           </FormControl>
         </Flex>
       </GridItem>
-      <GridItem {...useDialogHeaderConfig(useColorModeValue)}>사업장 주소</GridItem>
+      <GridItem {...useDialogHeaderConfig(useColorModeValue)}>사업장 주소*</GridItem>
       <GridItem {...useDialogValueConfig(useColorModeValue)}>
         <FormControl isInvalid={!!errors.businessAddress}>
           <Input
@@ -189,7 +201,7 @@ function BusinessRegistrationFormTag(props: BusinessRegistrationFormProps): JSX.
         </FormControl>
       </GridItem>
       <GridItem {...useDialogHeaderConfig(useColorModeValue)}>
-        전자세금계산서 수신 이메일
+        전자세금계산서 수신 이메일*
       </GridItem>
       <GridItem {...useDialogValueConfig(useColorModeValue)}>
         <FormControl isInvalid={!!errors.taxInvoiceMail}>
@@ -213,17 +225,7 @@ function BusinessRegistrationFormTag(props: BusinessRegistrationFormProps): JSX.
           </FormErrorMessage>
         </FormControl>
       </GridItem>
-      <GridItem {...useDialogHeaderConfig(useColorModeValue)}>
-        사업자 등록증 이미지 업로드
-      </GridItem>
-      <GridItem {...useDialogValueConfig(useColorModeValue)}>
-        <FormControl isInvalid={!!errors.businessRegistrationImage}>
-          <ImageInput handleSuccess={handleSuccess} handleError={handleError} />
-          <FormErrorMessage ml={3} mt={0}>
-            {errors.businessRegistrationImage && errors.businessRegistrationImage.message}
-          </FormErrorMessage>
-        </FormControl>
-      </GridItem>
+      <BusinessRegistrationMailOrderNumerSection {...props} />
     </Grid>
   );
 }

--- a/libs/components/src/lib/BusinessRegistrationMailOrderNumerSection.tsx
+++ b/libs/components/src/lib/BusinessRegistrationMailOrderNumerSection.tsx
@@ -77,7 +77,11 @@ export function BusinessRegistrationMailOrderNumerSection(
       </GridItem>
       <GridItem {...useDialogValueConfig(useColorModeValue)}>
         <FormControl isInvalid={!!errors.mailOrderSalesImage}>
-          <ImageInput handleSuccess={handleSuccess} handleError={handleError} />
+          <ImageInput
+            handleSuccess={handleSuccess}
+            handleError={handleError}
+            required={false}
+          />
           <FormErrorMessage ml={3} mt={0}>
             {errors.mailOrderSalesImage && errors.mailOrderSalesImage.message}
           </FormErrorMessage>

--- a/libs/components/src/lib/BusinessRegistrationMailOrderNumerSection.tsx
+++ b/libs/components/src/lib/BusinessRegistrationMailOrderNumerSection.tsx
@@ -1,0 +1,88 @@
+import {
+  GridItem,
+  FormControl,
+  FormErrorMessage,
+  useColorModeValue,
+  Input,
+} from '@chakra-ui/react';
+import { useDialogHeaderConfig, useDialogValueConfig } from './GridTableItem';
+import { ImageInput, ImageInputErrorTypes } from './ImageInput';
+import { BusinessRegistrationFormProps } from './BusinessRegistrationForm';
+
+export function BusinessRegistrationMailOrderNumerSection(
+  props: Omit<BusinessRegistrationFormProps, 'inputRef'>,
+): JSX.Element {
+  const { register, errors, setvalue, seterror, clearErrors } = props;
+
+  function handleSuccess(fileName: string, file: File): void {
+    setvalue('mailOrderSalesImage', file);
+    setvalue('mailOrderSalesImageName', fileName);
+    clearErrors(['mailOrderSalesImage', 'mailOrderSalesImageName']);
+  }
+
+  function handleError(errorType?: ImageInputErrorTypes): void {
+    switch (errorType) {
+      case 'over-size': {
+        seterror('mailOrderSalesImage', {
+          type: 'validate',
+          message: '10MB 이하의 이미지를 업로드해주세요.',
+        });
+        break;
+      }
+      case 'invalid-format': {
+        seterror('mailOrderSalesImage', {
+          type: 'error',
+          message: '파일의 형식이 올바르지 않습니다.',
+        });
+        break;
+      }
+      default: {
+        // only chrome
+        setvalue('mailOrderSalesImage', null);
+        setvalue('mailOrderSalesImageName', null);
+        clearErrors(['mailOrderSalesImage', 'mailOrderSalesImageName']);
+      }
+    }
+  }
+
+  return (
+    <>
+      <GridItem {...useDialogHeaderConfig(useColorModeValue)}>
+        통신판매업 신고번호*
+      </GridItem>
+      <GridItem {...useDialogValueConfig(useColorModeValue)}>
+        <FormControl isInvalid={!!errors.mailOrderSalesNumber}>
+          <Input
+            id="mailOrderSalesNumber"
+            m={[1, 3, 3, 3]}
+            variant="flushed"
+            maxW={['inherit', 300, 300, 300]}
+            autoComplete="off"
+            placeholder="통신판매업 신고번호를 입력해주세요('-' 포함)"
+            {...register('mailOrderSalesNumber', {
+              required: '통신판매업신고증의 좌측상단 신고번호를 입력해주세요.',
+              minLength: {
+                value: 10,
+                message: '통신판매업 신고번호는 10글자 이상이어야 합니다.',
+              },
+            })}
+          />
+          <FormErrorMessage ml={3} mt={0}>
+            {errors.mailOrderSalesNumber && errors.mailOrderSalesNumber.message}
+          </FormErrorMessage>
+        </FormControl>
+      </GridItem>
+      <GridItem {...useDialogHeaderConfig(useColorModeValue)}>
+        통신판매업신고증 이미지 업로드
+      </GridItem>
+      <GridItem {...useDialogValueConfig(useColorModeValue)}>
+        <FormControl isInvalid={!!errors.mailOrderSalesImage}>
+          <ImageInput handleSuccess={handleSuccess} handleError={handleError} />
+          <FormErrorMessage ml={3} mt={0}>
+            {errors.mailOrderSalesImage && errors.mailOrderSalesImage.message}
+          </FormErrorMessage>
+        </FormControl>
+      </GridItem>
+    </>
+  );
+}

--- a/libs/hooks/src/lib/s3.tsx
+++ b/libs/hooks/src/lib/s3.tsx
@@ -2,7 +2,7 @@ import AWS from 'aws-sdk';
 import path from 'path';
 import moment from 'moment';
 
-// 전역 namespace에 대한 이해
+// 클로저를 통한 모듈 생성
 export const s3 = (() => {
   // 해당 네임 스페이스에서의 객체선언
   // bucket 이름
@@ -18,7 +18,7 @@ export const s3 = (() => {
   });
 
   // 추후에 S3에 저장할 데이터 종류가 더해지는 경우 추가
-  type s3KeyType = 'business-registration' | 'goods';
+  type s3KeyType = 'business-registration' | 'goods' | 'mail-order';
 
   interface S3UploadImageOptions {
     filename: string | null;
@@ -27,6 +27,13 @@ export const s3 = (() => {
     file: File | Buffer | null;
     companyName?: string;
   }
+
+  type s3FileNameParams = {
+    userMail: string;
+    type: s3KeyType;
+    filename: string | null;
+    companyName?: string;
+  };
 
   // 파일명에서 확장자를 추출하는 과정
   function getExtension(fileName: string | null): string {
@@ -38,29 +45,28 @@ export const s3 = (() => {
     return result;
   }
 
-  // 해당 이미지의 타입에 따라서 경로를 파일이름과 함께 생성
-  // 파일이름을 그대로 사용하지 않도록함.
-  function getS3Key({
-    userMail,
-    type,
-    filename,
-    companyName,
-  }: {
-    userMail: string;
-    type: string;
-    filename: string | null;
-    companyName?: string;
-  }): {
+  function getS3Key({ userMail, type, filename, companyName }: s3FileNameParams): {
     key: string;
     fileName: string;
   } {
-    // 확장자 추출
     const extension = getExtension(filename);
+
+    // 등록된 파일 구별을 위한 등록시간을 통한 접두사 추가
     const prefix = moment().format('YYMMDDHHmmss').toString();
-    let fileFullName = `${filename}`;
-    // companyName이 존재하지 않는 경우에 대한 분기처리
-    if (companyName) {
-      fileFullName = `${prefix}_${companyName}_사업자등록증${extension}`;
+
+    let fileFullName;
+    switch (type) {
+      case 'business-registration': {
+        fileFullName = `${prefix}_${companyName}_사업자등록증${extension}`;
+        break;
+      }
+      case 'mail-order': {
+        fileFullName = `${prefix}_${companyName}_통신판매업신고증${extension}`;
+        break;
+      }
+      default: {
+        fileFullName = `${filename}`;
+      }
     }
     const pathList = [type, userMail, fileFullName];
     return {
@@ -89,11 +95,21 @@ export const s3 = (() => {
     }).promise();
   }
 
+  /**
+   * S3를 저장하는 함수
+   *
+   * @param file        저장할 이미지 파일
+   * @param filename    저장할 이미지의 이름, 주로 확장자 추출을 위함
+   * @param type         'business-registration' | 'mail-order'
+   * @param userMail     업로드할 사용자의 이메일
+   * @param companyName? (optional) 사업자 등록증에 등록하는 사업자명
+   * @returns
+   */
   async function s3UploadImage({
-    filename,
-    userMail,
-    type,
     file,
+    filename,
+    type,
+    userMail,
     companyName,
   }: S3UploadImageOptions): Promise<string | null> {
     // key 만들기

--- a/libs/nest-modules/src/lib/seller/seller-settlement.service.ts
+++ b/libs/nest-modules/src/lib/seller/seller-settlement.service.ts
@@ -49,7 +49,9 @@ export class SellerSettlementService {
           businessItem: dto.businessItem,
           businessAddress: dto.businessAddress,
           taxInvoiceMail: dto.taxInvoiceMail,
-          fileName: dto.fileName,
+          businessRegistrationImageName: dto.businessRegistrationImageName,
+          mailOrderSalesImageName: dto.mailOrderSalesImageName,
+          mailOrderSalesNumber: dto.mailOrderSalesNumber,
         },
       });
 

--- a/libs/prisma-orm/prisma/migrations/20211007021538_/migration.sql
+++ b/libs/prisma-orm/prisma/migrations/20211007021538_/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `fileName` on the `SellerBusinessRegistration` table. All the data in the column will be lost.
+  - Added the required column `businessRegistrationImageName` to the `SellerBusinessRegistration` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `mailOrderSalesImageName` to the `SellerBusinessRegistration` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `mailOrderSalesNumber` to the `SellerBusinessRegistration` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `SellerBusinessRegistration` DROP COLUMN `fileName`,
+    ADD COLUMN `businessRegistrationImageName` VARCHAR(191) NOT NULL,
+    ADD COLUMN `mailOrderSalesImageName` VARCHAR(191) NOT NULL,
+    ADD COLUMN `mailOrderSalesNumber` VARCHAR(191) NOT NULL;

--- a/libs/prisma-orm/prisma/schema.prisma
+++ b/libs/prisma-orm/prisma/schema.prisma
@@ -32,17 +32,20 @@ model SellerShop {
 }
 
 model SellerBusinessRegistration {
-  id                         Int    @id @default(autoincrement()) // 사업자 등록증 DB 고유 번호
-  sellerEmail                String // 등록한 판매자 ID 
-  companyName                String // 상호명
-  businessRegistrationNumber String // 사업자등록증 등록번호
-  representativeName         String // 대표자명
-  businessType               String // 업태
-  businessItem               String // 종목
-  businessAddress            String // 사업장 주소
-  taxInvoiceMail             String // 세금계산서 전용 이메일
-  fileName                   String // 등록된 s3 파일명
-  seller                     Seller @relation(fields: [sellerEmail], references: [email], onDelete: Cascade)
+  id                            Int    @id @default(autoincrement()) // 사업자 등록증 DB 고유 번호
+  sellerEmail                   String // 등록한 판매자 ID 
+  companyName                   String // 상호명
+  businessRegistrationNumber    String // 사업자등록증 등록번호
+  representativeName            String // 대표자명
+  businessType                  String // 업태
+  businessItem                  String // 종목
+  businessAddress               String // 사업장 주소
+  taxInvoiceMail                String // 세금계산서 전용 이메일
+  businessRegistrationImageName String // 사업자등록증 이미지 파일명
+  mailOrderSalesNumber          String // 통신판매업 신고번호 
+  mailOrderSalesImageName       String // 통신판매업 이미지 파일명
+
+  seller Seller @relation(fields: [sellerEmail], references: [email], onDelete: Cascade)
 
   @@index(name: "BusinessRegistrationIndex", fields: [sellerEmail, id])
 }

--- a/libs/shared-types/src/lib/dto/businessRegistration.dto.ts
+++ b/libs/shared-types/src/lib/dto/businessRegistration.dto.ts
@@ -16,5 +16,9 @@ export class BusinessRegistrationDto {
   // 세금계산서 발행 이메일
   @IsEmail() taxInvoiceMail: string;
   // 이미지 파일명
-  @IsString() fileName: string;
+  @IsString() businessRegistrationImageName: string;
+
+  @IsString() mailOrderSalesNumber: string;
+
+  @IsString() mailOrderSalesImageName: string;
 }


### PR DESCRIPTION
### 마이페이지

- [x]  UI 수정
    - [x]  필수, 선택 구분을 위한 항목별 '*' 추가
    - [x]  통신판매업 신고번호 입력란
        - 필수로 등록
        - 입력 제한은 없이, 10자 이상의 길이제한만 추가
    - [x]  통신판매업신고증 업로드란
        - 선택으로 등록
- [x]  DTO 변경
    1. fileName → businessRegistrationImageName 로 변경
    2. mailOrderSalesImageName : 통신판매업신고증의 저장된 이미지이름
    3. mailOrderSalesNumber : 통신판매업신고번호
- [x]  seller-settlement service 수정
    - [x]  fileName → businessRegistrationImageName 수정

### 관리자페이지

- [x]  관리자페이지 UI 수정
    - [x]  주소항목 컬럼 너비 수정
        - 전체 주소를 확인하기 위해 여백 제공
    - [x]  기존의 사업자등록증 다운로드 수정
        - fileName → businessRegistrationImageName 수정
    - [x]  통신판매업 신고번호 컬럼추가
    - [x]  통신판매업신고증 다운로드
        - 신고증을 업로드하지 않은경우, 버튼 클릭 불가능