### PR TITLE
[기능 수정] 회원가입시 곧바로 로그인시키기

### DIFF
--- a/libs/components/src/lib/LoginForm.tsx
+++ b/libs/components/src/lib/LoginForm.tsx
@@ -52,7 +52,7 @@ export function LoginForm({ enableShadow = false }: LoginFormProps): JSX.Element
         setValue('password', '');
       });
       if (seller) {
-        router.push('/');
+        router.push('/mypage');
       }
     },
     [login, setValue, router],

--- a/libs/components/src/lib/SignupForm.tsx
+++ b/libs/components/src/lib/SignupForm.tsx
@@ -15,6 +15,7 @@ import {
   getEmailDupCheck,
   useMailVerificationMutation,
   useSellerSignupMutation,
+  useLoginMutation,
 } from '@project-lc/hooks';
 import {
   emailCodeRegisterOptions,
@@ -106,6 +107,7 @@ export function SignupForm({
 
   // * 회원가입 핸들러
   const signup = useSellerSignupMutation();
+  const login = useLoginMutation('seller');
   const onSubmit = useCallback(
     async (data: SignUpSellerDto) => {
       const seller = await signup.mutateAsync(data).catch((err) => {
@@ -117,7 +119,12 @@ export function SignupForm({
         });
       });
       if (seller) {
-        router.push('/');
+        // 로그인 과정이 수행
+        await login.mutateAsync({
+          email: data.email,
+          password: data.password,
+        });
+        router.push('/mypage');
       }
     },
     [router, setError, signup],


### PR DESCRIPTION
#### 구현 사항

- [x]  회원가입 이후에 로그인 작업 mutation 추가
    - 페이지를 빌드하는 과정이 필요하다보니 인증완료 버튼 이후 화면이 멈춘듯함. 배포 후에 빌드하는 과정의 소요시간을 보고 prefetch와 같은 작업 고려
- [x]  로컬 로그인 이후에 시작 지점 '/' → '/mypage' 변경