### PR TITLE
[마이페이지 - 주문상세보기] 배송메모 추가

### DIFF
--- a/libs/components/src/lib/ExportDetailItems.tsx
+++ b/libs/components/src/lib/ExportDetailItems.tsx
@@ -9,24 +9,23 @@ interface ExportDetailItemsProps {
 }
 export function ExportDetailItems({ exportData }: ExportDetailItemsProps): JSX.Element {
   const order = useFmOrder(exportData.order_seq);
+
   return (
     <Box>
-      <NextLink href={`/mypage/orders/${exportData.order_seq}`} passHref>
-        <Link isTruncated fontWeight="bold" textDecoration="underline">
-          {exportData.order_seq}
-        </Link>
-      </NextLink>
-
       <Stack mt={2}>
         {exportData.items.map((item) => (
           <Box key={item.item_option_seq}>
-            <Stack spacing={1}>
-              <OrderDetailExportInfoItem
-                itemOption={item}
-                orderItems={order.data?.items || []}
-                bundleExportCode={exportData.bundle_export_code}
-              />
-            </Stack>
+            <NextLink href={`/mypage/orders/${item.order_seq}`} passHref>
+              <Link isTruncated fontWeight="bold" textDecoration="underline">
+                {item.order_seq}
+              </Link>
+            </NextLink>
+
+            <OrderDetailExportInfoItem
+              itemOption={item}
+              orderItems={order.data?.items || []}
+              bundleExportCode={exportData.bundle_export_code}
+            />
           </Box>
         ))}
       </Stack>

--- a/libs/components/src/lib/OrderDetailDeliveryInfo.tsx
+++ b/libs/components/src/lib/OrderDetailDeliveryInfo.tsx
@@ -21,6 +21,7 @@ export function OrderDetailDeliveryInfo({
     | 'recipient_zipcode'
     | 'recipient_cellphone'
     | 'recipient_email'
+    | 'memo'
   >;
 }): JSX.Element {
   // 주문자 전화
@@ -69,6 +70,7 @@ export function OrderDetailDeliveryInfo({
         <Text>(우편번호) {orderDeliveryData.recipient_zipcode}</Text>
         <Text>(지번) {addressJibun}</Text>
         <Text>(도로명) {addressStreet}</Text>
+        <Text>(배송메모) {orderDeliveryData.memo}</Text>
         {recipientPhone && <Text>{recipientPhone}</Text>}
         <Text>{orderDeliveryData.recipient_cellphone}</Text>
         <Text>{orderDeliveryData.recipient_email}</Text>

--- a/libs/firstmall-db/src/__tests__/exportSample.ts
+++ b/libs/firstmall-db/src/__tests__/exportSample.ts
@@ -72,6 +72,7 @@ export const exportItemSample: FmExportItem[] = [
     ea: 1,
     price: '1000.00',
     step: '75',
+    order_seq: '123123123123',
   },
   {
     goods_name: 'test2',
@@ -83,5 +84,6 @@ export const exportItemSample: FmExportItem[] = [
     ea: 1,
     price: '100.00',
     step: '75',
+    order_seq: '123123123123',
   },
 ];

--- a/libs/firstmall-db/src/__tests__/exportSample.ts
+++ b/libs/firstmall-db/src/__tests__/exportSample.ts
@@ -59,6 +59,7 @@ export const exportSample: FmExport = {
   order_phone: '--',
   order_cellphone: '010-9999-9999',
   order_email: 'asdf@asdf.com',
+  memo: '1. 배송메모 : ㅁㄴㅇㄹ,',
 };
 
 export const exportItemSample: FmExportItem[] = [

--- a/libs/firstmall-db/src/__tests__/orderDetailSample.ts
+++ b/libs/firstmall-db/src/__tests__/orderDetailSample.ts
@@ -31,7 +31,7 @@ export const orderMetaInfoSample: FmOrderMetaInfo = {
   recipient_address: 'somewhere over the rainboe',
   recipient_address_street: 'somewhere over the rainboe',
   recipient_address_detail: 'somewhere over the rainboe',
-  memo: '1234',
+  memo: '1. 배송메모 : 1234,',
   order_seq: 'asdf',
   shipping_group: 'asdf',
   shipping_method: 'delivery',

--- a/libs/firstmall-db/src/lib/fm-exports/fm-exports.service.ts
+++ b/libs/firstmall-db/src/lib/fm-exports/fm-exports.service.ts
@@ -79,7 +79,8 @@ export class FmExportsService {
     const findItemsSql = `
     SELECT 
       goods_name, image,
-      item_option_seq, title1, option1, color, fm_goods_export_item.ea, price, step
+      item_option_seq, title1, option1, color, fm_goods_export_item.ea, price, step,
+      fm_order_item.order_seq
     FROM fm_order_item_option
       JOIN fm_order_item USING(item_seq)
     JOIN fm_goods_export_item ON item_option_seq = option_seq

--- a/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.spec.ts
+++ b/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.spec.ts
@@ -208,7 +208,7 @@ describe('FmOrdersService', () => {
 
       expect(querySpy).toBeCalledTimes(2);
 
-      expect(orderDetail).toEqual(orderMetaInfoSample);
+      expect(orderDetail).toEqual({ ...orderMetaInfoSample, memo: '1234' });
     });
 
     it('should be return null', async () => {

--- a/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.ts
+++ b/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.ts
@@ -17,6 +17,7 @@ import {
   FmOrderReturnItem,
   FmOrderStatusNumString,
 } from '@project-lc/shared-types';
+import { FmOrderMemoParser } from '@project-lc/utils';
 import { FirstmallDbService } from '../firstmall-db.service';
 
 @Injectable()
@@ -239,7 +240,10 @@ export class FmOrdersService {
     JOIN fm_order_shipping USING(order_seq)
     WHERE fm_order.order_seq = ?`;
     const result = await this.db.query(sql, [orderId]);
-    return result.length > 0 ? result[0] : null;
+    const order = result.length > 0 ? result[0] : null;
+    if (!order) return null;
+    const parser = new FmOrderMemoParser(order.memo);
+    return { ...order, memo: parser.memo };
   }
 
   private async findOneOrderItems(

--- a/libs/shared-types/src/lib/res-types/fmExport.res.ts
+++ b/libs/shared-types/src/lib/res-types/fmExport.res.ts
@@ -119,7 +119,7 @@ export interface FmExport {
   recipient_email: FmOrder['recipient_email'];
 }
 
-export type FmExportItem = FmOrderExportItemOption;
+export type FmExportItem = FmOrderExportItemOption & { order_seq: FmOrder['order_seq'] };
 export type FmExportRes = FmExport & {
   /** 이 출고에 포함된 상품(옵션) 목록 */
   items: FmExportItem[];

--- a/libs/shared-types/src/lib/res-types/fmExport.res.ts
+++ b/libs/shared-types/src/lib/res-types/fmExport.res.ts
@@ -117,6 +117,8 @@ export interface FmExport {
   recipient_address_detail: FmOrder['recipient_address_detail'];
   /** 받는자 이메일 */
   recipient_email: FmOrder['recipient_email'];
+  /** 배송메모 */
+  memo: string;
 }
 
 export type FmExportItem = FmOrderExportItemOption & { order_seq: FmOrder['order_seq'] };

--- a/libs/utils/.babelrc
+++ b/libs/utils/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/libs/utils/.eslintrc.json
+++ b/libs/utils/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/utils/README.md
+++ b/libs/utils/README.md
@@ -1,0 +1,7 @@
+# utils
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test utils` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/utils/jest.config.js
+++ b/libs/utils/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  displayName: 'utils',
+  preset: '../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/libs/utils',
+};

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/utils';

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -1,1 +1,1 @@
-export * from './lib/utils';
+export * from './lib/fmOrderMemoParser';

--- a/libs/utils/src/lib/fmOrderMemoParser.ts
+++ b/libs/utils/src/lib/fmOrderMemoParser.ts
@@ -84,42 +84,54 @@ export class FmOrderMemoParser {
 
   private parseMemo(s: string): FmOrderMemoItem['memo'] {
     if (!s) return null;
-    const [_, __, memo] = /(배송메모 : )(.*?)(,)/g.exec(s);
+    const processed = /(배송메모 : )(.*?)(,)/g.exec(s);
+    if (!processed) return null;
+    const [_, __, memo] = processed;
     if (!memo) return null;
     return memo;
   }
 
   private parseBroadcaster(s: string): string | null {
     if (!s) return null;
-    const [_, __, broadcaster] = /(크리에이터 채널명 : )(.*?)(,)/g.exec(s);
+    const processed = /(크리에이터 채널명 : )(.*?)(,)/g.exec(s);
+    if (!processed) return null;
+    const [_, __, broadcaster] = processed;
     if (!broadcaster) return null;
     return broadcaster;
   }
 
   private parseBuyer(s: string): FmOrderMemoItem['buyer'] {
     if (!s) return null;
-    const [_, __, buyer] = /(작성자 : )(.*?)(,)/g.exec(s);
+    const processed = /(작성자 : )(.*?)(,)/g.exec(s);
+    if (!processed) return null;
+    const [_, __, buyer] = processed;
     if (!buyer) return null;
     return buyer;
   }
 
   private parseDonationMessaage(s: string): FmOrderMemoItem['donationMessaage'] {
     if (!s) return null;
-    const [_, __, donationMessage] = /(응원내용 : )(.*?)(,)/g.exec(s);
+    const processed = /(응원내용 : )(.*?)(,)/g.exec(s);
+    if (!processed) return null;
+    const [_, __, donationMessage] = processed;
     if (!donationMessage) return null;
     return donationMessage;
   }
 
   private parsePhoneEventFlag(s: string): FmOrderMemoItem['phoneEventFlag'] {
     if (!s) return false;
-    const [_, __, phoneEventFlag] = /(통화 이벤트 : )(.*?)(,)/g.exec(s);
+    const processed = /(통화 이벤트 : )(.*?)(,)/g.exec(s);
+    if (!processed) return false;
+    const [_, __, phoneEventFlag] = processed;
     if (phoneEventFlag && phoneEventFlag === this.PHONE_EVENT_YES_TEXT) return true;
     return false;
   }
 
   private parseGiftFlag(s: string): FmOrderMemoItem['giftFlag'] {
     if (!s) return false;
-    const [_, __, giftFlag] = /(선물하기 여부 : )(.*)/g.exec(s);
+    const processed = /(선물하기 여부 : )(.*)/g.exec(s);
+    if (!processed) return false;
+    const [_, __, giftFlag] = processed;
     if (giftFlag && giftFlag === this.GIFT_YES_TEXT) return true;
     return false;
   }

--- a/libs/utils/src/lib/fmOrderMemoParser.ts
+++ b/libs/utils/src/lib/fmOrderMemoParser.ts
@@ -1,0 +1,126 @@
+// 1. 배송메모 : ,
+// 2. 크리에이터 채널명 : 크리에이터,
+// 3. 작성자 : 시청자,
+// 4. 응원내용 : 시청자의응원,
+// 5. 통화 이벤트 : 통화 이벤트 참여 하지 않습니다.,
+// 6. 선물하기 여부 : 이 상품을 크리에이터에게 선물하고 싶습니다.
+
+export interface FmOrderMemoItem {
+  memo: string | null;
+  broadcaster: string | null;
+  buyer: string | null;
+  donationMessaage: string | null;
+  phoneEventFlag: boolean;
+  giftFlag: boolean;
+}
+
+/** project-lc 주문의 수령자 배송메모 파서 */
+export class FmOrderMemoParser {
+  private readonly PHONE_EVENT_YES_TEXT = '통화 이벤트 참여 합니다.';
+  private readonly GIFT_YES_TEXT = '이 상품을 크리에이터에게 선물하고 싶습니다.';
+  private __parsed: FmOrderMemoItem;
+  private __memo: string;
+  private __broadcaster: string;
+  private __buyer: string;
+  private __donationMessaage: string;
+  private __phoneEventFlag: boolean;
+  private __giftFlag: boolean;
+
+  constructor(memoInput: string) {
+    const parsed = this.parse(memoInput);
+    this.__parsed = parsed;
+
+    this.__memo = parsed.memo;
+    this.__broadcaster = parsed.broadcaster;
+    this.__buyer = parsed.buyer;
+    this.__donationMessaage = parsed.donationMessaage;
+    this.__phoneEventFlag = parsed.phoneEventFlag;
+    this.__giftFlag = parsed.giftFlag;
+  }
+
+  get parsed(): FmOrderMemoItem {
+    return this.__parsed;
+  }
+
+  get memo(): string {
+    return this.__memo;
+  }
+
+  get broadcaster(): string {
+    return this.__broadcaster;
+  }
+
+  get buyer(): string {
+    return this.__buyer;
+  }
+
+  get donationMessaage(): string {
+    return this.__donationMessaage;
+  }
+
+  get phoneEventFlag(): boolean {
+    return this.__phoneEventFlag;
+  }
+
+  get giftFlag(): boolean {
+    return this.__giftFlag;
+  }
+
+  /**
+   * 배송메모 전문을 파싱하여 JS 객체의 형태로 반환합니다.
+   * @param s 배송메모 전문
+   * @returns {FmOrderMemoItem}
+   */
+  public parse(s: string): FmOrderMemoItem {
+    return {
+      memo: this.parseMemo(s),
+      broadcaster: this.parseBroadcaster(s),
+      buyer: this.parseBuyer(s),
+      donationMessaage: this.parseDonationMessaage(s),
+      phoneEventFlag: this.parsePhoneEventFlag(s),
+      giftFlag: this.parseGiftFlag(s),
+    };
+  }
+
+  private parseMemo(s: string): FmOrderMemoItem['memo'] {
+    if (!s) return null;
+    const [_, __, memo] = /(배송메모 : )(.*?)(,)/g.exec(s);
+    if (!memo) return null;
+    return memo;
+  }
+
+  private parseBroadcaster(s: string): string | null {
+    if (!s) return null;
+    const [_, __, broadcaster] = /(크리에이터 채널명 : )(.*?)(,)/g.exec(s);
+    if (!broadcaster) return null;
+    return broadcaster;
+  }
+
+  private parseBuyer(s: string): FmOrderMemoItem['buyer'] {
+    if (!s) return null;
+    const [_, __, buyer] = /(작성자 : )(.*?)(,)/g.exec(s);
+    if (!buyer) return null;
+    return buyer;
+  }
+
+  private parseDonationMessaage(s: string): FmOrderMemoItem['donationMessaage'] {
+    if (!s) return null;
+    const [_, __, donationMessage] = /(응원내용 : )(.*?)(,)/g.exec(s);
+    if (!donationMessage) return null;
+    return donationMessage;
+  }
+
+  private parsePhoneEventFlag(s: string): FmOrderMemoItem['phoneEventFlag'] {
+    if (!s) return false;
+    const [_, __, phoneEventFlag] = /(통화 이벤트 : )(.*?)(,)/g.exec(s);
+    if (phoneEventFlag && phoneEventFlag === this.PHONE_EVENT_YES_TEXT) return true;
+    return false;
+  }
+
+  private parseGiftFlag(s: string): FmOrderMemoItem['giftFlag'] {
+    if (!s) return false;
+    const [_, __, giftFlag] = /(선물하기 여부 : )(.*)/g.exec(s);
+    if (giftFlag && giftFlag === this.GIFT_YES_TEXT) return true;
+    return false;
+  }
+}

--- a/libs/utils/src/lib/fmOrderMemoParser.ts
+++ b/libs/utils/src/lib/fmOrderMemoParser.ts
@@ -83,56 +83,60 @@ export class FmOrderMemoParser {
   }
 
   private parseMemo(s: string): FmOrderMemoItem['memo'] {
-    if (!s) return null;
-    const processed = /(배송메모 : )(.*?)(,)/g.exec(s);
-    if (!processed) return null;
-    const [_, __, memo] = processed;
-    if (!memo) return null;
-    return memo;
+    return this.__parse({ s, regexp: /(배송메모 : )(.*?)(,)/g, targetGroupNum: 2 });
   }
 
   private parseBroadcaster(s: string): string | null {
-    if (!s) return null;
-    const processed = /(크리에이터 채널명 : )(.*?)(,)/g.exec(s);
-    if (!processed) return null;
-    const [_, __, broadcaster] = processed;
-    if (!broadcaster) return null;
-    return broadcaster;
+    return this.__parse({
+      s,
+      regexp: /(크리에이터 채널명 : )(.*?)(,)/g,
+      targetGroupNum: 2,
+    });
   }
 
   private parseBuyer(s: string): FmOrderMemoItem['buyer'] {
-    if (!s) return null;
-    const processed = /(작성자 : )(.*?)(,)/g.exec(s);
-    if (!processed) return null;
-    const [_, __, buyer] = processed;
-    if (!buyer) return null;
-    return buyer;
+    return this.__parse({ s, regexp: /(작성자 : )(.*?)(,)/g, targetGroupNum: 2 });
   }
 
   private parseDonationMessaage(s: string): FmOrderMemoItem['donationMessaage'] {
-    if (!s) return null;
-    const processed = /(응원내용 : )(.*?)(,)/g.exec(s);
-    if (!processed) return null;
-    const [_, __, donationMessage] = processed;
-    if (!donationMessage) return null;
-    return donationMessage;
+    return this.__parse({ s, regexp: /(응원내용 : )(.*?)(,)/g, targetGroupNum: 2 });
   }
 
   private parsePhoneEventFlag(s: string): FmOrderMemoItem['phoneEventFlag'] {
-    if (!s) return false;
-    const processed = /(통화 이벤트 : )(.*?)(,)/g.exec(s);
-    if (!processed) return false;
-    const [_, __, phoneEventFlag] = processed;
+    const phoneEventFlag = this.__parse({
+      s,
+      regexp: /(통화 이벤트 : )(.*?)(,)/g,
+      targetGroupNum: 2,
+    });
     if (phoneEventFlag && phoneEventFlag === this.PHONE_EVENT_YES_TEXT) return true;
     return false;
   }
 
   private parseGiftFlag(s: string): FmOrderMemoItem['giftFlag'] {
-    if (!s) return false;
-    const processed = /(선물하기 여부 : )(.*)/g.exec(s);
-    if (!processed) return false;
-    const [_, __, giftFlag] = processed;
+    const giftFlag = this.__parse({
+      s,
+      regexp: /(선물하기 여부 : )(.*)/g,
+      targetGroupNum: 2,
+    });
     if (giftFlag && giftFlag === this.GIFT_YES_TEXT) return true;
     return false;
   }
+
+  private __parse({ s, regexp, targetGroupNum }: FmOrderMemoParseOptions): string | null {
+    if (!s) return null;
+    const processed = regexp.exec(s);
+    if (!processed) return null;
+    const target = processed[targetGroupNum];
+    if (!target) return null;
+    return target;
+  }
+}
+
+interface FmOrderMemoParseOptions {
+  /** 파싱 대상 문자열 */
+  s: string;
+  /** 정규표현식 그룹을 필수적으로 포함하기를 권장 */
+  regexp: RegExp;
+  /** 정규표현식으로 그룹화된 배열 중 선택될 그룹인덱스 */
+  targetGroupNum: number;
 }

--- a/libs/utils/src/lib/parseFmOrderMemo.spec.ts
+++ b/libs/utils/src/lib/parseFmOrderMemo.spec.ts
@@ -1,0 +1,54 @@
+import { FmOrderMemoParser } from './fmOrderMemoParser';
+
+describe('FmOrderMemoParser', () => {
+  test('통화이벤트O, 선물O', () => {
+    const teststring = `1. 배송메모 : 집앞에 두세요.,
+2. 크리에이터 채널명 : 크리에이터이름,
+3. 작성자 : 시청자,
+4. 응원내용 : 응원메시지내용,
+5. 통화 이벤트 : 통화 이벤트 참여 합니다.,
+6. 선물하기 여부 : 이 상품을 크리에이터에게 선물하고 싶습니다.`;
+
+    const parser = new FmOrderMemoParser(teststring);
+    expect(parser.memo).toEqual('집앞에 두세요.');
+    expect(parser.broadcaster).toEqual('크리에이터이름');
+    expect(parser.buyer).toEqual('시청자');
+    expect(parser.donationMessaage).toEqual('응원메시지내용');
+    expect(parser.phoneEventFlag).toEqual(true);
+    expect(parser.giftFlag).toEqual(true);
+  });
+
+  test('통화이벤트X, 선물X', () => {
+    const teststring = `1. 배송메모 : 집앞에 두세요.,
+2. 크리에이터 채널명 : 크리에이터이름,
+3. 작성자 : 시청자,
+4. 응원내용 : 응원메시지내용,
+5. 통화 이벤트 : 통화 이벤트 참여 하지 않습니다.,
+6. 선물하기 여부 : 크리에이터에게 선물하지 않습니다.`;
+
+    const parser = new FmOrderMemoParser(teststring);
+    expect(parser.memo).toEqual('집앞에 두세요.');
+    expect(parser.broadcaster).toEqual('크리에이터이름');
+    expect(parser.buyer).toEqual('시청자');
+    expect(parser.donationMessaage).toEqual('응원메시지내용');
+    expect(parser.phoneEventFlag).toEqual(false);
+    expect(parser.giftFlag).toEqual(false);
+  });
+
+  test('통화이벤트X, 선물입력X', () => {
+    const teststring = `1. 배송메모 : 집앞에 두세요.,
+2. 크리에이터 채널명 : 크리에이터이름,
+3. 작성자 : 시청자,
+4. 응원내용 : 응원메시지내용,
+5. 통화 이벤트 : 통화 이벤트 참여 하지 않습니다.,
+6. 선물하기 여부 : `;
+
+    const parser = new FmOrderMemoParser(teststring);
+    expect(parser.memo).toEqual('집앞에 두세요.');
+    expect(parser.broadcaster).toEqual('크리에이터이름');
+    expect(parser.buyer).toEqual('시청자');
+    expect(parser.donationMessaage).toEqual('응원메시지내용');
+    expect(parser.phoneEventFlag).toEqual(false);
+    expect(parser.giftFlag).toEqual(false);
+  });
+});

--- a/libs/utils/src/lib/utils.spec.ts
+++ b/libs/utils/src/lib/utils.spec.ts
@@ -1,0 +1,7 @@
+import { utils } from './utils';
+
+describe('utils', () => {
+  it('should work', () => {
+    expect(utils()).toEqual('utils');
+  });
+});

--- a/libs/utils/src/lib/utils.spec.ts
+++ b/libs/utils/src/lib/utils.spec.ts
@@ -1,7 +1,0 @@
-import { utils } from './utils';
-
-describe('utils', () => {
-  it('should work', () => {
-    expect(utils()).toEqual('utils');
-  });
-});

--- a/libs/utils/src/lib/utils.ts
+++ b/libs/utils/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function utils(): string {
+  return 'utils';
+}

--- a/libs/utils/src/lib/utils.ts
+++ b/libs/utils/src/lib/utils.ts
@@ -1,3 +1,0 @@
-export function utils(): string {
-  return 'utils';
-}

--- a/libs/utils/tsconfig.json
+++ b/libs/utils/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/utils/tsconfig.lib.json
+++ b/libs/utils/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["**/*.spec.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/utils/tsconfig.spec.json
+++ b/libs/utils/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/nx.json
+++ b/nx.json
@@ -64,6 +64,9 @@
     "stores": {
       "tags": []
     },
+    "utils": {
+      "tags": []
+    },
     "web": {
       "tags": []
     },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,7 +21,8 @@
       "@project-lc/nest-modules": ["libs/nest-modules/src/index.ts"],
       "@project-lc/prisma-orm": ["libs/prisma-orm/src/index.ts"],
       "@project-lc/shared-types": ["libs/shared-types/src/index.ts"],
-      "@project-lc/stores": ["libs/stores/src/index.ts"]
+      "@project-lc/stores": ["libs/stores/src/index.ts"],
+      "@project-lc/utils": ["libs/utils/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]

--- a/workspace.json
+++ b/workspace.json
@@ -8,9 +8,7 @@
       "targets": {
         "build": {
           "executor": "@nrwl/next:build",
-          "outputs": [
-            "{options.outputPath}"
-          ],
+          "outputs": ["{options.outputPath}"],
           "options": {
             "root": "apps/admin",
             "outputPath": "dist/apps/admin"
@@ -40,9 +38,7 @@
         },
         "test": {
           "executor": "@nrwl/jest:jest",
-          "outputs": [
-            "coverage/apps/admin"
-          ],
+          "outputs": ["coverage/apps/admin"],
           "options": {
             "jestConfig": "apps/admin/jest.config.js",
             "passWithNoTests": true
@@ -51,9 +47,7 @@
         "lint": {
           "executor": "@nrwl/linter:eslint",
           "options": {
-            "lintFilePatterns": [
-              "apps/admin/**/*.{ts,tsx,js,jsx}"
-            ]
+            "lintFilePatterns": ["apps/admin/**/*.{ts,tsx,js,jsx}"]
           }
         }
       }
@@ -79,9 +73,7 @@
         "lint": {
           "executor": "@nrwl/linter:eslint",
           "options": {
-            "lintFilePatterns": [
-              "apps/admin-e2e/**/*.{js,ts}"
-            ]
+            "lintFilePatterns": ["apps/admin-e2e/**/*.{js,ts}"]
           }
         }
       }
@@ -125,16 +117,12 @@
         },
         "build": {
           "executor": "@nrwl/node:build",
-          "outputs": [
-            "{options.outputPath}"
-          ],
+          "outputs": ["{options.outputPath}"],
           "options": {
             "outputPath": "dist/apps/api",
             "main": "apps/api/src/main.ts",
             "tsConfig": "apps/api/tsconfig.app.json",
-            "assets": [
-              "apps/api/src/assets"
-            ],
+            "assets": ["apps/api/src/assets"],
             "generatePackageJson": true
           },
           "configurations": {
@@ -160,16 +148,12 @@
         "lint": {
           "executor": "@nrwl/linter:eslint",
           "options": {
-            "lintFilePatterns": [
-              "apps/api/**/*.ts"
-            ]
+            "lintFilePatterns": ["apps/api/**/*.ts"]
           }
         },
         "test": {
           "executor": "@nrwl/jest:jest",
-          "outputs": [
-            "coverage/apps/api"
-          ],
+          "outputs": ["coverage/apps/api"],
           "options": {
             "jestConfig": "apps/api/jest.config.js",
             "passWithNoTests": true
@@ -185,16 +169,12 @@
         "lint": {
           "executor": "@nrwl/linter:eslint",
           "options": {
-            "lintFilePatterns": [
-              "libs/components/**/*.{ts,tsx,js,jsx}"
-            ]
+            "lintFilePatterns": ["libs/components/**/*.{ts,tsx,js,jsx}"]
           }
         },
         "test": {
           "executor": "@nrwl/jest:jest",
-          "outputs": [
-            "coverage/libs/components"
-          ],
+          "outputs": ["coverage/libs/components"],
           "options": {
             "jestConfig": "libs/components/jest.config.js",
             "passWithNoTests": true
@@ -210,16 +190,12 @@
         "lint": {
           "executor": "@nrwl/linter:eslint",
           "options": {
-            "lintFilePatterns": [
-              "libs/firstmall-db/**/*.ts"
-            ]
+            "lintFilePatterns": ["libs/firstmall-db/**/*.ts"]
           }
         },
         "test": {
           "executor": "@nrwl/jest:jest",
-          "outputs": [
-            "coverage/libs/firstmall-db"
-          ],
+          "outputs": ["coverage/libs/firstmall-db"],
           "options": {
             "jestConfig": "libs/firstmall-db/jest.config.js",
             "passWithNoTests": true
@@ -235,16 +211,12 @@
         "lint": {
           "executor": "@nrwl/linter:eslint",
           "options": {
-            "lintFilePatterns": [
-              "libs/hooks/**/*.{ts,tsx,js,jsx}"
-            ]
+            "lintFilePatterns": ["libs/hooks/**/*.{ts,tsx,js,jsx}"]
           }
         },
         "test": {
           "executor": "@nrwl/jest:jest",
-          "outputs": [
-            "coverage/libs/hooks"
-          ],
+          "outputs": ["coverage/libs/hooks"],
           "options": {
             "jestConfig": "libs/hooks/jest.config.js",
             "passWithNoTests": true
@@ -260,16 +232,12 @@
         "lint": {
           "executor": "@nrwl/linter:eslint",
           "options": {
-            "lintFilePatterns": [
-              "libs/nest-modules/**/*.ts"
-            ]
+            "lintFilePatterns": ["libs/nest-modules/**/*.ts"]
           }
         },
         "test": {
           "executor": "@nrwl/jest:jest",
-          "outputs": [
-            "coverage/libs/nest-modules"
-          ],
+          "outputs": ["coverage/libs/nest-modules"],
           "options": {
             "jestConfig": "libs/nest-modules/jest.config.js",
             "passWithNoTests": true
@@ -316,9 +284,7 @@
         },
         "build": {
           "executor": "@nrwl/node:build",
-          "outputs": [
-            "{options.outputPath}"
-          ],
+          "outputs": ["{options.outputPath}"],
           "options": {
             "outputPath": "dist/apps/overlay",
             "main": "apps/overlay/src/main.ts",
@@ -353,16 +319,12 @@
         "lint": {
           "executor": "@nrwl/linter:eslint",
           "options": {
-            "lintFilePatterns": [
-              "apps/overlay/**/*.ts"
-            ]
+            "lintFilePatterns": ["apps/overlay/**/*.ts"]
           }
         },
         "test": {
           "executor": "@nrwl/jest:jest",
-          "outputs": [
-            "coverage/apps/overlay"
-          ],
+          "outputs": ["coverage/apps/overlay"],
           "options": {
             "jestConfig": "apps/overlay/jest.config.js",
             "passWithNoTests": true
@@ -377,9 +339,7 @@
       "targets": {
         "build": {
           "executor": "@nrwl/node:build",
-          "outputs": [
-            "{options.outputPath}"
-          ],
+          "outputs": ["{options.outputPath}"],
           "options": {
             "outputPath": "dist/apps/overlay-controller",
             "main": "apps/overlay-controller/src/main.ts",
@@ -413,16 +373,12 @@
         "lint": {
           "executor": "@nrwl/linter:eslint",
           "options": {
-            "lintFilePatterns": [
-              "apps/overlay-controller/**/*.ts"
-            ]
+            "lintFilePatterns": ["apps/overlay-controller/**/*.ts"]
           }
         },
         "test": {
           "executor": "@nrwl/jest:jest",
-          "outputs": [
-            "coverage/apps/overlay-controller"
-          ],
+          "outputs": ["coverage/apps/overlay-controller"],
           "options": {
             "jestConfig": "apps/overlay-controller/jest.config.js",
             "passWithNoTests": true
@@ -438,16 +394,12 @@
         "lint": {
           "executor": "@nrwl/linter:eslint",
           "options": {
-            "lintFilePatterns": [
-              "libs/prisma-orm/**/*.ts"
-            ]
+            "lintFilePatterns": ["libs/prisma-orm/**/*.ts"]
           }
         },
         "test": {
           "executor": "@nrwl/jest:jest",
-          "outputs": [
-            "coverage/libs/prisma-orm"
-          ],
+          "outputs": ["coverage/libs/prisma-orm"],
           "options": {
             "jestConfig": "libs/prisma-orm/jest.config.js",
             "passWithNoTests": true
@@ -580,16 +532,12 @@
         "lint": {
           "executor": "@nrwl/linter:eslint",
           "options": {
-            "lintFilePatterns": [
-              "libs/shared-types/**/*.ts"
-            ]
+            "lintFilePatterns": ["libs/shared-types/**/*.ts"]
           }
         },
         "test": {
           "executor": "@nrwl/jest:jest",
-          "outputs": [
-            "coverage/libs/shared-types"
-          ],
+          "outputs": ["coverage/libs/shared-types"],
           "options": {
             "jestConfig": "libs/shared-types/jest.config.js",
             "passWithNoTests": true
@@ -605,18 +553,35 @@
         "lint": {
           "executor": "@nrwl/linter:eslint",
           "options": {
-            "lintFilePatterns": [
-              "libs/stores/**/*.{ts,tsx,js,jsx}"
-            ]
+            "lintFilePatterns": ["libs/stores/**/*.{ts,tsx,js,jsx}"]
           }
         },
         "test": {
           "executor": "@nrwl/jest:jest",
-          "outputs": [
-            "coverage/libs/stores"
-          ],
+          "outputs": ["coverage/libs/stores"],
           "options": {
             "jestConfig": "libs/stores/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
+    "utils": {
+      "root": "libs/utils",
+      "sourceRoot": "libs/utils/src",
+      "projectType": "library",
+      "targets": {
+        "lint": {
+          "executor": "@nrwl/linter:eslint",
+          "options": {
+            "lintFilePatterns": ["libs/utils/**/*.ts"]
+          }
+        },
+        "test": {
+          "executor": "@nrwl/jest:jest",
+          "outputs": ["coverage/libs/utils"],
+          "options": {
+            "jestConfig": "libs/utils/jest.config.js",
             "passWithNoTests": true
           }
         }
@@ -629,9 +594,7 @@
       "targets": {
         "build": {
           "executor": "@nrwl/next:build",
-          "outputs": [
-            "{options.outputPath}"
-          ],
+          "outputs": ["{options.outputPath}"],
           "options": {
             "root": "apps/web",
             "outputPath": "dist/apps/web"
@@ -661,9 +624,7 @@
         },
         "test": {
           "executor": "@nrwl/jest:jest",
-          "outputs": [
-            "coverage/apps/web"
-          ],
+          "outputs": ["coverage/apps/web"],
           "options": {
             "jestConfig": "apps/web/jest.config.js",
             "passWithNoTests": true
@@ -672,9 +633,7 @@
         "lint": {
           "executor": "@nrwl/linter:eslint",
           "options": {
-            "lintFilePatterns": [
-              "apps/web/**/*.{ts,tsx,js,jsx}"
-            ]
+            "lintFilePatterns": ["apps/web/**/*.{ts,tsx,js,jsx}"]
           }
         }
       }
@@ -700,9 +659,7 @@
         "lint": {
           "executor": "@nrwl/linter:eslint",
           "options": {
-            "lintFilePatterns": [
-              "apps/web-e2e/**/*.{js,ts}"
-            ]
+            "lintFilePatterns": ["apps/web-e2e/**/*.{js,ts}"]
           }
         }
       }


### PR DESCRIPTION
1. nx 라이브러리 생성 = utils
    1. 목적: 유틸함수 모음 (이 일감에서는, 배송메모 파싱함수)
    - [x]  완료여부
2. 파싱 함수 작성
    - [x]  완료여부
3. API orders service 배송 메모 파서 적용
    - [x]  완료여부
4. Web 주문상세보기 배송메모 필드 추가
    - [x]  완료여부
5. [추가 진행 작업] 출고 주문정보 주문별 주문번호 링크 추가
    - [x]  완료여부