### PR TITLE
[관리자 - 상품검수] 반려 사유 적용 및 실수방지 확인창 추가

### DIFF
--- a/libs/components/src/lib/GoodsDetailCommonInfo.tsx
+++ b/libs/components/src/lib/GoodsDetailCommonInfo.tsx
@@ -11,10 +11,10 @@ export function GoodsDetailCommonInfo({
 }: GoodsDetailCommonInfoProps): JSX.Element {
   return (
     <Stack>
-      {goods.common_contents ? (
+      {goods.goodsInfoId && goods.GoodsInfo ? (
         <TextViewerWithDetailModal
           title={`${goods.goods_name} 상품 공통 정보`}
-          contents={goods.common_contents}
+          contents={goods.GoodsInfo?.info_value}
         />
       ) : (
         <Text>상품 공통 정보가 입력되지 않은 상품입니다.</Text>

--- a/libs/components/src/lib/GoodsDetailSummary.tsx
+++ b/libs/components/src/lib/GoodsDetailSummary.tsx
@@ -1,10 +1,11 @@
-import { GoodsConfirmationStatuses } from '@prisma/client';
 import { GoodsByIdRes } from '@project-lc/shared-types';
 import dayjs from 'dayjs';
+import { Text, Stack } from '@chakra-ui/react';
 import { AiTwotoneExperiment } from 'react-icons/ai';
 import { BsFillDisplayFill } from 'react-icons/bs';
 import { IoImagesOutline } from 'react-icons/io5';
 import { MdDateRange } from 'react-icons/md';
+import { InfoIcon } from '@chakra-ui/icons';
 import { SummaryList } from '..';
 import { GOODS_CONFIRMATION_STATUS } from '../constants/goodsStatus';
 
@@ -12,8 +13,33 @@ export interface GoodsDetailSummaryProps {
   goods: GoodsByIdRes;
 }
 export function GoodsDetailSummary({ goods }: GoodsDetailSummaryProps): JSX.Element {
+  const { status, rejectionReason } = goods.confirmation;
+  const confirmationStatusText = `검수상태 : ${GOODS_CONFIRMATION_STATUS[status].label}`;
+  const confirmationValue =
+    status === 'rejected' ? (
+      <Stack whiteSpace="break-spaces">
+        <Text>{confirmationStatusText}</Text>
+        <Text fontWeight="bold">
+          <InfoIcon mr={1} />
+          상품 검수가 반려되었습니다. <br />
+          아래 검수 반려 사유를 참고하여 상품 정보를 수정 하신 후 다시 등록해주세요.
+        </Text>
+        <Text
+          whiteSpace="break-spaces"
+          borderWidth="1px"
+          borderRadius="lg"
+          p={7}
+          height="100%"
+        >
+          {rejectionReason}
+        </Text>
+      </Stack>
+    ) : (
+      confirmationStatusText
+    );
   return (
     <SummaryList
+      spacing={3}
       listItems={[
         {
           id: '등록일',
@@ -27,14 +53,9 @@ export function GoodsDetailSummary({ goods }: GoodsDetailSummaryProps): JSX.Elem
         },
         {
           id: '검수',
-          value: `검수상태 ${
-            GOODS_CONFIRMATION_STATUS[
-              goods.confirmation?.status as GoodsConfirmationStatuses
-            ]?.label || ''
-          }`,
+          value: confirmationValue,
           icon: AiTwotoneExperiment,
           iconColor: goods.confirmation?.status === 'rejected' ? 'orange.400' : undefined,
-          disabled: !goods.confirmation,
         },
         {
           id: '노출여부',

--- a/libs/components/src/lib/SellerGoodsList.tsx
+++ b/libs/components/src/lib/SellerGoodsList.tsx
@@ -29,6 +29,7 @@ import { ChakraDataGrid } from './ChakraDataGrid';
 import DeleteGoodsAlertDialog from './DeleteGoodsAlertDialog';
 import { GoodsExposeSwitch } from './GoodsExposeSwitch';
 import { ShippingGroupDetailModal } from './GoodsRegistShippingPolicy';
+import TextWithPopperButton from './TextWithPopperButton';
 
 function formatPrice(price: number): string {
   const formattedPrice = price.toLocaleString();
@@ -238,9 +239,41 @@ const columns: GridColumns = [
     headerName: '검수',
     width: 60,
     renderCell: ({ row }) => {
-      const { label, colorScheme } = row.confirmation
-        ? GOODS_CONFIRMATION_STATUS[row.confirmation.status as GoodsConfirmationStatuses]
-        : GOODS_CONFIRMATION_STATUS.waiting;
+      const {
+        status,
+        rejectionReason,
+      }: { status: GoodsConfirmationStatuses; rejectionReason?: string | null } =
+        row.confirmation;
+      const { label, colorScheme } =
+        GOODS_CONFIRMATION_STATUS[status as GoodsConfirmationStatuses];
+
+      // 검수 상태 : 반려된 경우
+      // 상태 옆에 '?' 버튼 추가, 해당 버튼 눌렀을 때 반려사유 팝오버
+      if (status === 'rejected') {
+        return (
+          <TextWithPopperButton
+            title={
+              <Badge
+                variant="solid"
+                colorScheme={colorScheme}
+                width="100%"
+                textAlign="center"
+              >
+                {label}
+              </Badge>
+            }
+            iconAriaLabel={label}
+            iconColor="black"
+            portalBody
+          >
+            <Text fontWeight="bold" mb={1}>
+              반려 사유
+            </Text>
+            <Text whiteSpace="break-spaces">{rejectionReason}</Text>
+          </TextWithPopperButton>
+        );
+      }
+      // 검수 상태 : 대기, 승인의 경우
       return (
         <Badge variant="solid" colorScheme={colorScheme} width="100%" textAlign="center">
           {label}

--- a/libs/components/src/lib/SummaryList.tsx
+++ b/libs/components/src/lib/SummaryList.tsx
@@ -1,4 +1,4 @@
-import { List, ListIcon, ListItem, Theme, Colors, IconProps } from '@chakra-ui/react';
+import { List, ListIcon, ListItem, Theme, IconProps } from '@chakra-ui/react';
 import { IconType } from 'react-icons/lib';
 
 export interface SummaryListProps {
@@ -17,7 +17,7 @@ export function SummaryList({ spacing = 2, listItems }: SummaryListProps): JSX.E
       {listItems.map((i) => {
         if (i.disabled) return null;
         return (
-          <ListItem isTruncated key={i.id}>
+          <ListItem isTruncated key={i.id} display="flex">
             <ListIcon boxSize="1.5rem" as={i.icon} color={i.iconColor || 'green.500'} />
             {i.value}
           </ListItem>

--- a/libs/components/src/lib/TextWithPopperButton.tsx
+++ b/libs/components/src/lib/TextWithPopperButton.tsx
@@ -16,7 +16,7 @@ import {
 } from '@chakra-ui/react';
 
 interface TextWithPopperButtonProps extends Partial<PopoverProps> {
-  title: string;
+  title: string | React.ReactNode;
   children: React.ReactNode;
   icon?: React.ReactElement;
   iconAriaLabel: string;
@@ -35,9 +35,11 @@ export default function TextWithPopperButton({
 }: TextWithPopperButtonProps): JSX.Element {
   const { onOpen, onClose, isOpen } = useDisclosure();
 
+  const titleComponent = typeof title === 'string' ? <Text>{title}</Text> : title;
+
   return (
     <HStack spacing={0}>
-      <Text>{title}</Text>
+      {titleComponent}
       <Popover
         isLazy
         isOpen={isOpen}

--- a/libs/components/src/lib/admin/AdminGoodsConfirmationDialog.tsx
+++ b/libs/components/src/lib/admin/AdminGoodsConfirmationDialog.tsx
@@ -16,6 +16,7 @@ import {
   ModalOverlay,
   useToast,
   Grid,
+  Text,
 } from '@chakra-ui/react';
 import { GoodsConfirmationStatus } from '@project-lc/shared-types';
 import { useGoodConfirmationMutation } from '@project-lc/hooks';
@@ -45,6 +46,7 @@ export function AdminGoodsConfirmationDialog(
     handleSubmit,
     reset,
     formState: { errors, isSubmitting },
+    watch,
   } = useForm();
   const initialRef = useRef(null);
   const toast = useToast();
@@ -102,7 +104,15 @@ export function AdminGoodsConfirmationDialog(
             <FormLabel fontSize="md">상품 ID</FormLabel>
             <FormHelperText>
               퍼스트몰에 등록한 상품의 고유번호를
-              입력하세요.(http://whiletrue.firstmall.kr/goods/view?no=41 의 41을 입력)
+              입력하세요.(http://whiletrue.firstmall.kr/goods/view?no=
+              <Text as="span" color="red">
+                41
+              </Text>
+              의&nbsp;
+              <Text as="span" color="red">
+                41
+              </Text>
+              을 입력)
             </FormHelperText>
             <Input
               id="firstmallGoodsConnectionId"
@@ -125,7 +135,11 @@ export function AdminGoodsConfirmationDialog(
           </FormControl>
         </ModalBody>
         <ModalFooter>
-          <Button type="submit" isLoading={isSubmitting}>
+          <Button
+            type="submit"
+            isLoading={isSubmitting}
+            isDisabled={!watch('firstmallGoodsConnectionId')}
+          >
             승인하기
           </Button>
         </ModalFooter>

--- a/libs/components/src/lib/admin/AdminGoodsConfirmationDialog.tsx
+++ b/libs/components/src/lib/admin/AdminGoodsConfirmationDialog.tsx
@@ -26,7 +26,7 @@ import { AxiosError } from 'axios';
 import { GridTableItem } from '../GridTableItem';
 
 // 검수 승인시에 필요한 최소한의 데이터
-type GoodRowType = { id: number; goods_name: string };
+export type GoodRowType = { id: number; goods_name: string };
 
 type GoodsConfirmationDialogType = {
   isOpen: boolean;
@@ -81,7 +81,15 @@ export function AdminGoodsConfirmationDialog(
   }
 
   return (
-    <Modal isOpen={isOpen} size="md" onClose={useClose} initialFocusRef={initialRef}>
+    <Modal
+      isOpen={isOpen}
+      size="md"
+      onClose={() => {
+        reset();
+        onClose();
+      }}
+      initialFocusRef={initialRef}
+    >
       <ModalOverlay />
       <ModalContent as="form" onSubmit={handleSubmit(useSubmit)}>
         <ModalHeader>검수 승인 하기</ModalHeader>

--- a/libs/components/src/lib/admin/AdminGoodsList.tsx
+++ b/libs/components/src/lib/admin/AdminGoodsList.tsx
@@ -1,30 +1,25 @@
-import NextLink from 'next/link';
 import {
   Box,
   Button,
+  Link,
   Select,
   Stack,
   Text,
-  Link,
-  useDisclosure,
   useColorModeValue,
-  useToast,
+  useDisclosure,
 } from '@chakra-ui/react';
-import {
-  useProfile,
-  useAdminGoodsList,
-  useGoodRejectionMutation,
-} from '@project-lc/hooks';
-import { GridColumns, GridCellParams } from '@material-ui/data-grid';
-import dayjs from 'dayjs';
+import { GridCellParams, GridColumns } from '@material-ui/data-grid';
 import { GoodsStatus } from '@prisma/client';
+import { useAdminGoodsList, useProfile } from '@project-lc/hooks';
+import { SellerGoodsSortColumn } from '@project-lc/shared-types';
 import { useSellerGoodsListPanelStore } from '@project-lc/stores';
-import { GoodsConfirmationStatus, SellerGoodsSortColumn } from '@project-lc/shared-types';
+import dayjs from 'dayjs';
+import NextLink from 'next/link';
 import { useState } from 'react';
-import { AdminGoodsConfirmationDialog } from './AdminGoodsConfirmationDialog';
-import { ChakraDataGrid } from '../ChakraDataGrid';
 import { GOODS_STATUS } from '../../constants/goodsStatus';
+import { ChakraDataGrid } from '../ChakraDataGrid';
 import { ShippingGroupDetailButton } from '../SellerGoodsList';
+import { AdminGoodsConfirmationDialog } from './AdminGoodsConfirmationDialog';
 import AdminGoodsRejectionDialog from './AdminGoodsRejectionDialog';
 
 function formatPrice(price: number): string {
@@ -129,7 +124,6 @@ const columns: GridColumns = [
 export function AdminGoodsList(): JSX.Element {
   const { data: profileData } = useProfile();
   const {
-    page,
     itemPerPage,
     sort,
     direction,
@@ -137,7 +131,6 @@ export function AdminGoodsList(): JSX.Element {
     handlePageSizeChange,
     handleSortChange,
   } = useSellerGoodsListPanelStore();
-  const toast = useToast();
   const { isOpen, onOpen, onClose } = useDisclosure();
   const {
     isOpen: isRejectionOpen,
@@ -155,34 +148,12 @@ export function AdminGoodsList(): JSX.Element {
     },
   );
 
-  const rejectMutation = useGoodRejectionMutation();
-
-  async function handleRejectionGood(row: any): Promise<void> {
-    try {
-      await rejectMutation.mutateAsync({
-        goodsId: row.id,
-        status: GoodsConfirmationStatus.REJECTED,
-      });
-      toast({
-        title: '상품이 반려되었습니다.',
-        status: 'success',
-      });
-      refetch();
-    } catch (error) {
-      toast({
-        title: '상품 반려가 실패하였습니다.',
-        status: 'error',
-      });
-    }
-  }
-
   async function handleClick(param: GridCellParams): Promise<void> {
     if (param.field === 'confirmation') {
       setSelectedRow(param.row);
       onOpen();
     }
     if (param.field === 'rejection') {
-      // handleRejectionGood(param.row);
       setSelectedRow(param.row);
       onRejectionOpen();
     }

--- a/libs/components/src/lib/admin/AdminGoodsList.tsx
+++ b/libs/components/src/lib/admin/AdminGoodsList.tsx
@@ -25,6 +25,7 @@ import { AdminGoodsConfirmationDialog } from './AdminGoodsConfirmationDialog';
 import { ChakraDataGrid } from '../ChakraDataGrid';
 import { GOODS_STATUS } from '../../constants/goodsStatus';
 import { ShippingGroupDetailButton } from '../SellerGoodsList';
+import AdminGoodsRejectionDialog from './AdminGoodsRejectionDialog';
 
 function formatPrice(price: number): string {
   const formattedPrice = price.toLocaleString();
@@ -138,6 +139,11 @@ export function AdminGoodsList(): JSX.Element {
   } = useSellerGoodsListPanelStore();
   const toast = useToast();
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const {
+    isOpen: isRejectionOpen,
+    onOpen: onRejectionOpen,
+    onClose: onRejectionClose,
+  } = useDisclosure();
   const [selectedRow, setSelectedRow] = useState({});
   const { data, isLoading, refetch } = useAdminGoodsList(
     {
@@ -176,7 +182,9 @@ export function AdminGoodsList(): JSX.Element {
       onOpen();
     }
     if (param.field === 'rejection') {
-      handleRejectionGood(param.row);
+      // handleRejectionGood(param.row);
+      setSelectedRow(param.row);
+      onRejectionOpen();
     }
     // 이외의 클릭에 대해서는 다른 패널에 대해서 상세보기로 이동시키기
   }
@@ -236,6 +244,11 @@ export function AdminGoodsList(): JSX.Element {
         callback={() => {
           refetch();
         }}
+      />
+      <AdminGoodsRejectionDialog
+        isOpen={isRejectionOpen}
+        onClose={onRejectionClose}
+        row={selectedRow}
       />
     </Box>
   );

--- a/libs/components/src/lib/admin/AdminGoodsRejectionDialog.tsx
+++ b/libs/components/src/lib/admin/AdminGoodsRejectionDialog.tsx
@@ -15,8 +15,12 @@ import {
   FormLabel,
   Grid,
   Textarea,
+  useToast,
 } from '@chakra-ui/react';
 import { GridRowData } from '@material-ui/data-grid';
+import { useGoodRejectionMutation } from '@project-lc/hooks';
+import { GoodsConfirmationStatus } from '@project-lc/shared-types';
+import { useRouter } from 'next/router';
 import { useRef, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { GridTableItem } from '../GridTableItem';
@@ -31,26 +35,60 @@ export interface AdminGoodsRejectionDialogProps {
 type rejectionFormData = {
   rejectionReason: string;
 };
+
 export function AdminGoodsRejectionDialog({
   isOpen,
   onClose,
   row,
 }: AdminGoodsRejectionDialogProps): JSX.Element {
+  const toast = useToast();
+  const router = useRouter();
   const {
     register,
     handleSubmit,
     reset,
+    watch,
     formState: { errors, isSubmitting },
   } = useForm<rejectionFormData>();
 
   const initialRef = useRef(null);
 
+  // 다른 상품의 검수 반려 눌렀을때만 반려사유 textarea 초기화
   useEffect(() => {
     reset();
   }, [reset, row]);
 
+  const rejectMutation = useGoodRejectionMutation();
+
+  async function handleRejectionGood({
+    goodsId,
+    rejectionReason,
+  }: {
+    goodsId: number;
+    rejectionReason: string;
+  }): Promise<void> {
+    try {
+      await rejectMutation.mutateAsync({
+        goodsId,
+        rejectionReason,
+        status: GoodsConfirmationStatus.REJECTED,
+      });
+      toast({
+        title: '상품이 반려되었습니다.',
+        status: 'success',
+      });
+      router.push('/goods');
+    } catch (error) {
+      toast({
+        title: '상품 반려가 실패하였습니다.',
+        status: 'error',
+      });
+    }
+  }
+
   const useSubmit = (data: rejectionFormData): void => {
-    console.log(data);
+    const { rejectionReason } = data;
+    handleRejectionGood({ goodsId: row.id, rejectionReason });
   };
   return (
     <Modal isOpen={isOpen} size="xl" onClose={onClose} initialFocusRef={initialRef}>
@@ -62,17 +100,37 @@ export function AdminGoodsRejectionDialog({
           <Grid templateColumns="2fr 3fr" borderTopWidth={1.5} width={['100%', '70%']}>
             <GridTableItem title="현재 상품명" value={row?.goods_name} />
           </Grid>
-          <FormControl isInvalid={!!errors.rejectionReason} m={2} mt={6}>
+          <FormControl m={2} mt={6} isInvalid={!!errors.rejectionReason}>
             <FormLabel fontSize="md">반려사유</FormLabel>
             <FormHelperText>해당 상품의 승인 불가 사유를 입력해주세요.</FormHelperText>
-            <Textarea {...register('rejectionReason', { required: true })} />
+            <Textarea
+              isInvalid={!!errors.rejectionReason}
+              minHeight="250px"
+              resize="none"
+              placeholder="예) 상품명과 상품 사진이 일치하지 않습니다"
+              {...register('rejectionReason', {
+                required: '반려 사유를 입력해주세요',
+                validate: {
+                  notEmpty: (v) => {
+                    if (!v || /^\s*$/.test(v))
+                      return '빈 문자는 반려사유가 될 수 없습니다';
+                    return true;
+                  },
+                },
+              })}
+            />
+
             <FormErrorMessage>
               {errors.rejectionReason && errors.rejectionReason.message}
             </FormErrorMessage>
           </FormControl>
         </ModalBody>
         <ModalFooter>
-          <Button type="submit" isLoading={isSubmitting}>
+          <Button
+            type="submit"
+            isLoading={isSubmitting}
+            isDisabled={!watch('rejectionReason') || !!errors.rejectionReason}
+          >
             반려하기
           </Button>
         </ModalFooter>

--- a/libs/components/src/lib/admin/AdminGoodsRejectionDialog.tsx
+++ b/libs/components/src/lib/admin/AdminGoodsRejectionDialog.tsx
@@ -1,0 +1,84 @@
+import { Button } from '@chakra-ui/button';
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
+  ModalFooter,
+} from '@chakra-ui/modal';
+import {
+  FormControl,
+  FormErrorMessage,
+  FormHelperText,
+  FormLabel,
+  Grid,
+  Textarea,
+} from '@chakra-ui/react';
+import { GridRowData } from '@material-ui/data-grid';
+import { useRef, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { GridTableItem } from '../GridTableItem';
+import { GoodRowType } from './AdminGoodsConfirmationDialog';
+
+export interface AdminGoodsRejectionDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  row: GoodRowType | GridRowData;
+}
+
+type rejectionFormData = {
+  rejectionReason: string;
+};
+export function AdminGoodsRejectionDialog({
+  isOpen,
+  onClose,
+  row,
+}: AdminGoodsRejectionDialogProps): JSX.Element {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<rejectionFormData>();
+
+  const initialRef = useRef(null);
+
+  useEffect(() => {
+    reset();
+  }, [reset, row]);
+
+  const useSubmit = (data: rejectionFormData): void => {
+    console.log(data);
+  };
+  return (
+    <Modal isOpen={isOpen} size="xl" onClose={onClose} initialFocusRef={initialRef}>
+      <ModalOverlay />
+      <ModalContent as="form" onSubmit={handleSubmit(useSubmit)}>
+        <ModalHeader>상품 반려 하기</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Grid templateColumns="2fr 3fr" borderTopWidth={1.5} width={['100%', '70%']}>
+            <GridTableItem title="현재 상품명" value={row?.goods_name} />
+          </Grid>
+          <FormControl isInvalid={!!errors.rejectionReason} m={2} mt={6}>
+            <FormLabel fontSize="md">반려사유</FormLabel>
+            <FormHelperText>해당 상품의 승인 불가 사유를 입력해주세요.</FormHelperText>
+            <Textarea {...register('rejectionReason', { required: true })} />
+            <FormErrorMessage>
+              {errors.rejectionReason && errors.rejectionReason.message}
+            </FormErrorMessage>
+          </FormControl>
+        </ModalBody>
+        <ModalFooter>
+          <Button type="submit" isLoading={isSubmitting}>
+            반려하기
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}
+
+export default AdminGoodsRejectionDialog;

--- a/libs/components/src/lib/admin/AdminGoodsStatusButtons.tsx
+++ b/libs/components/src/lib/admin/AdminGoodsStatusButtons.tsx
@@ -5,13 +5,20 @@ import { CheckIcon, CloseIcon } from '@chakra-ui/icons';
 import { GoodsConfirmationStatus, GoodsByIdRes } from '@project-lc/shared-types';
 import { useRouter } from 'next/router';
 import { useGoodRejectionMutation } from '@project-lc/hooks';
+import { useMemo } from 'react';
 import { AdminGoodsConfirmationDialog } from './AdminGoodsConfirmationDialog';
+import AdminGoodsRejectionDialog from './AdminGoodsRejectionDialog';
 
 export function AdminGoodsStatusButtons(props: { goods: GoodsByIdRes }): JSX.Element {
   const { goods } = props;
   const router = useRouter();
   const toast = useToast();
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const {
+    isOpen: isRejecionOpen,
+    onOpen: onRejectionOpen,
+    onClose: onRejectionClose,
+  } = useDisclosure();
   const rejectMutation = useGoodRejectionMutation();
 
   async function handleRejectionGood(row: any): Promise<void> {
@@ -34,6 +41,11 @@ export function AdminGoodsStatusButtons(props: { goods: GoodsByIdRes }): JSX.Ele
     }
   }
 
+  const goodsRowData = useMemo(
+    () => ({ id: goods.id, goods_name: goods.goods_name }),
+    [goods],
+  );
+
   return (
     <>
       <Grid templateColumns="1fr 1fr" gap={3}>
@@ -49,16 +61,23 @@ export function AdminGoodsStatusButtons(props: { goods: GoodsByIdRes }): JSX.Ele
           size="sm"
           color="red.400"
           leftIcon={<CloseIcon />}
-          onClick={() => handleRejectionGood({ id: goods.id })}
+          onClick={() => onRejectionOpen()}
         >
           검수 반려
         </Button>
       </Grid>
+      {/* 검수 승인 다이얼로그 - 퍼스트몰 상품 id 입력 */}
       <AdminGoodsConfirmationDialog
         isOpen={isOpen}
         onClose={onClose}
-        row={{ id: goods.id, goods_name: goods.goods_name }}
+        row={goodsRowData}
         callback={() => router.push('/goods')}
+      />
+      {/* 검수 반려 다이얼로그 - 반려사유 입력 */}
+      <AdminGoodsRejectionDialog
+        isOpen={isRejecionOpen}
+        onClose={onRejectionClose}
+        row={goodsRowData}
       />
     </>
   );

--- a/libs/components/src/lib/admin/AdminGoodsStatusButtons.tsx
+++ b/libs/components/src/lib/admin/AdminGoodsStatusButtons.tsx
@@ -1,10 +1,9 @@
 // 검수 승인 및 거절 버튼 그룹
 
-import { Grid, useToast, useDisclosure, Button } from '@chakra-ui/react';
+import { Grid, useDisclosure, Button } from '@chakra-ui/react';
 import { CheckIcon, CloseIcon } from '@chakra-ui/icons';
-import { GoodsConfirmationStatus, GoodsByIdRes } from '@project-lc/shared-types';
+import { GoodsByIdRes } from '@project-lc/shared-types';
 import { useRouter } from 'next/router';
-import { useGoodRejectionMutation } from '@project-lc/hooks';
 import { useMemo } from 'react';
 import { AdminGoodsConfirmationDialog } from './AdminGoodsConfirmationDialog';
 import AdminGoodsRejectionDialog from './AdminGoodsRejectionDialog';
@@ -12,34 +11,12 @@ import AdminGoodsRejectionDialog from './AdminGoodsRejectionDialog';
 export function AdminGoodsStatusButtons(props: { goods: GoodsByIdRes }): JSX.Element {
   const { goods } = props;
   const router = useRouter();
-  const toast = useToast();
   const { isOpen, onOpen, onClose } = useDisclosure();
   const {
     isOpen: isRejecionOpen,
     onOpen: onRejectionOpen,
     onClose: onRejectionClose,
   } = useDisclosure();
-  const rejectMutation = useGoodRejectionMutation();
-
-  async function handleRejectionGood(row: any): Promise<void> {
-    try {
-      await rejectMutation.mutateAsync({
-        goodsId: row.id,
-        status: GoodsConfirmationStatus.REJECTED,
-      });
-      toast({
-        title: '상품이 반려되었습니다.',
-        status: 'success',
-      });
-    } catch (error) {
-      toast({
-        title: '상품 반려가 실패하였습니다.',
-        status: 'error',
-      });
-    } finally {
-      router.push('/goods');
-    }
-  }
 
   const goodsRowData = useMemo(
     () => ({ id: goods.id, goods_name: goods.goods_name }),

--- a/libs/hooks/src/lib/mutation/useCreateGoodsCommonInfo.tsx
+++ b/libs/hooks/src/lib/mutation/useCreateGoodsCommonInfo.tsx
@@ -18,7 +18,7 @@ export const useCreateGoodsCommonInfo = (): UseMutationResult<
         .then((res) => res.data),
     {
       onSuccess: (data) => {
-        queryClient.invalidateQueries('GoodsCommonInfoList');
+        queryClient.invalidateQueries('GoodsCommonInfoList', { refetchInactive: true });
       },
     },
   );

--- a/libs/hooks/src/lib/mutation/useGoodRejectionMutation.tsx
+++ b/libs/hooks/src/lib/mutation/useGoodRejectionMutation.tsx
@@ -1,4 +1,4 @@
-import { useMutation, UseMutationResult } from 'react-query';
+import { useMutation, UseMutationResult, useQueryClient } from 'react-query';
 import { GoodsRejectionDto } from '@project-lc/shared-types';
 import { AxiosError } from 'axios';
 import axios from '../../axios';
@@ -8,7 +8,15 @@ export const useGoodRejectionMutation = (): UseMutationResult<
   AxiosError,
   GoodsRejectionDto
 > => {
-  return useMutation<any, AxiosError, GoodsRejectionDto>((dto: GoodsRejectionDto) => {
-    return axios.put<any>(`/admin/goods/reject`, dto);
-  });
+  const queryClient = useQueryClient();
+  return useMutation<any, AxiosError, GoodsRejectionDto>(
+    (dto: GoodsRejectionDto) => {
+      return axios.put<any>(`/admin/goods/reject`, dto);
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries('AdminGoodsList', { refetchInactive: true });
+      },
+    },
+  );
 };

--- a/libs/nest-modules/src/lib/admin/admin.service.ts
+++ b/libs/nest-modules/src/lib/admin/admin.service.ts
@@ -122,6 +122,7 @@ export class AdminService {
       data: {
         firstmallGoodsConnectionId: dto.firstmallGoodsConnectionId,
         status: dto.status,
+        rejectionReason: null,
       },
     });
 
@@ -137,6 +138,7 @@ export class AdminService {
       where: { goodsId: dto.goodsId },
       data: {
         status: dto.status,
+        rejectionReason: dto.rejectionReason,
       },
     });
 

--- a/libs/nest-modules/src/lib/admin/admin.service.ts
+++ b/libs/nest-modules/src/lib/admin/admin.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { PrismaService } from '@project-lc/prisma-orm';
 import {
   GoodsByIdRes,
@@ -114,13 +114,38 @@ export class AdminService {
     };
   }
 
+  /** 동일한 퍼스트몰 상품 고유번호로 검수된 상품이 있는지 확인(중복 상품 연결 방지 위함) */
+  private async checkDupFMGoodsConnectionId(fmGoodsId: number): Promise<boolean> {
+    const confirmData = await this.prisma.goodsConfirmation.findFirst({
+      where: { firstmallGoodsConnectionId: fmGoodsId },
+    });
+
+    if (confirmData) {
+      return true;
+    }
+    return false;
+  }
+
   public async setGoodsConfirmation(
     dto: GoodsConfirmationDto,
   ): Promise<GoodsConfirmation> {
+    // 상품 검수 확인시 동일한 퍼스트몰 상품번호로 검수된 상품이 있는지(중복 여부) 확인 - 이미 존재하면 400 에러
+    const { firstmallGoodsConnectionId } = dto;
+    const hasDuplicatedFmGoodsConnectionId = await this.checkDupFMGoodsConnectionId(
+      firstmallGoodsConnectionId,
+    );
+
+    if (hasDuplicatedFmGoodsConnectionId) {
+      throw new BadRequestException(
+        `이미 ( 퍼스트몰 상품 고유번호 : ${firstmallGoodsConnectionId} ) 로 검수된 상품이 존재합니다. 퍼스트몰 상품 고유번호를 다시 확인해주세요.`,
+      );
+    }
+
+    // 동일한 퍼스트몰 상품번호로 검수된 상품이 없다면(중복이 아닌 경우) 그대로 검수 확인 진행
     const goodsConfirmation = await this.prisma.goodsConfirmation.update({
       where: { goodsId: dto.goodsId },
       data: {
-        firstmallGoodsConnectionId: dto.firstmallGoodsConnectionId,
+        firstmallGoodsConnectionId,
         status: dto.status,
         rejectionReason: null,
       },

--- a/libs/prisma-orm/prisma/migrations/20211007013259_/migration.sql
+++ b/libs/prisma-orm/prisma/migrations/20211007013259_/migration.sql
@@ -1,2 +1,0 @@
--- AlterTable
-ALTER TABLE `GoodsConfirmation` ADD COLUMN `rejectionReason` TEXT;

--- a/libs/prisma-orm/prisma/migrations/20211007013259_/migration.sql
+++ b/libs/prisma-orm/prisma/migrations/20211007013259_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `GoodsConfirmation` ADD COLUMN `rejectionReason` TEXT;

--- a/libs/prisma-orm/prisma/migrations/20211008005702_/migration.sql
+++ b/libs/prisma-orm/prisma/migrations/20211008005702_/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE `GoodsConfirmation` ADD COLUMN `rejectionReason` TEXT;
+
+-- CreateIndex
+CREATE INDEX `firstmallGoodsConnectionId` ON `GoodsConfirmation`(`firstmallGoodsConnectionId`);

--- a/libs/prisma-orm/prisma/schema.prisma
+++ b/libs/prisma-orm/prisma/schema.prisma
@@ -146,6 +146,8 @@ model GoodsConfirmation {
   firstmallGoodsConnectionId Int? // 퍼스트몰 상품 고유 ID (fm_goods.goods_seq)
   goods                      Goods                     @relation(fields: [goodsId], references: [id], onDelete: Cascade)
   rejectionReason            String?                   @db.Text // 반려사유 - 관리자가 입력
+
+  @@index([firstmallGoodsConnectionId], name: "firstmallGoodsConnectionId")
 }
 
 model GoodsOptions {

--- a/libs/prisma-orm/prisma/schema.prisma
+++ b/libs/prisma-orm/prisma/schema.prisma
@@ -145,6 +145,7 @@ model GoodsConfirmation {
   status                     GoodsConfirmationStatuses @default(waiting) // 검수 상태
   firstmallGoodsConnectionId Int? // 퍼스트몰 상품 고유 ID (fm_goods.goods_seq)
   goods                      Goods                     @relation(fields: [goodsId], references: [id], onDelete: Cascade)
+  rejectionReason            String?                   @db.Text // 반려사유 - 관리자가 입력
 }
 
 model GoodsOptions {

--- a/libs/prisma-orm/prisma/seed.ts
+++ b/libs/prisma-orm/prisma/seed.ts
@@ -30,7 +30,7 @@ const common_contents = `
 <p>고객님께서 주문하신 상품은 입금 확인후 배송해 드립니다.</p>
 <p>다만, 상품종류에 따라서 상품의 배송이 다소 지연될 수 있습니다.</p>
 `;
-const testSellerEmail = 'a1919361@gmail.com';
+const testSellerEmail = 'testSeller@gmail.com';
 const testSellerData = {
   email: testSellerEmail,
   name: 'testSeller',
@@ -98,7 +98,7 @@ async function main(): Promise<void> {
           baseAddress: '반송지 주소',
           detailAddress: '반송지 주소 상세',
           postalCode: '12345',
-          shipping_group_name: '배송그룹이름',
+          shipping_group_name: '기본 배송 그룹',
           seller: {
             connect: { id: seller.id },
           },
@@ -107,9 +107,10 @@ async function main(): Promise<void> {
               shipping_set_name: '배송세트이름',
               shippingOptions: {
                 create: {
+                  shipping_opt_type: 'fixed',
                   shippingCost: {
                     create: {
-                      shipping_area_name: 'shipping_area_name',
+                      shipping_area_name: '대한민국',
                       shipping_cost: 2500,
                     },
                   },
@@ -132,7 +133,7 @@ async function main(): Promise<void> {
       image: {
         create: {
           cut_number: 1,
-          image: 'test2.png',
+          image: 'https://picsum.photos/301/300',
         },
       },
       options: {
@@ -166,7 +167,7 @@ async function main(): Promise<void> {
       image: {
         create: {
           cut_number: 1,
-          image: 'test3.png',
+          image: 'https://picsum.photos/301/300',
         },
       },
       options: {

--- a/libs/prisma-orm/prisma/seed.ts
+++ b/libs/prisma-orm/prisma/seed.ts
@@ -38,7 +38,20 @@ const testSellerData = {
     '$argon2i$v=19$m=4096,t=3,p=1$97nVwdfXR9h8Wu38n5YuvQ$w5XgpncJVDAxURkmyJyMzDLMe2axEV6WT1PoSxNYqjY', // asdfasdf!
 };
 
+const testAdminEmail = 'testAdmin@gmail.com';
+const testAdminData = {
+  email: testAdminEmail,
+  name: 'test관리자',
+  password:
+    '$argon2i$v=19$m=4096,t=3,p=1$97nVwdfXR9h8Wu38n5YuvQ$w5XgpncJVDAxURkmyJyMzDLMe2axEV6WT1PoSxNYqjY', // asdfasdf!
+};
+
 async function main(): Promise<void> {
+  await prisma.seller.upsert({
+    where: { email: testAdminEmail },
+    update: {},
+    create: testAdminData,
+  });
   let seller = await prisma.seller.findUnique({
     where: { email: testSellerData.email },
   });
@@ -152,7 +165,7 @@ async function main(): Promise<void> {
         ],
       },
       confirmation: {
-        create: { status: 'rejected' },
+        create: { status: 'waiting' },
       },
     },
     include: { options: { include: { supply: true } } },

--- a/libs/shared-types/src/lib/dto/goodsConfirmation.dto.ts
+++ b/libs/shared-types/src/lib/dto/goodsConfirmation.dto.ts
@@ -1,4 +1,4 @@
-import { IsEnum, IsNumber } from 'class-validator';
+import { IsEnum, IsNumber, IsOptional, IsString } from 'class-validator';
 
 export enum GoodsConfirmationStatus {
   WAITING = 'waiting',
@@ -23,4 +23,8 @@ export class GoodsRejectionDto {
 
   @IsEnum(GoodsConfirmationStatus)
   status = GoodsConfirmationStatus.REJECTED;
+
+  @IsString()
+  @IsOptional() // TODO: optional 삭제
+  rejectionReason?: string;
 }

--- a/libs/shared-types/src/lib/dto/goodsConfirmation.dto.ts
+++ b/libs/shared-types/src/lib/dto/goodsConfirmation.dto.ts
@@ -1,4 +1,4 @@
-import { IsEnum, IsNumber, IsOptional, IsString } from 'class-validator';
+import { IsEnum, IsNumber, IsString } from 'class-validator';
 
 export enum GoodsConfirmationStatus {
   WAITING = 'waiting',
@@ -25,6 +25,5 @@ export class GoodsRejectionDto {
   status = GoodsConfirmationStatus.REJECTED;
 
   @IsString()
-  @IsOptional() // TODO: optional 삭제
-  rejectionReason?: string;
+  rejectionReason: string;
 }

--- a/libs/shared-types/src/lib/res-types/goodsById.res.ts
+++ b/libs/shared-types/src/lib/res-types/goodsById.res.ts
@@ -24,7 +24,7 @@ export type GoodsByIdRes = Goods & {
         >;
       })
     | null;
-  confirmation: GoodsConfirmation | null;
+  confirmation: GoodsConfirmation;
   image: GoodsImages[];
   GoodsInfo: GoodsInfo | null;
 };


### PR DESCRIPTION
## 백엔드
- GoodsConfirmation 테이블 반려사유 컬럼 rejectionReason 추가
- adminService 검수, 반려시 rejectionReason 수정

## 프론트
- 관리자 페이지 - '반려하기' 버튼 눌렀을 때 반려사유 입력 다이얼로그 추가

![검수반려창](https://user-images.githubusercontent.com/18395475/136482966-f75e4925-0324-42a5-bff5-48990bc0f639.png)
- 판매자 페이지 - 상품목록, 상품상세보기 화면에서 반려사유 확인
![스크린샷 2021-10-08 오전 10 11 30](https://user-images.githubusercontent.com/18395475/136482977-71e61309-66b3-4bec-9eb3-4e85c0eff249.png)
![스크린샷 2021-10-08 오전 10 11 17](https://user-images.githubusercontent.com/18395475/136482980-e0956368-e6bc-44fc-b95a-378e9aaa223e.png)

## 기타 수정 사항
- 관리자페이지 상품 상세페이지 상품 공통정보 표시
- 검수하기 눌렀을 때 중복된 퍼스트몰 상품번호 등록 방지