### PR TITLE
[기능 수정] 상품수정 기능 - 라이브쇼핑이 진행중인경우 불가능하도록 처리

### DIFF
--- a/apps/web/pages/mypage/goods/[goodsId].tsx
+++ b/apps/web/pages/mypage/goods/[goodsId].tsx
@@ -11,7 +11,6 @@ import {
   GoodsDetailShippingInfo,
   GoodsDetailSummary,
   GoodsDetailTitle,
-  GoodsEditButton,
   MypageLayout,
   SectionWithTitle,
 } from '@project-lc/components';
@@ -32,7 +31,7 @@ export function GoodsDetail(): JSX.Element {
     <MypageLayout>
       <Stack m="auto" maxW="4xl" mt={{ base: 2, md: 8 }} spacing={8} p={2} mb={16}>
         <Box as="section">
-          <Stack direction="row" justifyContent="space-between">
+          <Stack direction="row">
             <Button
               size="sm"
               leftIcon={<ChevronLeftIcon />}
@@ -40,7 +39,6 @@ export function GoodsDetail(): JSX.Element {
             >
               목록으로
             </Button>
-            <GoodsEditButton goodsId={goodsId} />
           </Stack>
         </Box>
 

--- a/libs/components/src/lib/GoodsDetailActions.tsx
+++ b/libs/components/src/lib/GoodsDetailActions.tsx
@@ -1,4 +1,5 @@
 import { Box, Stack, Text } from '@chakra-ui/react';
+import { useGoodsOnLiveFlag } from '@project-lc/hooks';
 import { GoodsByIdRes } from '@project-lc/shared-types';
 import { GoodsExposeSwitch } from './GoodsExposeSwitch';
 
@@ -6,18 +7,16 @@ export interface GoodsDetailActionsProps {
   goods: GoodsByIdRes;
 }
 export function GoodsDetailActions({ goods }: GoodsDetailActionsProps): JSX.Element {
+  const onLiveShopping = useGoodsOnLiveFlag(goods);
   return (
     <Stack>
-      {/* <HStack>
-        <Button>버튼1</Button>
-        <Button>버튼2</Button>
-      </HStack> */}
       <Box>
         <Text>상품노출 상태변경</Text>
         <GoodsExposeSwitch
           goodsId={goods.id}
           goodsView={goods.goods_view}
           confirmedGoodsId={goods.confirmation?.firstmallGoodsConnectionId || undefined}
+          isReadOnly={onLiveShopping}
         />
       </Box>
     </Stack>

--- a/libs/components/src/lib/GoodsDetailTitle.tsx
+++ b/libs/components/src/lib/GoodsDetailTitle.tsx
@@ -1,15 +1,26 @@
 import { Heading, Stack, Text } from '@chakra-ui/react';
+import { useGoodsOnLiveFlag } from '@project-lc/hooks';
 import { GoodsByIdRes } from '@project-lc/shared-types';
 import dayjs from 'dayjs';
-import { GoodsConfirmStatusBadge, GoodsStatusBadge, TextDotConnector } from '..';
+import {
+  GoodsConfirmStatusBadge,
+  GoodsEditButton,
+  GoodsStatusBadge,
+  TextDotConnector,
+} from '..';
 
 export interface GoodsDetailTitleProps {
   goods: GoodsByIdRes;
 }
 export function GoodsDetailTitle({ goods }: GoodsDetailTitleProps): JSX.Element {
+  const onLiveShopping = useGoodsOnLiveFlag(goods);
   return (
-    <>
-      <Heading>{goods.goods_name}</Heading>
+    <Stack>
+      <Stack direction="row" justifyContent="space-between" alignItems="center">
+        <Heading>{goods.goods_name}</Heading>
+        <GoodsEditButton goodsId={goods.id} onLiveShopping={onLiveShopping} />
+      </Stack>
+
       <Stack direction="row" alignItems="center">
         <GoodsStatusBadge goodsStatus={goods.goods_status} />
         <TextDotConnector />
@@ -17,6 +28,6 @@ export function GoodsDetailTitle({ goods }: GoodsDetailTitleProps): JSX.Element 
         <TextDotConnector />
         <Text>{dayjs(goods.regist_date).fromNow()}</Text>
       </Stack>
-    </>
+    </Stack>
   );
 }

--- a/libs/components/src/lib/GoodsEditForm.tsx
+++ b/libs/components/src/lib/GoodsEditForm.tsx
@@ -8,8 +8,14 @@ import {
   theme,
   useColorModeValue,
   useToast,
+  Box,
 } from '@chakra-ui/react';
-import { useCreateGoodsCommonInfo, useProfile, useEditGoods } from '@project-lc/hooks';
+import {
+  useCreateGoodsCommonInfo,
+  useProfile,
+  useEditGoods,
+  useGoodsOnLiveFlag,
+} from '@project-lc/hooks';
 import { GoodsByIdRes, RegistGoodsDto } from '@project-lc/shared-types';
 import { useRouter } from 'next/router';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -34,7 +40,7 @@ type GoodsFormSubmitDataType = Omit<GoodsFormValues, 'options'> & {
 };
 
 /** 상품 수정 폼 컴포넌트 */
-export function GoodsEditForm({ goodsData }: { goodsData?: GoodsByIdRes }): JSX.Element {
+export function GoodsEditForm({ goodsData }: { goodsData: GoodsByIdRes }): JSX.Element {
   const { data: profileData } = useProfile();
   const { mutateAsync: editGoodsRequest, isLoading } = useEditGoods();
   const { mutateAsync: createGoodsCommonInfo } = useCreateGoodsCommonInfo();
@@ -43,8 +49,7 @@ export function GoodsEditForm({ goodsData }: { goodsData?: GoodsByIdRes }): JSX.
 
   const methods = useForm<GoodsFormValues>({
     defaultValues: {
-      // 상품 id (상품 수정하는 경우 id 존재, 상품 등록하는 경우 id undefined)
-      id: goodsData?.id || undefined,
+      id: goodsData.id,
       // 기본정보
       goods_name: goodsData?.goods_name || undefined, // 상품명
       summary: goodsData?.summary || undefined, // 간략설명
@@ -215,6 +220,22 @@ export function GoodsEditForm({ goodsData }: { goodsData?: GoodsByIdRes }): JSX.
       });
   };
 
+  const onLiveShopping = useGoodsOnLiveFlag(goodsData);
+  const fixedStackBgColor = useColorModeValue('white', 'gray.800');
+
+  if (onLiveShopping) {
+    return (
+      <Stack spacing={10} py={10}>
+        <Text>해당 상품은 라이브 쇼핑 진행중인 상품으로 수정할 수 없습니다</Text>
+        <Box>
+          <Button leftIcon={<ChevronLeftIcon />} onClick={router.back}>
+            돌아가기
+          </Button>
+        </Box>
+      </Stack>
+    );
+  }
+
   return (
     <FormProvider {...methods}>
       <Stack p={2} spacing={5} as="form" onSubmit={handleSubmit(editGoods)}>
@@ -223,7 +244,7 @@ export function GoodsEditForm({ goodsData }: { goodsData?: GoodsByIdRes }): JSX.
           mx={-2}
           direction="row"
           position="sticky"
-          bgColor={useColorModeValue('white', 'gray.800')}
+          bgColor={fixedStackBgColor}
           top="0px"
           left="0px"
           right="0px"

--- a/libs/components/src/lib/GoodsExposeSwitch.tsx
+++ b/libs/components/src/lib/GoodsExposeSwitch.tsx
@@ -15,10 +15,12 @@ export function GoodsExposeSwitch({
   goodsId,
   goodsView,
   confirmedGoodsId,
+  isReadOnly = false,
 }: {
   goodsId: number;
   goodsView: GoodsView;
   confirmedGoodsId?: number;
+  isReadOnly?: boolean;
 }): JSX.Element {
   const queryClient = useQueryClient();
   const changeGoodsView = useChangeGoodsView();
@@ -60,6 +62,7 @@ export function GoodsExposeSwitch({
           id={`${goodsId}_view_switch`}
           isChecked={goodsView === 'look'}
           onChange={changeView}
+          isDisabled={isReadOnly}
         />
       )}
     </FormControl>

--- a/libs/components/src/lib/SellerGoodsList.tsx
+++ b/libs/components/src/lib/SellerGoodsList.tsx
@@ -38,6 +38,24 @@ function formatDate(date: Date): string {
   return dayjs(date).format('YYYY/MM/DD HH:mm');
 }
 
+/** 라이브쇼핑 진행중이므로 수정 불가 표시 */
+export function GoodsEditDisabledText(): JSX.Element {
+  return (
+    <TextWithPopperButton
+      title="수정불가"
+      iconAriaLabel="수정불가"
+      iconColor="black"
+      portalBody
+    >
+      <Text>
+        현재 라이브 쇼핑이 진행중인 상품으로 상품 정보를 변경할 수 없습니다. <br />
+        상품 정보를 수정하고 싶은 경우 고객센터로 문의해주세요.
+      </Text>
+    </TextWithPopperButton>
+  );
+}
+
+/** 배송비 그룹 상세정보 조회 버튼 */
 export function ShippingGroupDetailButton(props: {
   id: number;
   name: string;
@@ -68,7 +86,15 @@ export function ShippingGroupDetailButton(props: {
 }
 
 /** 상품 수정 페이지로 이동하는 링크 */
-export function GoodsEditButton({ goodsId }: { goodsId: number | string }): JSX.Element {
+export function GoodsEditButton({
+  goodsId,
+  onLiveShopping = false,
+}: {
+  goodsId: number | string;
+  onLiveShopping?: boolean;
+}): JSX.Element {
+  // 라이브쇼핑 진행중인 상품의 경우
+  if (onLiveShopping) return <GoodsEditDisabledText />;
   return (
     <NextLink href={`/mypage/goods/edit/${goodsId}`} passHref>
       <Link>
@@ -241,12 +267,14 @@ const columns: GridColumns = [
       const goodsId = row.id;
       const goodsView = row.goods_view;
       const confirmedGoodsId = row.confirmation?.firstmallGoodsConnectionId;
+      const goodsOnLiveShopping = row.onLiveShopping; // 라이브쇼핑 진행중인 경우 노출 변경 불가하도록
       return (
         <Flex alignItems="center" justifyContent="center">
           <GoodsExposeSwitch
             goodsId={goodsId}
             goodsView={goodsView}
             confirmedGoodsId={confirmedGoodsId}
+            isReadOnly={goodsOnLiveShopping}
           />
         </Flex>
       );
@@ -315,7 +343,8 @@ const columns: GridColumns = [
     minWidth: 60,
     renderCell: ({ row }) => {
       const goodsId = row.id;
-      return <GoodsEditButton goodsId={goodsId} />;
+      const goodsOnLiveShopping = row.onLiveShopping;
+      return <GoodsEditButton goodsId={goodsId} onLiveShopping={goodsOnLiveShopping} />;
     },
   },
 ];

--- a/libs/components/src/lib/ShopInfoShippingGroup.tsx
+++ b/libs/components/src/lib/ShopInfoShippingGroup.tsx
@@ -75,12 +75,13 @@ export function ShopInfoShippingPolicyItem({
     <>
       <Grid templateColumns="repeat(9, 1fr)" mb={1}>
         {/* 배송그룹명 */}
-        <GridItem colSpan={4}>
+        <GridItem colSpan={3}>
           <Button
             variant="link"
             onClick={onInfoModalOpen}
             isFullWidth
             textDecoration="underline"
+            color="teal.500"
           >
             <Text isTruncated>{`${shipping_group_name}`}</Text>
           </Button>
@@ -88,17 +89,18 @@ export function ShopInfoShippingPolicyItem({
 
         {/* 배송비 계산 기준 */}
         <GridItem colSpan={3}>
-          <Text>{`${ShippingCalculTypeOptions[shipping_calcul_type].label}`}</Text>
+          <Text align="center">{`${ShippingCalculTypeOptions[shipping_calcul_type].label}`}</Text>
         </GridItem>
 
         {/* 연결된 상품 */}
-        <GridItem colSpan={1}>
+        <GridItem colSpan={2}>
           {_count.goods > 0 ? (
             <Button
               variant="link"
               onClick={onRelatedGoodsModalOpen}
               isFullWidth
               textDecoration="underline"
+              color="teal.500"
             >
               <Text>{`${_count.goods}`}</Text>
             </Button>
@@ -108,7 +110,7 @@ export function ShopInfoShippingPolicyItem({
         </GridItem>
 
         {/* 삭제버튼 */}
-        <GridItem>
+        <GridItem display="flex" justifyContent="flex-end">
           <CloseButton size="sm" onClick={onConfirmModalOpen} />
         </GridItem>
       </Grid>
@@ -179,13 +181,11 @@ export function ShopInfoShippingGroup(): JSX.Element {
       />
 
       {/* 배송비 정책 목록 컨테이너 */}
-      <ShippingGroupContainerBox>
+      <ShippingGroupContainerBox maxHeight="150px" overflowY="auto">
         {/* 생성된 배송비 정책 없는경우 */}
         {(!data || data.length === 0) && <Text>등록된 배송비 정책이 없습니다. </Text>}
         {/* 배송비 정책 목록 */}
-        <Box maxHeight="150px" overflowY="auto">
-          {data && data.map((g) => <ShopInfoShippingPolicyItem key={g.id} group={g} />)}
-        </Box>
+        {data && data.map((g) => <ShopInfoShippingPolicyItem key={g.id} group={g} />)}
       </ShippingGroupContainerBox>
     </SettingSectionLayout>
   );

--- a/libs/hooks/src/index.ts
+++ b/libs/hooks/src/index.ts
@@ -74,6 +74,7 @@ export * from './lib/s3';
 export * from './lib/shipping-group-hooks';
 export * from './lib/useCountdown';
 export * from './lib/useDisplaySize';
+export * from './lib/useGoodsOnLive';
 export * from './lib/useHorizontalScroll';
 export * from './lib/useOrderExportableCheck';
 export * from './lib/useOrderReturnOrRefundStatus';

--- a/libs/hooks/src/lib/useGoodsOnLive.tsx
+++ b/libs/hooks/src/lib/useGoodsOnLive.tsx
@@ -1,0 +1,16 @@
+import { getLiveShoppingProgress, GoodsByIdRes } from '@project-lc/shared-types';
+import { useMemo } from 'react';
+
+/** 해당 상품에 대해 라이브쇼핑 진행중인지 여부 리턴 */
+export const useGoodsOnLiveFlag = (goods: GoodsByIdRes): boolean => {
+  const onLiveShopping = useMemo(() => {
+    if (!goods.LiveShopping || goods.LiveShopping.length === 0) return false;
+    // 모든 데이터가 '판매종료', '취소됨' 상태가 아니라면 라이브쇼핑 진행중으로 봄
+    const liveShoppingIng = !goods.LiveShopping.every((live) => {
+      const liveShoppingProgress = getLiveShoppingProgress(live);
+      return ['판매종료', '취소됨'].includes(liveShoppingProgress);
+    });
+    return liveShoppingIng;
+  }, [goods]);
+  return onLiveShopping;
+};

--- a/libs/nest-modules/src/lib/goods/goods.service.spec.ts
+++ b/libs/nest-modules/src/lib/goods/goods.service.spec.ts
@@ -1,3 +1,4 @@
+import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Goods, GoodsView, PrismaClient } from '@prisma/client';
 import { PrismaModule } from '@project-lc/prisma-orm';
@@ -6,10 +7,8 @@ import {
   SellerGoodsSortDirection,
 } from '@project-lc/shared-types';
 import { nanoid } from 'nanoid';
-import { ConfigModule } from '@nestjs/config';
-import { DeleteObjectsCommandOutput } from '@aws-sdk/client-s3';
-import { GoodsService } from './goods.service';
 import { S3Module } from '../s3/s3.module';
+import { GoodsService } from './goods.service';
 
 describe('GoodsService', () => {
   let __prisma: PrismaClient;

--- a/libs/nest-modules/src/lib/goods/goods.service.ts
+++ b/libs/nest-modules/src/lib/goods/goods.service.ts
@@ -18,6 +18,7 @@ import {
   RegistGoodsDto,
   TotalStockInfo,
   ApprovedGoodsNameAndId,
+  getLiveShoppingProgress,
 } from '@project-lc/shared-types';
 import {
   getImgSrcListFromHtmlStringList,
@@ -117,6 +118,7 @@ export class GoodsService {
         },
         confirmation: true,
         ShippingGroup: true,
+        LiveShopping: true,
       },
     });
 
@@ -125,6 +127,18 @@ export class GoodsService {
       const itemStockInfo = this.intergrateOptionStocks(optionsWithStockInfo);
 
       const defaultOption = item.options.find((opt) => opt.default_option === 'y');
+
+      let onLiveShopping = true;
+      if (item.LiveShopping.length === 0) onLiveShopping = false;
+
+      // 상품에 연결된 라이브쇼핑 데이터가 있는 경우
+      if (item.LiveShopping.length > 0) {
+        // 모든 데이터가 '판매종료', '취소됨' 상태가 아니라면 라이브쇼핑 진행중으로 봄
+        onLiveShopping = !item.LiveShopping.every((live) => {
+          const liveShoppingProgress = getLiveShoppingProgress(live);
+          return ['판매종료', '취소됨'].includes(liveShoppingProgress);
+        });
+      }
 
       return {
         id: item.id,
@@ -146,6 +160,7 @@ export class GoodsService {
               shipping_group_name: item.ShippingGroup.shipping_group_name,
             }
           : undefined,
+        onLiveShopping,
       };
     });
 
@@ -372,6 +387,7 @@ export class GoodsService {
         confirmation: true,
         image: true,
         GoodsInfo: true,
+        LiveShopping: true,
       },
     });
   }

--- a/libs/shared-types/src/lib/res-types/goodsById.res.ts
+++ b/libs/shared-types/src/lib/res-types/goodsById.res.ts
@@ -9,6 +9,7 @@ import {
   ShippingSet,
   ShippingOption,
   ShippingCost,
+  LiveShopping,
 } from '@prisma/client';
 
 export type GoodsByIdRes = Goods & {
@@ -27,4 +28,5 @@ export type GoodsByIdRes = Goods & {
   confirmation: GoodsConfirmation;
   image: GoodsImages[];
   GoodsInfo: GoodsInfo | null;
+  LiveShopping?: LiveShopping[];
 };

--- a/libs/shared-types/src/lib/res-types/goodsList.res.ts
+++ b/libs/shared-types/src/lib/res-types/goodsList.res.ts
@@ -53,6 +53,7 @@ export type SellerGoodsListItem = Pick<
     default_consumer_price: Decimal; // 소비자가(미할인가) - GoodsOptions중 default_option의 소비자가
     shippingGroup?: Pick<ShippingGroup, 'id' | 'shipping_group_name'>;
     businessRegistrationStatus?: string;
+    onLiveShopping?: boolean;
   };
 
 export type GoodsListRes = {


### PR DESCRIPTION
- 특정 상품이 라이브쇼핑 진행중인 경우 상품정보 수정 못하도록 처리(라이브쇼핑이 등록된 상품 삭제와 동일한 기준 사용 - 라이브쇼핑이 취소됨/진행완료 인 경우에는 수정 가능. 이 외에는 불가)
   - 노출버튼 disable
   - 수정버튼(수정페이지로 이동 링크) 숨김처리

이유
-  판매자가 실수로 라이브쇼핑중인 상품을 숨김처리 하지 않도록 하기 위함이다. 라이브쇼핑 진행중인 상품은 검수된 상품이다. 검수된 상품 노출여부 변경시 검수과정 없이 퍼스트몰 상품의 노출여부도 변경된다.
- 라이브쇼핑 등록된 상품의 상품명을 변경하는 경우, '내 라이브쇼핑 관리' 페이지에 표시되는 상품명도 변경된다. 하지만 실제 크크마켓에 표시되는 상품명은 퍼스트몰에서 관리자가 수정하기 전에는 변경되지 않는다. 판매자가 상품명이 즉각적으로 변경되었다고 오해하는 일을 방지하고자 함. 

기타 수정사항 
- 배송비정책 목록 컨테이너 스타일 수정