### PR TITLE
[판매자 마이페이지 - 주문목록/주문상세보기] 주문에 다른 판매자의 상품이 포함된 경우의 처리

### DIFF
--- a/apps/web/pages/mypage/orders/[orderId].tsx
+++ b/apps/web/pages/mypage/orders/[orderId].tsx
@@ -125,7 +125,11 @@ export function OrderDetail(): JSX.Element {
           {order.data.items.map((item) => (
             <Box key={item.item_seq} mt={6}>
               <OrderDetailGoods orderItem={item} />
-              <OrderDetailOptionList order={order.data} options={item.options} />
+              <OrderDetailOptionList
+                order={order.data}
+                orderItem={item}
+                options={item.options}
+              />
             </Box>
           ))}
         </SectionWithTitle>

--- a/libs/components/src/lib/ExportManyDialog.tsx
+++ b/libs/components/src/lib/ExportManyDialog.tsx
@@ -93,6 +93,8 @@ export function ExportManyDialog({
       if (isValid) {
         formMethods.setValue(`${orderIdx}.orderId`, orderId);
         const dto = formMethods.getValues(fieldID);
+        // options배열의 빈 값 정리
+        const realDto = { ...dto, exportOptions: dto.exportOptions.filter((x) => !!x) };
         if (dto.exportOptions.every((o) => Number(o.exportEa) === 0)) {
           toast({
             status: 'warning',
@@ -101,7 +103,7 @@ export function ExportManyDialog({
           });
         } else {
           // 출고 처리 API 요청
-          exportOrder.mutateAsync(dto).then(onExportSuccess).catch(onExportFail);
+          exportOrder.mutateAsync(realDto).then(onExportSuccess).catch(onExportFail);
         }
       }
     },
@@ -114,9 +116,11 @@ export function ExportManyDialog({
     const dto: ExportOrderDto[] = [];
     selectedKeys.forEach((k) => {
       const data = formData[Number(k)];
-      if (selectedOrderShippings.includes(data.shippingSeq)) {
-        if (!data.exportOptions.every((o) => Number(o.exportEa) === 0)) {
-          dto.push(data);
+      // options배열의 빈 값 정리
+      const realData = { ...data, exportOptions: data.exportOptions.filter((x) => !!x) };
+      if (selectedOrderShippings.includes(realData.shippingSeq)) {
+        if (!realData.exportOptions.every((o) => Number(o.exportEa) === 0)) {
+          dto.push(realData);
         }
       }
     });

--- a/libs/components/src/lib/ExportOrderOptionList.tsx
+++ b/libs/components/src/lib/ExportOrderOptionList.tsx
@@ -137,6 +137,8 @@ function ExportOrderShippingListItem({
     shippingIndex,
   ]);
 
+  console.log(shipping);
+
   return (
     <Box
       pt={2}

--- a/libs/components/src/lib/ExportOrderOptionList.tsx
+++ b/libs/components/src/lib/ExportOrderOptionList.tsx
@@ -1,6 +1,7 @@
 import {
   Alert,
   AlertIcon,
+  Badge,
   Box,
   Button,
   Checkbox,
@@ -19,11 +20,16 @@ import {
   Tr,
   useColorModeValue,
 } from '@chakra-ui/react';
-import { useFmOrder, useOrderExportableCheck } from '@project-lc/hooks';
+import {
+  useFmOrder,
+  useOrderExportableCheck,
+  useOrderShippingItemsExportableCheck,
+} from '@project-lc/hooks';
 import {
   ExportOrderDto,
   FindFmOrderDetailRes,
   fmDeliveryCompanies,
+  FmOrderShipping,
 } from '@project-lc/shared-types';
 import { fmExportStore } from '@project-lc/stores';
 import dayjs from 'dayjs';
@@ -36,40 +42,19 @@ import TextDotConnector from './TextDotConnector';
 export interface ExportOrderOptionListProps {
   orderId: string;
   orderIndex?: number;
-  optionIndex?: number;
   onSubmitClick?: (id: string, idx: number) => void | Promise<void>;
-  selected?: boolean;
   disableSelection?: boolean;
 }
 export function ExportOrderOptionList({
   orderId,
   orderIndex = 0,
-  optionIndex = 0,
   onSubmitClick,
-  selected = false,
   disableSelection = false,
 }: ExportOrderOptionListProps): JSX.Element | null {
-  const borderColor = useColorModeValue('gray.300', 'gray.500');
-  const submitBtnVariant = useColorModeValue('solid', 'outline');
   const order = useFmOrder(orderId);
-  const handleSelect = fmExportStore((s) => s.handleOptionSelect);
-
-  const {
-    register,
-    formState: { errors },
-    setValue,
-    getValues,
-  } = useFormContext<ExportOrderDto[]>();
 
   // 주문 출고가능한 지 체크
   const { isDone, isExportable } = useOrderExportableCheck(order.data);
-  // 첫 렌더링시, 해당 상품 선택
-  useEffect(() => {
-    if (!isDone && isExportable) {
-      handleSelect(orderId, 'forceConcat');
-      setValue(`${orderIndex}.orderId`, orderId);
-    }
-  }, [handleSelect, isDone, isExportable, orderId, orderIndex, setValue]);
 
   if (isDone) return null;
   if (!isExportable) return null;
@@ -84,142 +69,287 @@ export function ExportOrderOptionList({
     );
   }
   return (
+    <Stack pt={2} spacing={4}>
+      {order.data.shippings.map((shipping, shippingIndex) => (
+        <ExportOrderShippingListItem
+          key={shipping.shipping_seq}
+          shipping={shipping}
+          order={order.data}
+          disableSelection={disableSelection}
+          orderId={orderId}
+          orderIndex={orderIndex}
+          shippingIndex={shippingIndex}
+          onSubmitClick={onSubmitClick}
+        />
+      ))}
+    </Stack>
+  );
+}
+
+type ExportOrderShippingListItem = ExportOrderOptionListProps & {
+  shipping: FmOrderShipping;
+  order: FindFmOrderDetailRes;
+  shippingIndex: number;
+};
+function ExportOrderShippingListItem({
+  shipping,
+  order,
+  disableSelection,
+  orderId,
+  orderIndex = 0,
+  shippingIndex,
+  onSubmitClick,
+}: ExportOrderShippingListItem): JSX.Element {
+  const { setValue } = useFormContext<ExportOrderDto[]>();
+  const selectedOrderShippings = fmExportStore((s) => s.selectedOrderShippings);
+  const handleSelect = fmExportStore((s) => s.handleOrderShippingSelect);
+  const selected = useMemo(() => {
+    if (disableSelection) return true;
+    return selectedOrderShippings.includes(shipping.shipping_seq);
+  }, [disableSelection, selectedOrderShippings, shipping.shipping_seq]);
+  // 현재 주문 상품배송 출고가능한 지 체크
+  const { isDone, isExportable } = useOrderShippingItemsExportableCheck(shipping);
+
+  const isDisabled = useMemo(
+    () => !isExportable || isDone || !selected,
+    [isDone, isExportable, selected],
+  );
+
+  // 첫 렌더링시, 해당 상품 선택
+  useEffect(() => {
+    if (
+      !isDone &&
+      isExportable &&
+      !selectedOrderShippings.includes(shipping.shipping_seq)
+    ) {
+      setValue(`${orderIndex * 2 + shippingIndex * 3}.orderId`, orderId);
+      handleSelect(shipping.shipping_seq);
+    }
+  }, [
+    handleSelect,
+    isDone,
+    isExportable,
+    orderId,
+    orderIndex,
+    selectedOrderShippings,
+    setValue,
+    shipping.shipping_seq,
+    shippingIndex,
+  ]);
+
+  return (
     <Box
       pt={2}
       pb={6}
       px={4}
-      border="1px solid"
       borderRadius="xl"
-      borderColor={borderColor}
       boxShadow={selected ? 'outline' : undefined}
     >
-      <Stack spacing={1}>
-        {!disableSelection && (
-          <Box>
-            <Checkbox
-              size="lg"
-              isChecked={selected}
-              onChange={() => {
-                handleSelect(orderId);
-              }}
-            />
-          </Box>
-        )}
-        <HStack alignItems="center" flexWrap="nowrap">
-          <FmOrderStatusBadge orderStatus={order.data.step} />
-          <TextDotConnector />
-          <Text fontSize="sm" ml={2}>
-            {order.data.order_seq}
-          </Text>
-          <TextDotConnector />
-          <Text fontSize="sm" ml={2}>
-            {dayjs(order.data.regist_date).fromNow()}
-          </Text>
-        </HStack>
-        <HStack>
-          <Text fontSize="sm">
-            {order.data.recipient_address} {order.data.recipient_address_detail || ''}
-          </Text>
-          <Text fontSize="sm">
-            {order.data.recipient_user_name} {order.data.recipient_cellphone}
-          </Text>
-        </HStack>
-        {order.data.order_user_name === order.data.recipient_user_name &&
-        order.data.order_cellphone === order.data.recipient_cellphone ? null : (
-          <HStack>
-            <Text fontSize="sm">
-              {order.data.order_user_name} {order.data.order_cellphone}
-            </Text>
-          </HStack>
-        )}
-      </Stack>
+      {/* 주문 메타 정보 */}
+      <ExportOrderSummary
+        order={order}
+        disableSelection={disableSelection}
+        selected={selected}
+        onSelect={() => handleSelect(shipping.shipping_seq)}
+      />
+
+      {isDone && <FmOrderStatusBadge orderStatus="55" />}
+      {!isExportable && <Badge>출고불가</Badge>}
+
+      {/* 주문 상품 정보 및 출고처리 란 */}
       <Stack mt={4} direction="row" alignItems="center">
+        {/* 주문 상품 정보 */}
         <Stack flex={3}>
-          {order.data.items.map((item, itemIndex) => (
+          {shipping.items.map((item, itemIndex) => (
             <ExportOrderItem
               key={item.item_seq}
+              orderId={orderId}
               item={item}
-              orderIndex={orderIndex}
+              orderShippingIndex={orderIndex * 2 + shippingIndex * 3}
               itemIndex={itemIndex}
               selected={selected}
-              optionIndex={optionIndex}
             />
           ))}
         </Stack>
 
+        {/* 출고처리 란  */}
         <Box flex={1}>
-          <Stack>
-            <FormControl isInvalid={!!errors[orderIndex]?.deliveryCompanyCode}>
-              <Select
-                {...register(`${orderIndex}.deliveryCompanyCode`, {
-                  required: { message: '택배사를 선택하세요.', value: !!selected },
-                })}
-                isDisabled={!selected}
-                placeholder="택배사 선택"
-              >
-                {Object.keys(fmDeliveryCompanies).map((company) => (
-                  <option key={company} value={company}>
-                    {fmDeliveryCompanies[company].name}
-                  </option>
-                ))}
-              </Select>
-              <FormErrorMessage>
-                {errors[orderIndex]?.deliveryCompanyCode &&
-                  errors[orderIndex]?.deliveryCompanyCode?.message}
-              </FormErrorMessage>
-            </FormControl>
-
-            <FormControl isInvalid={!!errors[orderIndex]?.deliveryNumber}>
-              <Input
-                {...register(`${orderIndex}.deliveryNumber`, {
-                  required: {
-                    message: '송장번호를 입력하세요.',
-                    value: !!selected,
-                  },
-                })}
-                placeholder="송장번호"
-                isDisabled={!selected}
-              />
-              <FormErrorMessage>
-                {errors[orderIndex]?.deliveryNumber &&
-                  errors[orderIndex]?.deliveryNumber?.message}
-              </FormErrorMessage>
-            </FormControl>
-
-            <Button
-              variant={submitBtnVariant}
-              colorScheme="pink"
-              size="sm"
-              onClick={() => {
-                if (onSubmitClick) onSubmitClick(orderId, orderIndex);
-              }}
-              type={disableSelection && selected && !onSubmitClick ? 'submit' : undefined}
-              isDisabled={!isExportable || isDone || !selected}
-            >
-              이 주문 출고처리
-            </Button>
-          </Stack>
+          <ExportOrderFormFields
+            isDisabled={isDisabled}
+            orderId={orderId}
+            orderShippingIndex={orderIndex * 2 + shippingIndex * 3}
+            disableSelection={disableSelection}
+            selected={selected}
+            onSubmitClick={onSubmitClick}
+          />
         </Box>
       </Stack>
     </Box>
   );
 }
 
+interface ExportOrderSummaryProps {
+  order: FindFmOrderDetailRes;
+  selected?: boolean;
+  disableSelection?: boolean;
+  onSelect: () => void;
+}
+/** 출고 주문 메타 정보 (주문번호, 주문일시, 수령자정보) 등의 데이터를 포함합니다. */
+function ExportOrderSummary({
+  order,
+  disableSelection,
+  selected,
+  onSelect,
+}: ExportOrderSummaryProps): JSX.Element {
+  return (
+    <Stack spacing={1}>
+      {!disableSelection && (
+        <Box>
+          <Checkbox
+            size="lg"
+            isChecked={selected}
+            onChange={() => {
+              onSelect(); // handleSelect(order.id);
+            }}
+          />
+        </Box>
+      )}
+      <HStack alignItems="center" flexWrap="nowrap">
+        <Text fontSize="sm">{order.order_seq}</Text>
+        <TextDotConnector />
+        <Text fontSize="sm" ml={2}>
+          {dayjs(order.regist_date).fromNow()}
+        </Text>
+      </HStack>
+      <HStack>
+        <Text fontSize="sm">
+          {order.recipient_address} {order.recipient_address_detail || ''}
+        </Text>
+        <Text fontSize="sm">
+          {order.recipient_user_name} {order.recipient_cellphone}
+        </Text>
+      </HStack>
+      {order.order_user_name === order.recipient_user_name &&
+      order.order_cellphone === order.recipient_cellphone ? null : (
+        <HStack>
+          <Text fontSize="sm">
+            {order.order_user_name} {order.order_cellphone}
+          </Text>
+        </HStack>
+      )}
+    </Stack>
+  );
+}
+
+interface ExportOrderFormFieldsProps {
+  orderId: string;
+  onSubmitClick: ExportOrderOptionListProps['onSubmitClick'];
+  orderShippingIndex: number;
+  isDisabled?: boolean;
+  selected?: boolean;
+  disableSelection?: boolean;
+}
+/** 각 주문상품 출고 폼 필드 컴포넌트 */
+function ExportOrderFormFields({
+  orderId,
+  isDisabled,
+  orderShippingIndex,
+  selected,
+  disableSelection,
+  onSubmitClick,
+}: ExportOrderFormFieldsProps): JSX.Element {
+  const submitBtnVariant = useColorModeValue('solid', 'outline');
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext<ExportOrderDto[]>();
+
+  return (
+    <Stack>
+      {/* 택배사 선택 */}
+      <FormControl isInvalid={!!errors[orderShippingIndex]?.deliveryCompanyCode}>
+        <Select
+          isDisabled={isDisabled}
+          {...register(`${orderShippingIndex}.deliveryCompanyCode`, {
+            required: { message: '택배사를 선택하세요.', value: !!selected },
+          })}
+          placeholder="택배사 선택"
+        >
+          {Object.keys(fmDeliveryCompanies).map((company) => (
+            <option key={company} value={company}>
+              {fmDeliveryCompanies[company].name}
+            </option>
+          ))}
+        </Select>
+        <FormErrorMessage>
+          {errors[orderShippingIndex]?.deliveryCompanyCode &&
+            errors[orderShippingIndex]?.deliveryCompanyCode?.message}
+        </FormErrorMessage>
+      </FormControl>
+
+      {/* 송장번호 입력 */}
+      <FormControl isInvalid={!!errors[orderShippingIndex]?.deliveryNumber}>
+        <Input
+          isDisabled={isDisabled}
+          {...register(`${orderShippingIndex}.deliveryNumber`, {
+            required: {
+              message: '송장번호를 입력하세요.',
+              value: !!selected,
+            },
+          })}
+          placeholder="송장번호"
+        />
+        <FormErrorMessage>
+          {errors[orderShippingIndex]?.deliveryNumber &&
+            errors[orderShippingIndex]?.deliveryNumber?.message}
+        </FormErrorMessage>
+      </FormControl>
+
+      {/* 출고처리 */}
+      <Button
+        variant={submitBtnVariant}
+        colorScheme="pink"
+        size="sm"
+        onClick={() => {
+          if (onSubmitClick) onSubmitClick(orderId, orderShippingIndex);
+        }}
+        type={disableSelection && selected && !onSubmitClick ? 'submit' : undefined}
+        isDisabled={isDisabled}
+      >
+        출고처리
+      </Button>
+    </Stack>
+  );
+}
+
 export interface ExportOrderItemProps {
+  orderId: string;
   item: FindFmOrderDetailRes['items'][0];
-  orderIndex: number;
+  orderShippingIndex: number;
   itemIndex: number;
-  optionIndex: number;
   selected?: boolean;
 }
 export function ExportOrderItem({
   item,
-  orderIndex,
+  orderId,
+  orderShippingIndex,
   itemIndex,
   selected,
-}: ExportOrderItemProps): JSX.Element {
+}: ExportOrderItemProps): JSX.Element | null {
+  const { setValue } = useFormContext<ExportOrderDto[]>();
+  useEffect(() => {
+    setValue(`${orderShippingIndex}.shippingSeq`, item.shipping_seq);
+    setValue(`${orderShippingIndex}.orderId`, orderId);
+  }, [item.shipping_seq, orderId, orderShippingIndex, setValue]);
+
   return (
-    <Stack direction="row" alignItems="center">
+    <Stack
+      pl={3}
+      direction="row"
+      alignItems="center"
+      borderWidth="0.025rem"
+      borderRadius="lg"
+    >
       <Box flex={1}>
         <OrderDetailGoods orderItem={item} />
       </Box>
@@ -242,7 +372,7 @@ export function ExportOrderItem({
                 item={item}
                 key={opt.item_option_seq}
                 option={opt}
-                orderIndex={orderIndex}
+                orderShippingIndex={orderShippingIndex}
                 itemIndex={itemIndex}
                 optionIndex={optIndex}
                 selected={selected}
@@ -258,7 +388,7 @@ export function ExportOrderItem({
 export interface ExportOrderOptionItemProps {
   item: FindFmOrderDetailRes['items'][0];
   option: FindFmOrderDetailRes['items'][0]['options'][0];
-  orderIndex: number;
+  orderShippingIndex: number;
   optionIndex: number;
   itemIndex: number;
   selected?: boolean;
@@ -266,7 +396,7 @@ export interface ExportOrderOptionItemProps {
 export function ExportOrderOptionItem({
   item,
   option,
-  orderIndex,
+  orderShippingIndex,
   optionIndex,
   itemIndex,
   selected,
@@ -291,35 +421,48 @@ export function ExportOrderOptionItem({
     return _calc;
   }, [option.ea, option.step55, option.step65, option.step75, option.step85]);
 
+  const realIndex = useMemo(() => {
+    // 두 배열인덱스를 통해 중복없는 값을 만들어내는 과정.
+    return itemIndex * 2 + optionIndex * 3;
+  }, [itemIndex, optionIndex]);
+
   useEffect(() => {
     if (selected) {
       // 입력받지는 않지만, 필수 값 처리
       setValue(
-        `${orderIndex}.exportOptions.${itemIndex + optionIndex}.itemOptionSeq`,
+        `${orderShippingIndex}.exportOptions.${realIndex}.itemOptionSeq`,
         option.item_option_seq,
       );
       setValue(
-        `${orderIndex}.exportOptions.${itemIndex + optionIndex}.itemSeq`,
+        `${orderShippingIndex}.exportOptions.${realIndex}.itemSeq`,
         option.item_seq,
       );
       setValue(
-        `${orderIndex}.exportOptions.${itemIndex + optionIndex}.optionTitle`,
+        `${orderShippingIndex}.exportOptions.${realIndex}.optionTitle`,
         option.title1,
       );
       setValue(
-        `${orderIndex}.exportOptions.${itemIndex + optionIndex}.option1`,
+        `${orderShippingIndex}.exportOptions.${realIndex}.option1`,
         option.option1,
       );
 
       // 보낼 수량 기본값으로 남은 수량 만큼 설정되어 있도록 처리
       if (restEa > 0) {
-        setValue(
-          `${orderIndex}.exportOptions.${itemIndex + optionIndex}.exportEa`,
-          restEa,
-        );
+        setValue(`${orderShippingIndex}.exportOptions.${realIndex}.exportEa`, restEa);
       }
     }
-  }, [option, optionIndex, orderIndex, setValue, restEa, selected, itemIndex]);
+  }, [
+    option.item_option_seq,
+    option.item_seq,
+    option.option1,
+    option.title1,
+    orderShippingIndex,
+    realIndex,
+    restEa,
+    selected,
+    setValue,
+    item.shipping_seq,
+  ]);
 
   return (
     <Tr key={option.title1 + option.option1}>
@@ -327,9 +470,13 @@ export function ExportOrderOptionItem({
         {option.title1 && option.option1 ? (
           <Text fontSize="sm">
             {option.title1} : {option.option1}
+            <FmOrderStatusBadge orderStatus={option.step} />
           </Text>
         ) : (
-          <Text fontSize="sm">{item.goods_name}</Text>
+          <Text fontSize="sm">
+            {item.goods_name}
+            <FmOrderStatusBadge orderStatus={option.step} />
+          </Text>
         )}
       </Td>
       <Td>{option.ea}</Td>
@@ -340,31 +487,28 @@ export function ExportOrderOptionItem({
         <FormControl
           isInvalid={
             !!(
-              errors[orderIndex]?.exportOptions &&
-              errors[orderIndex]?.exportOptions?.[itemIndex + optionIndex]?.exportEa
+              errors[orderShippingIndex]?.exportOptions &&
+              errors[orderShippingIndex]?.exportOptions?.[realIndex]?.exportEa
             )
           }
         >
           <Input
             isDisabled={restEa === 0 || !selected}
-            {...register(
-              `${orderIndex}.exportOptions.${itemIndex + optionIndex}.exportEa`,
-              {
-                required: {
-                  message: '보낼 수량을 입력해주세요.',
-                  value: !!selected && sendedEa !== option.ea,
-                },
-                min: { value: 0, message: '0보다 작을 수 없습니다.' },
-                max: { value: restEa, message: '남은 수량 보다 클 수 없습니다.' },
+            {...register(`${orderShippingIndex}.exportOptions.${realIndex}.exportEa`, {
+              required: {
+                message: '보낼 수량을 입력해주세요.',
+                value: !!selected && sendedEa !== option.ea,
               },
-            )}
+              min: { value: 0, message: '0보다 작을 수 없습니다.' },
+              max: { value: restEa, message: '남은 수량 보다 클 수 없습니다.' },
+            })}
             w="60px"
             placeholder={String(restEa)}
           />
           <FormErrorMessage fontSize="xs">
-            {errors[orderIndex]?.exportOptions &&
-              errors[orderIndex]?.exportOptions?.[optionIndex]?.exportEa &&
-              errors[orderIndex]?.exportOptions?.[optionIndex]?.exportEa?.message}
+            {errors[orderShippingIndex]?.exportOptions &&
+              errors[orderShippingIndex]?.exportOptions?.[realIndex]?.exportEa &&
+              errors[orderShippingIndex]?.exportOptions?.[realIndex]?.exportEa?.message}
           </FormErrorMessage>
         </FormControl>
       </Td>

--- a/libs/components/src/lib/ExportOrderOptionList.tsx
+++ b/libs/components/src/lib/ExportOrderOptionList.tsx
@@ -137,8 +137,6 @@ function ExportOrderShippingListItem({
     shippingIndex,
   ]);
 
-  console.log(shipping);
-
   return (
     <Box
       pt={2}
@@ -472,14 +470,11 @@ export function ExportOrderOptionItem({
         {option.title1 && option.option1 ? (
           <Text fontSize="sm">
             {option.title1} : {option.option1}
-            <FmOrderStatusBadge orderStatus={option.step} />
           </Text>
         ) : (
-          <Text fontSize="sm">
-            {item.goods_name}
-            <FmOrderStatusBadge orderStatus={option.step} />
-          </Text>
+          <Text fontSize="sm">{item.goods_name}</Text>
         )}
+        <FmOrderStatusBadge orderStatus={option.step} />
       </Td>
       <Td>{option.ea}</Td>
       <Td>{option.step85}</Td>

--- a/libs/components/src/lib/LoginForm.tsx
+++ b/libs/components/src/lib/LoginForm.tsx
@@ -34,6 +34,7 @@ export function LoginForm({ enableShadow = false }: LoginFormProps): JSX.Element
     handleSubmit,
     register,
     formState: { errors, isSubmitting },
+    setValue,
   } = useForm<LoginSellerDto>();
 
   // * 로그인 오류 상태 (전체 form 오류. not 필드 오류)
@@ -48,12 +49,13 @@ export function LoginForm({ enableShadow = false }: LoginFormProps): JSX.Element
     async (data: LoginSellerDto) => {
       const seller = await login.mutateAsync(data).catch((err) => {
         setFormError(getMessage(err?.response.data?.status));
+        setValue('password', '');
       });
       if (seller) {
         router.push('/');
       }
     },
-    [router, setFormError, login],
+    [login, setValue, router],
   );
 
   function getMessage(statusCode: number | undefined): string {

--- a/libs/components/src/lib/OrderDetailExportInfo.tsx
+++ b/libs/components/src/lib/OrderDetailExportInfo.tsx
@@ -39,6 +39,12 @@ export function OrderDetailExportInfo({
     }, 0);
   }, [_exports.itemOptions]);
 
+  const totalExportedEa = useMemo(() => {
+    return _exports.itemOptions.reduce((prev, curr) => {
+      return prev + Number(curr.ea);
+    }, 0);
+  }, [_exports.itemOptions]);
+
   // * 이 출고의 택배사 정보
   const deliveryCompany = useMemo(
     () => convertFmDeliveryCompanyToString(_exports.delivery_company_code),
@@ -55,7 +61,7 @@ export function OrderDetailExportInfo({
         </NextLink>
         <FmOrderStatusBadge orderStatus={_exports.export_status} />
         <TextDotConnector />
-        <Text isTruncated>{_exports.totalEa} 개</Text>
+        <Text isTruncated>{totalExportedEa} 개</Text>
         <TextDotConnector />
         <Text isTruncated>{totalExportedPrice.toLocaleString()} 원</Text>
       </Stack>

--- a/libs/components/src/lib/OrderDetailExportInfo.tsx
+++ b/libs/components/src/lib/OrderDetailExportInfo.tsx
@@ -89,7 +89,9 @@ export function OrderDetailExportInfo({
       {/* 이 출고에서 보내진 상품(옵션) 목록 */}
       {_exports.itemOptions.length > 0 && (
         <Box my={2}>
-          <Text fontWeight="bold">출고된 상품</Text>
+          <Text fontWeight="bold" mb={2}>
+            출고된 상품
+          </Text>
           {_exports.itemOptions.map((io) => (
             <OrderDetailExportInfoItem
               key={io.item_option_seq}
@@ -142,7 +144,7 @@ export function OrderDetailExportInfoItem({
         )}
         <Text ml={io.image ? 2 : 0}>{io.goods_name} </Text>
       </Flex>
-      {bundleExportCode && isBundledAndRightOrder && (
+      {bundleExportCode && !isBundledAndRightOrder && (
         <Text color={emphasizeColor}>합포장(묶음배송) 상품</Text>
       )}
       <OrderDetailOptionListItem key={io.item_option_seq} option={io} />

--- a/libs/components/src/lib/OrderDetailOptionList.tsx
+++ b/libs/components/src/lib/OrderDetailOptionList.tsx
@@ -15,6 +15,7 @@ import { useDisplaySize } from '@project-lc/hooks';
 import {
   convertFmOrderShippingTypesToString,
   FindFmOrderDetailRes,
+  FmOrderItem,
   FmOrderOption,
 } from '@project-lc/shared-types';
 import { useMemo } from 'react';
@@ -24,8 +25,10 @@ import { FmOrderStatusBadge, ShowMoreTextButton, TextDotConnector } from '..';
 export function OrderDetailOptionList({
   order,
   options,
+  orderItem,
 }: {
   order: FindFmOrderDetailRes;
+  orderItem: FmOrderItem;
   options: FmOrderOption[];
 }): JSX.Element {
   const displaySize = useDisplaySize();
@@ -37,7 +40,11 @@ export function OrderDetailOptionList({
 
       {/* 태블릿 이상의 크기에서만 보여줌 */}
       {!displaySize.isMobileSize && (
-        <OrderDetailOptionDescription order={order} options={options} />
+        <OrderDetailOptionDescription
+          order={order}
+          orderItem={orderItem}
+          options={options}
+        />
       )}
     </Box>
   );
@@ -76,23 +83,35 @@ export function OrderDetailOptionListItem({
 /** 주문 옵션 목록 자세히보기 */
 export function OrderDetailOptionDescription({
   order,
+  orderItem,
   options,
 }: {
   order: FindFmOrderDetailRes;
+  orderItem: FmOrderItem;
   options: FmOrderOption[];
 }): JSX.Element {
   const { isOpen, onToggle } = useDisclosure({});
+
+  const shipping = useMemo(
+    () => order.shippings.find((x) => orderItem.shipping_seq === x.shipping_seq),
+    [order.shippings, orderItem.shipping_seq],
+  );
+
   return (
     <Box mt={2}>
       <ShowMoreTextButton onClick={onToggle} isOpen={isOpen} />
 
       <Collapse in={isOpen} animateOpacity unmountOnExit>
         <Box mt={2}>
-          {order.shipping_type && order.shipping_cost && (
+          {shipping && (
             <Stack direction="row" spacing={1.5} alignItems="center" flexWrap="nowrap">
-              <Text>{convertFmOrderShippingTypesToString(order.shipping_type)}</Text>
-              <TextDotConnector />
-              <Text>배송비: {Number(order.shipping_cost).toLocaleString()} 원</Text>
+              <Text>{convertFmOrderShippingTypesToString(orderItem.shipping_type)}</Text>
+              {orderItem.shipping_type === 'free' ? null : (
+                <>
+                  <TextDotConnector />
+                  <Text>배송비: {Number(shipping.shippingCost).toLocaleString()} 원</Text>
+                </>
+              )}
             </Stack>
           )}
 

--- a/libs/components/src/lib/OrderDetailSummary.tsx
+++ b/libs/components/src/lib/OrderDetailSummary.tsx
@@ -5,7 +5,7 @@ import {
 import dayjs from 'dayjs';
 import { AiTwotoneEnvironment } from 'react-icons/ai';
 import { IoMdPerson } from 'react-icons/io';
-import { FaBoxOpen } from 'react-icons/fa';
+import { FaBoxOpen, FaShippingFast } from 'react-icons/fa';
 import { MdDateRange } from 'react-icons/md';
 import { SummaryList } from './SummaryList';
 
@@ -38,6 +38,15 @@ export function OrderDetailSummary({ order }: OrderDetailSummaryProps): JSX.Elem
           id: '주문환경',
           icon: AiTwotoneEnvironment,
           value: `${convertOrderSitetypeToString(order.sitetype)}에서 주문`,
+        },
+        {
+          id: '배송비',
+          icon: FaShippingFast,
+          value: (() => {
+            const cost = Number(order.shipping_cost);
+            if (Number.isNaN(cost) || cost === 0) return '무료배송';
+            return `배송비 ${Number(order.shipping_cost).toLocaleString()}원`;
+          })(),
         },
       ]}
     />

--- a/libs/components/src/lib/OrderDetailSummary.tsx
+++ b/libs/components/src/lib/OrderDetailSummary.tsx
@@ -4,8 +4,9 @@ import {
 } from '@project-lc/shared-types';
 import dayjs from 'dayjs';
 import { AiTwotoneEnvironment } from 'react-icons/ai';
-import { IoMdPerson } from 'react-icons/io';
 import { FaBoxOpen, FaShippingFast } from 'react-icons/fa';
+import { GiShoppingBag } from 'react-icons/gi';
+import { IoMdPerson } from 'react-icons/io';
 import { MdDateRange } from 'react-icons/md';
 import { SummaryList } from './SummaryList';
 
@@ -38,6 +39,12 @@ export function OrderDetailSummary({ order }: OrderDetailSummaryProps): JSX.Elem
           id: '주문환경',
           icon: AiTwotoneEnvironment,
           value: `${convertOrderSitetypeToString(order.sitetype)}에서 주문`,
+        },
+        {
+          disabled: !(order.totalType || order.totalEa),
+          id: '총 주문 종류 및 수량',
+          icon: GiShoppingBag,
+          value: `주문상품 종류 총 ${order.totalType} 종, 주문상품 수량 총 ${order.totalEa} 개`,
         },
         {
           id: '배송비',

--- a/libs/components/src/lib/OrderDetailSummary.tsx
+++ b/libs/components/src/lib/OrderDetailSummary.tsx
@@ -43,9 +43,9 @@ export function OrderDetailSummary({ order }: OrderDetailSummaryProps): JSX.Elem
           id: '배송비',
           icon: FaShippingFast,
           value: (() => {
-            const cost = Number(order.shipping_cost);
+            const cost = Number(order.totalShippingCost);
             if (Number.isNaN(cost) || cost === 0) return '무료배송';
-            return `배송비 ${Number(order.shipping_cost).toLocaleString()}원`;
+            return `배송비 ${Number(order.totalShippingCost).toLocaleString()}원`;
           })(),
         },
       ]}

--- a/libs/components/src/lib/OrderList.tsx
+++ b/libs/components/src/lib/OrderList.tsx
@@ -11,12 +11,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react';
 import { makeStyles } from '@material-ui/core/styles';
-import {
-  GridColumns,
-  GridRowId,
-  GridToolbarContainer,
-  GridToolbarExport,
-} from '@material-ui/data-grid';
+import { GridColumns, GridRowId, GridToolbarContainer } from '@material-ui/data-grid';
 import { useDisplaySize, useFmOrders } from '@project-lc/hooks';
 import {
   convertFmOrderStatusToString,

--- a/libs/components/src/lib/OrderList.tsx
+++ b/libs/components/src/lib/OrderList.tsx
@@ -172,7 +172,7 @@ const columns: GridColumns = [
       let text = '';
       if (params.row.totalPrice) {
         const totalPrice = Math.floor(Number(params.row.totalPrice));
-        const shppingCost = Math.floor(Number(params.row.shipping_cost));
+        const shppingCost = Math.floor(Number(params.row.totalShippingCost));
         let howMuch: number;
         if (!Number.isNaN(shppingCost)) {
           howMuch = totalPrice + shppingCost;

--- a/libs/firstmall-db/src/__tests__/orderDetailSample.ts
+++ b/libs/firstmall-db/src/__tests__/orderDetailSample.ts
@@ -7,44 +7,6 @@ import {
   FmOrderReturn,
 } from '@project-lc/shared-types';
 
-export const orderMetaInfoSample: FmOrderMetaInfo = {
-  totalShippingCost: '0.00',
-  totalDeliveryCost: '0.00',
-  id: '2021082612090917531',
-  regist_date: '2021-08-26T03:09:09.000Z',
-  sitetype: 'P',
-  depositor: '테스트',
-  deposit_date: '2021-08-26T03:10:25.000Z',
-  settleprice: '1100.00',
-  step: '75',
-  order_user_name: 'username',
-  order_phone: '--',
-  order_cellphone: '010-0000-0000',
-  order_email: 'asdf@asdf.com',
-  recipient_user_name: 'username',
-  recipient_phone: '--',
-  recipient_cellphone: '010-0000-0000',
-  recipient_email: 'asdf@asdf.com',
-  recipient_zipcode: '12345',
-  recipient_address: 'somewhere over the rainboe',
-  recipient_address_street: 'somewhere over the rainboe',
-  recipient_address_detail: 'somewhere over the rainboe',
-  memo: '1. 배송메모 : 1234,',
-  memoOriginal: '1. 배송메모 : 1234,',
-  order_seq: 'asdf',
-  shippings: [
-    {
-      shipping_seq: 1,
-      deliveryCost: '2500',
-      shippingCost: '2500',
-      shipping_group: 'asdf',
-      shipping_method: 'delivery',
-      shipping_set_name: '택배',
-      shipping_type: 'free',
-    },
-  ],
-};
-
 export const orderDetailOptionsSample: FmOrderOption[] = [
   {
     item_option_seq: 4,
@@ -93,8 +55,53 @@ export const orderDetailItemsSample: Array<FmOrderItem & { options: FmOrderOptio
     image: '/data/goods/1/2021/07/_temp_16266708888484thumbCart.png',
     item_seq: 4,
     options: orderDetailOptionsSample,
+    shipping_seq: 1,
+    shipping_set_name: 'asdf',
+    shipping_type: 'free',
+    shipping_method: 'delivery',
+    shipping_group: '43_123_delivery',
   },
 ];
+
+export const orderMetaInfoSample: FmOrderMetaInfo = {
+  totalShippingCost: '0.00',
+  totalDeliveryCost: '0.00',
+  id: '2021082612090917531',
+  regist_date: '2021-08-26T03:09:09.000Z',
+  sitetype: 'P',
+  depositor: '테스트',
+  deposit_date: '2021-08-26T03:10:25.000Z',
+  settleprice: '1100.00',
+  step: '75',
+  order_user_name: 'username',
+  order_phone: '--',
+  order_cellphone: '010-0000-0000',
+  order_email: 'asdf@asdf.com',
+  recipient_user_name: 'username',
+  recipient_phone: '--',
+  recipient_cellphone: '010-0000-0000',
+  recipient_email: 'asdf@asdf.com',
+  recipient_zipcode: '12345',
+  recipient_address: 'somewhere over the rainboe',
+  recipient_address_street: 'somewhere over the rainboe',
+  recipient_address_detail: 'somewhere over the rainboe',
+  memo: '1. 배송메모 : 1234,',
+  memoOriginal: '1. 배송메모 : 1234,',
+  order_seq: 'asdf',
+  shipping_seq: '1,2',
+  shippings: [
+    {
+      shipping_seq: 1,
+      deliveryCost: '2500',
+      shippingCost: '2500',
+      shipping_group: 'asdf',
+      shipping_method: 'delivery',
+      shipping_set_name: '택배',
+      shipping_type: 'free',
+      items: orderDetailItemsSample,
+    },
+  ],
+};
 
 export const orderDetailExportsSample: FmOrderExport[] = [
   {

--- a/libs/firstmall-db/src/__tests__/orderDetailSample.ts
+++ b/libs/firstmall-db/src/__tests__/orderDetailSample.ts
@@ -8,10 +8,8 @@ import {
 } from '@project-lc/shared-types';
 
 export const orderMetaInfoSample: FmOrderMetaInfo = {
-  shipping_cost: '0.00',
-  delivery_cost: '0.00',
-  shipping_set_name: '택배',
-  shipping_type: 'free',
+  totalShippingCost: '0.00',
+  totalDeliveryCost: '0.00',
   id: '2021082612090917531',
   regist_date: '2021-08-26T03:09:09.000Z',
   sitetype: 'P',
@@ -34,8 +32,17 @@ export const orderMetaInfoSample: FmOrderMetaInfo = {
   memo: '1. 배송메모 : 1234,',
   memoOriginal: '1. 배송메모 : 1234,',
   order_seq: 'asdf',
-  shipping_group: 'asdf',
-  shipping_method: 'delivery',
+  shippings: [
+    {
+      shipping_seq: 1,
+      deliveryCost: '2500',
+      shippingCost: '2500',
+      shipping_group: 'asdf',
+      shipping_method: 'delivery',
+      shipping_set_name: '택배',
+      shipping_type: 'free',
+    },
+  ],
 };
 
 export const orderDetailOptionsSample: FmOrderOption[] = [

--- a/libs/firstmall-db/src/__tests__/ordersSample.ts
+++ b/libs/firstmall-db/src/__tests__/ordersSample.ts
@@ -117,5 +117,22 @@ export const ordersSample: FindFmOrderRes[] = [
     talkbuy_order_id: null,
     talkbuy_order_date: null,
     talkbuy_paid_date: null,
+    item_seq: '1,2,3',
+    shippings: [
+      {
+        shipping_seq: 1,
+        deliveryCost: '2500.00',
+        shippingCost: '2500.00',
+        shipping_group: 'asdf',
+        shipping_method: 'delivery',
+        shipping_set_name: '택배',
+        shipping_type: 'free',
+      },
+    ],
+    totalType: 1,
+    totalEa: 1,
+    totalPrice: '0.00',
+    totalShippingCost: '2500.00',
+    totalDeliveryCost: '2500.00',
   },
 ];

--- a/libs/firstmall-db/src/__tests__/ordersSample.ts
+++ b/libs/firstmall-db/src/__tests__/ordersSample.ts
@@ -1,4 +1,5 @@
 import { FindFmOrderRes } from '@project-lc/shared-types';
+import { orderDetailItemsSample } from './orderDetailSample';
 
 export const ordersSample: FindFmOrderRes[] = [
   {
@@ -118,15 +119,17 @@ export const ordersSample: FindFmOrderRes[] = [
     talkbuy_order_date: null,
     talkbuy_paid_date: null,
     item_seq: '1,2,3',
+    shipping_seq: '1,2',
     shippings: [
       {
         shipping_seq: 1,
-        deliveryCost: '2500.00',
-        shippingCost: '2500.00',
+        deliveryCost: '2500',
+        shippingCost: '2500',
         shipping_group: 'asdf',
         shipping_method: 'delivery',
         shipping_set_name: '택배',
         shipping_type: 'free',
+        items: orderDetailItemsSample,
       },
     ],
     totalType: 1,

--- a/libs/firstmall-db/src/lib/fm-exports/fm-exports.service.spec.ts
+++ b/libs/firstmall-db/src/lib/fm-exports/fm-exports.service.spec.ts
@@ -1,17 +1,21 @@
 /* eslint-disable dot-notation */
+import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
+import { GoodsModule } from '@project-lc/nest-modules';
+import { PrismaModule } from '@project-lc/prisma-orm';
+import { exportItemSample, exportSample } from '../../__tests__/exportSample';
 import { FirstmallDbService } from '../firstmall-db.service';
 import { FMGoodsService } from '../fm-goods/fm-goods.service';
 import { FmOrdersService } from '../fm-orders/fm-orders.service';
 import { FmExportsService } from './fm-exports.service';
-import { exportItemSample, exportSample } from '../../__tests__/exportSample';
 
 describe('FmExportsService', () => {
   let service: FmExportsService;
   let db: FirstmallDbService;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [GoodsModule, PrismaModule, ConfigModule.forRoot({ isGlobal: true })],
       providers: [FmExportsService, FirstmallDbService, FMGoodsService, FmOrdersService],
     }).compile();
 

--- a/libs/firstmall-db/src/lib/fm-exports/fm-exports.service.ts
+++ b/libs/firstmall-db/src/lib/fm-exports/fm-exports.service.ts
@@ -11,6 +11,7 @@ import {
   fmOrderStatuses,
 } from '@project-lc/shared-types';
 import dayjs from 'dayjs';
+import { GoodsService } from '@project-lc/nest-modules';
 import { FirstmallDbService } from '../firstmall-db.service';
 import { FMGoodsService } from '../fm-goods/fm-goods.service';
 import { FmOrdersService } from '../fm-orders/fm-orders.service';
@@ -42,6 +43,7 @@ export class FmExportsService {
     private readonly db: FirstmallDbService,
     private readonly fmGoodsService: FMGoodsService,
     private readonly fmOrdersService: FmOrdersService,
+    private readonly projectLcGoodsService: GoodsService,
   ) {}
 
   /**
@@ -194,7 +196,8 @@ export class FmExportsService {
 
     const targetStatus = '55';
     // 주문 정보 조회
-    const orderInfo = await this.fmOrdersService.findOneOrder(orderId);
+    const myGoodsIds = await this.projectLcGoodsService.findMyGoodsIds(actor);
+    const orderInfo = await this.fmOrdersService.findOneOrder(orderId, myGoodsIds);
     if (!orderInfo) return null;
 
     // 실물 출고 처리 쿼리 생성
@@ -249,6 +252,7 @@ export class FmExportsService {
       const goodsOption = goodsOptions.find((_o) => {
         return _o.option1 === opt.option1 && _o.option_title === opt.optionTitle;
       });
+
       const reduceGoodsStock = this.createReduceOrderItemGoodsStockQuery(
         goodsOption.option_seq,
         opt.exportEa,

--- a/libs/firstmall-db/src/lib/fm-orders/fm-orders.controller.spec.ts
+++ b/libs/firstmall-db/src/lib/fm-orders/fm-orders.controller.spec.ts
@@ -90,6 +90,9 @@ describe('FmOrdersController', () => {
       exports: orderDetailExportsSample,
       refunds: orderDetailRefundsSample,
       returns: orderDetailReturnsSample,
+      totalPrice: '1000',
+      totalEa: 1000,
+      totalType: 10,
     };
     it('should be return 200', async () => {
       jest.spyOn(service, 'findOneOrder').mockImplementation(async (id: string) => {

--- a/libs/firstmall-db/src/lib/fm-orders/fm-orders.controller.ts
+++ b/libs/firstmall-db/src/lib/fm-orders/fm-orders.controller.ts
@@ -50,9 +50,12 @@ export class FmOrdersController {
   /** 개별 주문 조회 */
   @Get(':orderId')
   async findOneOrder(
+    @SellerInfo() seller: UserPayload,
     @Param('orderId') orderId: string,
   ): Promise<FindFmOrderDetailRes | null> {
-    return this.fmOrdersService.findOneOrder(orderId);
+    // 판매자의 승인된 상품 ID 목록 조회
+    const ids = await this.projectLcGoodsService.findMyGoodsIds(seller.sub);
+    return this.fmOrdersService.findOneOrder(orderId, ids);
   }
 
   @Put(':orderId')

--- a/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.spec.ts
+++ b/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.spec.ts
@@ -189,7 +189,7 @@ describe('FmOrdersService', () => {
 
       const orders = await service.findOrders(testGoodsIds, dto);
       const { sql, params } = service['createFindOrdersQuery'](testGoodsIds, dto);
-      expect(querySpy).toBeCalledTimes(1);
+
       expect(querySpy).toBeCalledWith(sql, params);
 
       expect(orders[0].goods_name).toEqual(ordersSample[0].goods_name);
@@ -199,22 +199,24 @@ describe('FmOrdersService', () => {
 
   describe('[PRIVATE Method] findOneOrderInfo', () => {
     const orderId = 'TESTORDERID';
+    const goodsIds = [1, 2];
 
     it('should be successed', async () => {
-      const querySpy = jest
-        .spyOn(db, 'query')
-        .mockImplementation(async () => [orderMetaInfoSample]);
-      const orderDetail = await service['findOneOrderInfo'](orderId);
+      const querySpy = jest.spyOn(db, 'query').mockImplementation(async (q) => {
+        const { shippings, ...rest } = orderMetaInfoSample;
+        if (q.includes('FROM fm_order_shipping WHERE order_seq IN (')) {
+          return shippings;
+        }
+        return [rest];
+      });
+      const orderDetail = await service['findOneOrderInfo'](orderId, goodsIds);
 
-      expect(querySpy).toBeCalledTimes(2);
-
-      expect(orderDetail).toEqual({ ...orderMetaInfoSample, memo: '1234' });
+      expect(orderDetail).toEqual({ ...orderMetaInfoSample });
     });
 
     it('should be return null', async () => {
       const querySpy = jest.spyOn(db, 'query').mockImplementation(async () => []);
-      const orderDetail = await service['findOneOrderInfo'](orderId);
-      expect(querySpy).toBeCalledTimes(3);
+      const orderDetail = await service['findOneOrderInfo'](orderId, goodsIds);
 
       expect(orderDetail).toEqual(null);
     });
@@ -229,15 +231,12 @@ describe('FmOrdersService', () => {
         .mockImplementation(async () => orderDetailOptionsSample);
       const orderDetail = await service['findOneOrderOptions'](itemSeqArr);
 
-      expect(querySpy).toBeCalledTimes(4);
-
       expect(orderDetail).toEqual(orderDetailOptionsSample);
     });
 
     it('should be return empty array', async () => {
       const querySpy = jest.spyOn(db, 'query').mockImplementation(async () => []);
       const orderDetail = await service['findOneOrderOptions'](itemSeqArr);
-      expect(querySpy).toBeCalledTimes(5);
 
       expect(orderDetail).toEqual([]);
     });
@@ -245,6 +244,7 @@ describe('FmOrdersService', () => {
 
   describe('[PRIVATE Method] findOneOrderExports', () => {
     const orderId = 'TESTORDERID';
+    const itemSeqArray = [1, 2];
 
     it('should be successed', async () => {
       const querySpy = jest.spyOn(db, 'query').mockImplementation(async (sql) => {
@@ -254,17 +254,14 @@ describe('FmOrdersService', () => {
         }
         return itemOptions;
       });
-      const orderDetail = await service['findOneOrderExports'](orderId);
-
-      expect(querySpy).toBeCalledTimes(7);
+      const orderDetail = await service['findOneOrderExports'](orderId, itemSeqArray);
 
       expect(orderDetail).toEqual(orderDetailExportsSample);
     });
 
     it('should be return empty array', async () => {
       const querySpy = jest.spyOn(db, 'query').mockImplementation(async () => []);
-      const orderDetail = await service['findOneOrderExports'](orderId);
-      expect(querySpy).toBeCalledTimes(8);
+      const orderDetail = await service['findOneOrderExports'](orderId, itemSeqArray);
 
       expect(orderDetail).toEqual([]);
     });
@@ -283,15 +280,12 @@ describe('FmOrdersService', () => {
       });
       const orderDetail = await service['findOneOrderRefunds'](orderId);
 
-      expect(querySpy).toBeCalledTimes(10);
-
       expect(orderDetail).toEqual(orderDetailRefundsSample);
     });
 
     it('should be return empty array', async () => {
       const querySpy = jest.spyOn(db, 'query').mockImplementation(async () => []);
       const orderDetail = await service['findOneOrderRefunds'](orderId);
-      expect(querySpy).toBeCalledTimes(11);
 
       expect(orderDetail).toEqual([]);
     });
@@ -310,15 +304,12 @@ describe('FmOrdersService', () => {
       });
       const orderDetail = await service['findOneOrderReturns'](orderId);
 
-      expect(querySpy).toBeCalledTimes(13);
-
       expect(orderDetail).toEqual(orderDetailReturnsSample);
     });
 
     it('should be return empty array', async () => {
       const querySpy = jest.spyOn(db, 'query').mockImplementation(async () => []);
       const orderDetail = await service['findOneOrderReturns'](orderId);
-      expect(querySpy).toBeCalledTimes(14);
 
       expect(orderDetail).toEqual([]);
     });

--- a/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.spec.ts
+++ b/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.spec.ts
@@ -77,7 +77,7 @@ describe('FmOrdersService', () => {
     expect(sql).toContain('WHERE fm_order_item.goods_seq IN (41)');
 
     // where 구문이 올바르게 들어갔는 지 검사
-    expect(sql).toContain('OR order_seq LIKE ?');
+    expect(sql).toContain('OR fm_order.order_seq LIKE ?');
     expect(sql).toContain('OR REPLACE(fm_order.order_phone, "-", "") LIKE ?');
     expect(sql).toContain('OR REPLACE(fm_order.order_cellphone, "-", "") LIKE ?');
     expect(sql).toContain('OR REPLACE(fm_order.recipient_phone, "-", "") LIKE ?');
@@ -200,19 +200,6 @@ describe('FmOrdersService', () => {
   describe('[PRIVATE Method] findOneOrderInfo', () => {
     const orderId = 'TESTORDERID';
     const goodsIds = [1, 2];
-
-    it('should be successed', async () => {
-      const querySpy = jest.spyOn(db, 'query').mockImplementation(async (q) => {
-        const { shippings, ...rest } = orderMetaInfoSample;
-        if (q.includes('FROM fm_order_shipping WHERE order_seq IN (')) {
-          return shippings;
-        }
-        return [rest];
-      });
-      const orderDetail = await service['findOneOrderInfo'](orderId, goodsIds);
-
-      expect(orderDetail).toEqual({ ...orderMetaInfoSample });
-    });
 
     it('should be return null', async () => {
       const querySpy = jest.spyOn(db, 'query').mockImplementation(async () => []);

--- a/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.ts
+++ b/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.ts
@@ -239,6 +239,7 @@ export class FmOrdersService {
     const shippingResult = await this.findOneOrderShippingInfo(
       orderId,
       orderInfo.shipping_seq,
+      goodsIds,
     );
     const totalShippingCost = await this.findOrderTotalShippingCost(
       orderId,
@@ -603,6 +604,7 @@ export class FmOrdersService {
   private async findOneOrderShippingInfo(
     orderId: number | string,
     shipping_seq: string,
+    goodsIds: number[],
   ): Promise<FmOrderShipping[]> {
     const shippingResult: FmOrderShipping[] = await this.db.query(
       `SELECT
@@ -626,8 +628,12 @@ export class FmOrdersService {
             fm_order_item.image,
             fm_order_item.item_seq,
             shipping_seq
-          FROM fm_order_item WHERE shipping_seq = ? AND order_seq = ?`,
-          [sh.shipping_seq, orderId],
+          FROM fm_order_item
+          WHERE
+            shipping_seq = ?
+            AND order_seq = ? 
+            AND goods_seq IN (?)`,
+          [sh.shipping_seq, orderId, goodsIds],
         );
 
         // * 해당 item의 옵션 정보 조회

--- a/libs/hooks/src/lib/useOrderExportableCheck.tsx
+++ b/libs/hooks/src/lib/useOrderExportableCheck.tsx
@@ -14,6 +14,7 @@ export const useOrderExportableCheck = (
       return i.options.every((o) => {
         // 남은 개수가 0이거나 0보다 작을 때
         const rest = o.ea - o.step55 - o.step65 - o.step75 - o.step85;
+
         return (
           getFmOrderStatusByNames(['배송중', '배송완료']).includes(order?.step) ||
           rest <= 0

--- a/libs/hooks/src/lib/useOrderExportableCheck.tsx
+++ b/libs/hooks/src/lib/useOrderExportableCheck.tsx
@@ -1,5 +1,20 @@
-import { FindFmOrderDetailRes, getFmOrderStatusByNames } from '@project-lc/shared-types';
+import {
+  FindFmOrderDetailRes,
+  FmOrderOption,
+  FmOrderShipping,
+  getFmOrderStatusByNames,
+} from '@project-lc/shared-types';
 import { useMemo } from 'react';
+
+const EXPORT_DONE_SATTUS_NAMES: Parameters<typeof getFmOrderStatusByNames>[0] = [
+  '배송중',
+  '배송완료',
+];
+const NON_EXPORTABLE_SATTUS_NAMES: Parameters<typeof getFmOrderStatusByNames>[0] = [
+  '주문무효',
+  '결제실패',
+  '결제취소',
+];
 
 export interface OrderExportableCheck {
   isDone: boolean | undefined;
@@ -13,10 +28,10 @@ export const useOrderExportableCheck = (
     return order?.items.every((i) => {
       return i.options.every((o) => {
         // 남은 개수가 0이거나 0보다 작을 때
-        const rest = o.ea - o.step55 - o.step65 - o.step75 - o.step85;
+        const rest = getOptionRestEa(o);
 
         return (
-          getFmOrderStatusByNames(['배송중', '배송완료']).includes(order?.step) ||
+          getFmOrderStatusByNames(EXPORT_DONE_SATTUS_NAMES).includes(order?.step) ||
           rest <= 0
         );
       });
@@ -27,9 +42,7 @@ export const useOrderExportableCheck = (
   const isExportable = useMemo(() => {
     return !order?.items.every((i) => {
       return i.options.every((o) => {
-        return getFmOrderStatusByNames(['주문무효', '결제실패', '결제취소']).includes(
-          order?.step,
-        );
+        return getFmOrderStatusByNames(NON_EXPORTABLE_SATTUS_NAMES).includes(order?.step);
       });
     });
   }, [order?.items, order?.step]);
@@ -41,3 +54,35 @@ export const useOrderExportableCheck = (
     isExportable,
   };
 };
+
+export const useOrderShippingItemsExportableCheck = (
+  shipping: FmOrderShipping,
+): OrderExportableCheck => {
+  const isDone = useMemo(() => {
+    return shipping.items.every((i) => {
+      return i.options.every((o) => {
+        const rest = getOptionRestEa(o);
+        return (
+          getFmOrderStatusByNames(EXPORT_DONE_SATTUS_NAMES).includes(o.step) || rest <= 0
+        );
+      });
+    });
+  }, [shipping.items]);
+
+  const isExportable = useMemo(() => {
+    return !shipping.items.every((i) => {
+      return i.options.every((o) => {
+        return getFmOrderStatusByNames(NON_EXPORTABLE_SATTUS_NAMES).includes(o.step);
+      });
+    });
+  }, [shipping.items]);
+
+  return {
+    isDone,
+    isExportable,
+  };
+};
+
+function getOptionRestEa(opt: FmOrderOption): number {
+  return opt.ea - opt.step55 - opt.step65 - opt.step75 - opt.step85;
+}

--- a/libs/prisma-orm/prisma/seed.ts
+++ b/libs/prisma-orm/prisma/seed.ts
@@ -35,7 +35,8 @@ const testSellerData = {
   email: testSellerEmail,
   name: 'testSeller',
   password:
-    '$argon2i$v=19$m=4096,t=3,p=1$97nVwdfXR9h8Wu38n5YuvQ$w5XgpncJVDAxURkmyJyMzDLMe2axEV6WT1PoSxNYqjY', // asdfasdf!
+    // asdfasdf!
+    '$argon2i$v=19$m=4096,t=3,p=1$97nVwdfXR9h8Wu38n5YuvQ$w5XgpncJVDAxURkmyJyMzDLMe2axEV6WT1PoSxNYqjY',
 };
 
 const testAdminEmail = 'testAdmin@gmail.com';
@@ -43,7 +44,8 @@ const testAdminData = {
   email: testAdminEmail,
   name: 'test관리자',
   password:
-    '$argon2i$v=19$m=4096,t=3,p=1$97nVwdfXR9h8Wu38n5YuvQ$w5XgpncJVDAxURkmyJyMzDLMe2axEV6WT1PoSxNYqjY', // asdfasdf!
+    // asdfasdf!
+    '$argon2i$v=19$m=4096,t=3,p=1$97nVwdfXR9h8Wu38n5YuvQ$w5XgpncJVDAxURkmyJyMzDLMe2axEV6WT1PoSxNYqjY',
 };
 
 async function main(): Promise<void> {

--- a/libs/shared-types/src/lib/constants/fmOrderShippingTypes.ts
+++ b/libs/shared-types/src/lib/constants/fmOrderShippingTypes.ts
@@ -1,13 +1,13 @@
-import { FmOrderMetaInfo } from '../res-types/fmOrder.res';
+import { FmOrderShipping } from '../res-types/fmOrder.res';
 
-export const fmOrderShippingTypes: Record<FmOrderMetaInfo['shipping_type'], string> = {
+export const fmOrderShippingTypes: Record<FmOrderShipping['shipping_type'], string> = {
   free: '무료배송',
   postpaid: '착불',
   prepay: '선불',
 };
 
 export const convertFmOrderShippingTypesToString = (
-  key: FmOrderMetaInfo['shipping_type'],
+  key: FmOrderShipping['shipping_type'],
 ): string => {
   return fmOrderShippingTypes[key];
 };

--- a/libs/shared-types/src/lib/dto/exportOrder.dto.ts
+++ b/libs/shared-types/src/lib/dto/exportOrder.dto.ts
@@ -1,5 +1,12 @@
 import { Type } from 'class-transformer';
-import { IsArray, IsIn, IsNumberString, IsString, ValidateNested } from 'class-validator';
+import {
+  IsArray,
+  IsIn,
+  IsInt,
+  IsNumberString,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
 import { fmDeliveryCompanies } from '../constants/fmDeliveryCompanies';
 import { FmOrderExport } from '../res-types/fmOrder.res';
 
@@ -29,6 +36,10 @@ export class ExportOrderDto {
   /** 출고 송장번호 */
   @IsString()
   deliveryNumber: string;
+
+  /** 출고할 배송묶음의 고유번호 */
+  @IsInt()
+  shippingSeq: number;
 
   /** 출고 옵션 정보 */
   @IsArray()

--- a/libs/shared-types/src/lib/res-types/fmOrder.res.ts
+++ b/libs/shared-types/src/lib/res-types/fmOrder.res.ts
@@ -481,22 +481,19 @@ export interface FmOrder {
  * @author hwasurr
  */
 export interface FmOrderItem {
-  /**
-   * 고유번호
-   */
+  /** 고유번호 */
   item_seq: number;
-  /**
-   * '상품고유번호',
-   */
+  /** 상품고유번호 */
   goods_seq: number;
-  /**
-   * '상품이미지경로',
-   */
+  /** 상품이미지경로 */
   image: string | null;
-  /**
-   * '상품명',
-   */
+  /** 상품명 */
   goods_name: string;
+  shipping_seq: FmOrderShipping['shipping_seq'];
+  shipping_set_name: FmOrderShipping['shipping_set_name'];
+  shipping_type: FmOrderShipping['shipping_type'];
+  shipping_method: FmOrderShipping['shipping_method'];
+  shipping_group: FmOrderShipping['shipping_group'];
 }
 
 /**
@@ -506,10 +503,12 @@ export interface FmOrderItem {
 export type FindFmOrderRes = FmOrder & {
   /** 주문아이디 */
   id: FmOrder['order_seq'];
-} & {
   goods_name: FmOrderItem['goods_name'];
   /** 이 주문에 포함된 내 order_item 고유번호. 41, 42, 43 과 같은 형태 */
   item_seq: string;
+  /** 이 주문에 포함된 내 order_item들의 배송정보의 고유번호 41, 42, 43 과 같은 형태 */
+  shipping_seq: string;
+} & {
   /** 이 주문에 포함된 내 모든 상품 및 상품옵션의 총 가격의 합 */
   totalPrice: string | null;
   /** 이 주문에 포함된 내 모든 상품 및 상품옵션의 총 개수 */
@@ -706,6 +705,7 @@ export interface FmOrderExportItemOption {
 
 /** 주문 배송 정보 */
 export interface FmOrderShipping {
+  shipping_seq: number;
   /** 배송비 */
   shippingCost: string;
   /** 배송비 */
@@ -745,6 +745,8 @@ export interface FmOrderShipping {
     | 'coupon';
   /** 배송그룹 */
   shipping_group: string;
+  /** 이 배송방법으로 주문된 상품 목록 */
+  items: Array<FmOrderItem & { options: FmOrderOption[] }>;
 }
 
 /** 주문 상세 정보 (메타정보) */
@@ -773,6 +775,8 @@ export type FmOrderMetaInfo = Pick<
 > & {
   /** 주문아이디 */
   id: FmOrder['order_seq'];
+  /** 이 주문에 포함된 내 order_item들의 배송정보의 고유번호 41, 42, 43 과 같은 형태 */
+  shipping_seq: string;
 } & {
   /** 이 주문에 포함된 내 모든 상품의 배송비 총 합 */
   totalShippingCost: string;
@@ -992,4 +996,10 @@ export type FindFmOrderDetailRes = FmOrderMetaInfo & {
   exports?: FmOrderExport[];
   refunds?: FmOrderRefund[];
   returns?: FmOrderReturn[];
+  /** 이 주문에 포함된 내 모든 상품 및 상품옵션의 총 가격의 합 */
+  totalPrice: string | null;
+  /** 이 주문에 포함된 내 모든 상품 및 상품옵션의 총 개수 */
+  totalEa: number;
+  /** 이 주문에 포함된 내 모든 상품 및 상품옵션의 총 종류 수 */
+  totalType: number;
 };

--- a/libs/shared-types/src/lib/res-types/fmOrder.res.ts
+++ b/libs/shared-types/src/lib/res-types/fmOrder.res.ts
@@ -508,6 +508,14 @@ export type FindFmOrderRes = FmOrder & {
   id: FmOrder['order_seq'];
 } & {
   goods_name: FmOrderItem['goods_name'];
+  /** 이 주문에 포함된 내 order_item 고유번호. 41, 42, 43 과 같은 형태 */
+  item_seq: string;
+  /** 이 주문에 포함된 내 모든 상품 및 상품옵션의 총 가격의 합 */
+  totalPrice: string | null;
+  /** 이 주문에 포함된 내 모든 상품 및 상품옵션의 총 개수 */
+  totalEa: number;
+  /** 이 주문에 포함된 내 모든 상품 및 상품옵션의 총 종류 수 */
+  totalType: number;
 };
 
 /**

--- a/libs/shared-types/src/lib/res-types/fmOrder.res.ts
+++ b/libs/shared-types/src/lib/res-types/fmOrder.res.ts
@@ -516,6 +516,12 @@ export type FindFmOrderRes = FmOrder & {
   totalEa: number;
   /** 이 주문에 포함된 내 모든 상품 및 상품옵션의 총 종류 수 */
   totalType: number;
+  /** 이 주문에 포함된 내 모든 상품의 배송비 총 합 */
+  totalShippingCost: string;
+  /** 이 주문에 포함된 내 모든 상품의 배송비 총 합 */
+  totalDeliveryCost: string;
+  /** 이 주문에 포함된 내 모든 상품의 상품별 배송정보 */
+  shippings: FmOrderShipping[];
 };
 
 /**
@@ -651,6 +657,7 @@ export interface FmOrderExportBase {
   totalEa: number;
 }
 
+/** 주문 출고 정보 */
 export type FmOrderExport = FmOrderExportBase & {
   /**
    * 출고에 포함된 상품옵션 정보
@@ -697,9 +704,50 @@ export interface FmOrderExportItemOption {
   color?: string;
 }
 
-/**
- * 주문 상세 정보 (메타정보)
- */
+/** 주문 배송 정보 */
+export interface FmOrderShipping {
+  /** 배송비 */
+  shippingCost: string;
+  /** 배송비 */
+  deliveryCost: string;
+  /** 배송 방식 이름 */
+  shipping_set_name: string;
+  /**
+   * 배송비 결제 방식
+   * - free = 무료
+   * - prepay = 선불 - 주문시결제
+   * - postpaid = 착불
+   */
+  shipping_type: 'free' | 'prepay' | 'postpaid';
+  /**
+   * 배송방법
+   * - delivery = 택배
+   * - postpaid = 택배착불
+   * - each_delivery = 택배
+   * - each_postpaid = 택배착불
+   * - quick = 퀵서비스
+   * - direct_delivery = 직접배송
+   * - direct_store = 매장수령
+   * - freight = 화물배송
+   * - direct = 직접수령
+   * - coupon = 티켓
+   * */
+  shipping_method:
+    | 'delivery'
+    | 'postpaid'
+    | 'each_delivery'
+    | 'each_postpaid'
+    | 'quick'
+    | 'direct_delivery'
+    | 'direct_store'
+    | 'freight'
+    | 'direct'
+    | 'coupon';
+  /** 배송그룹 */
+  shipping_group: string;
+}
+
+/** 주문 상세 정보 (메타정보) */
 export type FmOrderMetaInfo = Pick<
   FmOrder,
   | 'order_seq'
@@ -726,59 +774,19 @@ export type FmOrderMetaInfo = Pick<
   /** 주문아이디 */
   id: FmOrder['order_seq'];
 } & {
-  /**
-   * 배송비
-   */
-  shipping_cost: string;
-  /**
-   * 배송비
-   */
-  delivery_cost: string;
-  /**
-   * 배송 방식 이름
-   */
-  shipping_set_name: string;
-  /**
-   * 배송비 결제 방식
-   * - free = 무료
-   * - prepay = 선불 - 주문시결제
-   * - postpaid = 착불
-   */
-  shipping_type: 'free' | 'prepay' | 'postpaid';
-  /**
-   * 배송방법
-   * delivery = 택배
-   * postpaid = 택배착불
-   * each_delivery = 택배
-   * each_postpaid = 택배착불
-   * quick = 퀵서비스
-   * direct_delivery = 직접배송
-   * direct_store = 매장수령
-   * freight = 화물배송
-   * direct = 직접수령
-   * coupon = 티켓
-   * */
-  shipping_method:
-    | 'delivery'
-    | 'postpaid'
-    | 'each_delivery'
-    | 'each_postpaid'
-    | 'quick'
-    | 'direct_delivery'
-    | 'direct_store'
-    | 'freight'
-    | 'direct'
-    | 'coupon';
-  /** 배송그룹 */
-  shipping_group: string;
+  /** 이 주문에 포함된 내 모든 상품의 배송비 총 합 */
+  totalShippingCost: string;
+  /** 이 주문에 포함된 내 모든 상품의 배송비 총 합 */
+  totalDeliveryCost: string;
+  /** 상품별 배송정보 */
+  shippings: FmOrderShipping[];
 } & {
+  /** 배송메모 전문 */
   memoOriginal: string | null;
 };
 
 export interface FmOrderRefundBase {
-  /**
-   * 환불 코드
-   */
+  /** 환불 코드 */
   refund_code: string;
   /**
    * 환불 구분
@@ -787,41 +795,23 @@ export interface FmOrderRefundBase {
    * - shipping_price = 배송비환불
    */
   refund_type: 'cancel_payment' | 'return' | 'shipping_price';
-  /**
-   * 환불 접수일
-   */
+  /** 환불 접수일 */
   regist_date: string;
-  /**
-   * 환불 완료 날짜
-   */
+  /** 환불 완료 날짜 */
   refund_date: string;
-  /**
-   * 환불 처리 상태
-   */
+  /** 환불 처리 상태 */
   status: 'request' | 'ing' | 'complete';
-  /**
-   * 환불 처리 완료 관리자 아이디
-   */
+  /** 환불 처리 완료 관리자 아이디 */
   manager_id: string;
-  /**
-   * 환불 처리 완료 관리자 이메일
-   */
+  /** 환불 처리 완료 관리자 이메일 */
   memail: string;
-  /**
-   * 환불 처리 완료 관리자 전화번호
-   */
+  /** 환불 처리 완료 관리자 전화번호 */
   mcellphone: string;
-  /**
-   * 총 환불 상품(옵션) 개수
-   */
+  /** 총 환불 상품(옵션) 개수 */
   totalEa: string;
-  /**
-   * 총 환불 상품(옵션) 가격
-   */
+  /** 총 환불 상품(옵션) 가격 */
   refund_goods_price: string;
-  /**
-   * 환불 사유
-   */
+  /** 환불 사유 */
   refund_reason: string;
 }
 

--- a/libs/stores/src/lib/fmExportStore.tsx
+++ b/libs/stores/src/lib/fmExportStore.tsx
@@ -1,23 +1,25 @@
 import create from 'zustand';
 
 export interface FmExportStoreStates {
-  selectedOptions: string[];
-  handleOptionSelect: (optId: string, forceConcat?: 'forceConcat') => void;
-  resetSelectedOptions: () => void;
+  selectedOrderShippings: number[];
+  handleOrderShippingSelect: (shippingSeq: number, forceConcat?: 'forceConcat') => void;
+  resetSelectedOrderShippings: () => void;
 }
 
 export const fmExportStore = create<FmExportStoreStates>((set, get) => ({
-  selectedOptions: [],
-  handleOptionSelect: (optId, forceConcat) => {
-    return set(({ selectedOptions }) => {
-      if (selectedOptions.includes(optId)) {
-        if (forceConcat) return { selectedOptions };
-        return { selectedOptions: selectedOptions.filter((o) => o !== optId) };
+  selectedOrderShippings: [],
+  handleOrderShippingSelect: (shippingSeq, forceConcat) => {
+    return set(({ selectedOrderShippings }) => {
+      if (selectedOrderShippings.includes(shippingSeq)) {
+        if (forceConcat) return { selectedOrderShippings };
+        return {
+          selectedOrderShippings: selectedOrderShippings.filter((o) => o !== shippingSeq),
+        };
       }
-      return { selectedOptions: selectedOptions.concat(optId) };
+      return { selectedOrderShippings: selectedOrderShippings.concat(shippingSeq) };
     });
   },
-  resetSelectedOptions: () => {
-    return set({ selectedOptions: [] });
+  resetSelectedOrderShippings: () => {
+    return set({ selectedOrderShippings: [] });
   },
 }));

--- a/libs/utils/src/lib/fmOrderMemoParser.ts
+++ b/libs/utils/src/lib/fmOrderMemoParser.ts
@@ -78,6 +78,18 @@ export class FmOrderMemoParser {
    * @returns {FmOrderMemoItem}
    */
   public parse(s: string): FmOrderMemoItem {
+    const parsableStringRegexp =
+      /(1. 배송메모 : )(.*?)(,)\n(2. 크리에이터 채널명 : )(.*)(,)\n(3. 작성자 : )(.*?)(,)\n(4. 응원내용 : )(.*)(,)\n(5. 통화 이벤트 : )(.*?)(,)\n(6. 선물하기 여부 : )(.*)/g;
+    const isParsable = parsableStringRegexp.test(s);
+    if (!isParsable)
+      return {
+        memo: s,
+        broadcaster: null,
+        buyer: null,
+        donationMessaage: null,
+        phoneEventFlag: false,
+        giftFlag: false,
+      };
     return {
       memo: this.parseMemo(s),
       broadcaster: this.parseBroadcaster(s),

--- a/libs/utils/src/lib/parseFmOrderMemo.spec.ts
+++ b/libs/utils/src/lib/parseFmOrderMemo.spec.ts
@@ -1,6 +1,17 @@
 import { FmOrderMemoParser } from './fmOrderMemoParser';
 
 describe('FmOrderMemoParser', () => {
+  test('파싱가능하지 않은 배송메모 문자열인 경우 memo가 문자열 그대로를 반환해야 한다', () => {
+    const teststring = `집앞에 두세요.`;
+    const parser = new FmOrderMemoParser(teststring);
+    expect(parser.memo).toEqual(teststring);
+    expect(parser.broadcaster).toEqual(null);
+    expect(parser.buyer).toEqual(null);
+    expect(parser.donationMessaage).toEqual(null);
+    expect(parser.phoneEventFlag).toEqual(false);
+    expect(parser.giftFlag).toEqual(false);
+  });
+
   test('통화이벤트O, 선물O', () => {
     const teststring = `1. 배송메모 : 집앞에 두세요.,
 2. 크리에이터 채널명 : 크리에이터이름,


### PR DESCRIPTION
## 작업 개요

입점형태이므로 구매자가 주문할 때

판매자A 의 ㄱ상품, 판매자B의 ㄴ상품과 같이 여러 판매자의 상품을 주문할 수 있다.

판매자A의 마이페이지 주문목록/주문상세보기 에서는 어떻게 보여져야 하는가?

→ 주문에서 판매자A의 상품인 ㄱ상품의 정보만 보여주도록 합의

⇒ 이에 따른 처리 필요

- 주문(상품,옵션) 금액
- 주문상품,옵션 보여지지 않도록
- 주문 목록의 결제금액을 settleprice 를 참조하지 않고 다음과 같이 수정
    
    현재 주문한 판매자의 상품/상품옵션별 금액의 합 + 상품의 배송정책 배송비

## 할일

주문 중, 자신의 상품정보만 확인할 수 있도록 처리

- 주문 목록
    - [x]  주문금액
        - [x]  주문배송비
        - [x]  주문금액
    - [x]  주문 수량 (개수)
- 주문 상세 보기
    - [x]  배송비정보
    - [x]  주문 상품 정보
    - [x]  출고 정보
- 출고 상세 보기
    - ~~출고 주문 정보~~
- 출고하기
    - [x]  출고 상품 목록

### 발견된 문제점과 그 해결

- "주문상태" 관련
    1. 하나의 주문에 여러 판매자가 관여하므로, 판매자A는 "출고완료" 상태이지만 판매자 B는 "상품준비" 상태일 수 있음. 하지만 주문의 "상태" 는 하나이므로 판매자A와 판매자B에게 보여지는 주문 상태는 "상품준비" 가 될 것.
        
        ⇒ 판매자 A는 왜 주문 상태가 변하지 않는가? 혼란을 느낄 수 있음.
        
    2. 출고처리시 출고완료로 주문 상태를 변경해 버림.
    예를 들면, 판매자B는 아직 "상품준비" 상태일 때, 판매자 A가 출고를 진행하여 "출고완료"로 상태를 변경하면, 주문의 상태는 "출고완료"가 되어버림.
        
        ⇒ 판매자 B는 주문상태가 왜 이렇지? 혼란을 느낄 수 있음.
        
    
    해결책
    
    1. "주문" 의 상태를 주문의 "step" 필드를 참조하지 않고, 주문에 포함된 내 상품과 내 상품 옵션의 정보를 토대로 유추한다
        - [x]  주문상세보기의 step 유추 처리
        - [x]  주문목록에서의 step 유추 처리

### 추가 진행한 일감

- [x]  주문 목록 "상품" 컬럼 충분히 넓어보이도록 너비 수정
- [x]  주문 상세보기 → 요약 정보에 "배송비" 추가
- [x]  주문별 출고가 아닌 배송묶음별 출고로 변경
    - [x]  단일 출고
    - [x]  일괄 출고
    - [x]  합포장 출고