### PR TITLE
개발자간 통합테스트 이후 수정사항

### DIFF
--- a/apps/web/pages/mypage/orders/[orderId].tsx
+++ b/apps/web/pages/mypage/orders/[orderId].tsx
@@ -3,6 +3,7 @@ import {
   Box,
   Button,
   Center,
+  Flex,
   Skeleton,
   SkeletonCircle,
   SkeletonText,
@@ -75,7 +76,7 @@ export function OrderDetail(): JSX.Element {
   if (!order.isLoading && !isViewableOrder)
     return (
       <MypageLayout>
-        <Box m="auto" maxW="4xl">
+        <Flex m="auto" maxW="4xl" h={400} justify="center" alignItems="center">
           <Stack spacing={2}>
             <Center>
               <Text>주문 데이터를 불러오지 못했습니다.</Text>
@@ -87,7 +88,7 @@ export function OrderDetail(): JSX.Element {
               <Button onClick={() => router.push('/mypage/orders')}>돌아가기</Button>
             </Center>
           </Stack>
-        </Box>
+        </Flex>
       </MypageLayout>
     );
 

--- a/apps/web/pages/mypage/settlement/index.tsx
+++ b/apps/web/pages/mypage/settlement/index.tsx
@@ -1,4 +1,13 @@
-import { Container, Divider, Grid, GridItem, Heading, VStack } from '@chakra-ui/react';
+import {
+  Text,
+  Kbd,
+  Container,
+  Divider,
+  Grid,
+  GridItem,
+  Heading,
+  VStack,
+} from '@chakra-ui/react';
 import {
   BusinessRegistrationBox,
   MypageLayout,
@@ -6,6 +15,7 @@ import {
   SettlementList,
   SettlementRoundHistory,
   SettlementStateBox,
+  TextViewerWithDetailModal,
 } from '@project-lc/components';
 import { useSettlementInfo } from '@project-lc/hooks';
 import { BusinessRegistrationStatus } from '@project-lc/shared-types';

--- a/aws-cdk/lib/dev/app-stack.ts
+++ b/aws-cdk/lib/dev/app-stack.ts
@@ -254,7 +254,7 @@ export class LCDevAppStack extends cdk.Stack {
     // HTTP 리스너에 Overlay 서버 타겟그룹 추가
     HttpsListener.addTargetGroups(`${PREFIX}HTTPSApiTargetGroup`, {
       priority: 1,
-      conditions: [elbv2.ListenerCondition.hostHeaders(['preview-livecommerce.onad.io'])],
+      conditions: [elbv2.ListenerCondition.hostHeaders(['dev-live.onad.io'])],
       targetGroups: [overlayTargetGroup],
     });
 

--- a/aws-cdk/lib/env-agnostic/domain-stack.ts
+++ b/aws-cdk/lib/env-agnostic/domain-stack.ts
@@ -77,9 +77,15 @@ export class LCDomainStack extends cdk.Stack {
   }
 
   private createDevRecords(): void {
-    // Dev환경용 ALB로 라우팅하는 기본 dev.크크쇼.com 레코드 생성
-    new route53.ARecord(this, `${this.PUNYCODE_DOMAIN}_ARecord_dev`, {
-      recordName: `dev.${this.PUNYCODE_DOMAIN}`,
+    // Dev환경용 ALB로 라우팅하는 기본 dev-api.크크쇼.com 레코드 생성
+    new route53.ARecord(this, `${this.PUNYCODE_DOMAIN}_ARecord_devapi`, {
+      recordName: `dev-api.${this.PUNYCODE_DOMAIN}`,
+      zone: this.hostedzone,
+      target: route53.RecordTarget.fromAlias(this.devALBTarget),
+    });
+    // Dev환경용 ALB로 라우팅하는 기본 dev-live.크크쇼.com 레코드 생성
+    new route53.ARecord(this, `${this.PUNYCODE_DOMAIN}_ARecord_devlive`, {
+      recordName: `dev-live.${this.PUNYCODE_DOMAIN}`,
       zone: this.hostedzone,
       target: route53.RecordTarget.fromAlias(this.devALBTarget),
     });

--- a/libs/components/src/lib/ExportBundleDialog.tsx
+++ b/libs/components/src/lib/ExportBundleDialog.tsx
@@ -158,7 +158,8 @@ export function ExportBundleDialog({
           {isAbleToBundle ? (
             <>
               <Text>
-                선택된 주문 {selectedOrderShippings.length} 개를 합포장 처리 합니다.
+                선택된 주문의 배송묶음 {selectedOrderShippings.length} 개를 합포장 처리
+                합니다.
               </Text>
               <Stack mt={4} spacing={2}>
                 <FormControl>
@@ -207,7 +208,7 @@ export function ExportBundleDialog({
             colorScheme="pink"
             onClick={() => onBundledExportSubmit()}
           >
-            출고처리
+            합포장 출고처리
           </Button>
           <Button onClick={onClose} ml={2}>
             취소

--- a/libs/components/src/lib/ExportDialog.tsx
+++ b/libs/components/src/lib/ExportDialog.tsx
@@ -13,10 +13,15 @@ import {
   useDisclosure,
   useToast,
 } from '@chakra-ui/react';
-import { useExportOrderMutation, useOrderExportableCheck } from '@project-lc/hooks';
+import {
+  useExportOrderMutation,
+  useOrderExportableCheck,
+  checkShippingCanExport,
+  checkShippingExportIsDone,
+} from '@project-lc/hooks';
 import { ExportOrderDto, FindFmOrderDetailRes } from '@project-lc/shared-types';
 import { fmExportStore } from '@project-lc/stores';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { ExportBundleDialog } from './ExportBundleDialog';
 import { ExportOrderOptionList } from './ExportOrderOptionList';
@@ -84,6 +89,15 @@ export function ExportDialog({
     [exportOrder, formMethods, onExportFail, onExportSuccess, toast],
   );
 
+  /** 합포장 출고처리가 가능한지 여부 */
+  const isBundleExportable = useMemo(() => {
+    return order.shippings.every((shipping) => {
+      const a = checkShippingCanExport(shipping);
+      const isShippingDone = checkShippingExportIsDone(shipping);
+      return a && !isShippingDone;
+    });
+  }, [order.shippings]);
+
   return (
     <Modal
       isOpen={isOpen}
@@ -123,7 +137,7 @@ export function ExportDialog({
               colorScheme="pink"
               onClick={bundleDialog.onOpen}
               variant="outline"
-              isDisabled={order.shippings.length < 2}
+              isDisabled={!isBundleExportable}
             >
               합포장출고처리
             </Button>

--- a/libs/components/src/lib/OrderDetailExportInfo.tsx
+++ b/libs/components/src/lib/OrderDetailExportInfo.tsx
@@ -123,7 +123,7 @@ export function OrderDetailExportInfoItem({
 }): JSX.Element {
   const emphasizeColor = useColorModeValue('red.500', 'red.300');
   // * 합배송 여부 체크 + 현재 조회중인 주문이 아닌 다른 주문인 지 체크
-  const isBundledAndCurrenSeeingOrder = useMemo(() => {
+  const isBundledAndCurrentSeeingOrder = useMemo(() => {
     const allOpts: FmOrderOption[] = [];
 
     orderItems.forEach((oi) => {
@@ -150,7 +150,7 @@ export function OrderDetailExportInfoItem({
         )}
         <Text ml={io.image ? 2 : 0}>{io.goods_name} </Text>
       </Flex>
-      {bundleExportCode && !isBundledAndCurrenSeeingOrder && (
+      {bundleExportCode && !isBundledAndCurrentSeeingOrder && (
         <Text color={emphasizeColor}>합포장(묶음배송) 상품</Text>
       )}
       <OrderDetailOptionListItem key={io.item_option_seq} option={io} />

--- a/libs/components/src/lib/OrderDetailExportInfo.tsx
+++ b/libs/components/src/lib/OrderDetailExportInfo.tsx
@@ -123,7 +123,7 @@ export function OrderDetailExportInfoItem({
 }): JSX.Element {
   const emphasizeColor = useColorModeValue('red.500', 'red.300');
   // * 합배송 여부 체크 + 현재 조회중인 주문이 아닌 다른 주문인 지 체크
-  const isBundledAndRightOrder = useMemo(() => {
+  const isBundledAndCurrenSeeingOrder = useMemo(() => {
     const allOpts: FmOrderOption[] = [];
 
     orderItems.forEach((oi) => {
@@ -132,8 +132,8 @@ export function OrderDetailExportInfoItem({
       });
     });
 
-    const isRight = allOpts.find((x) => x.item_option_seq === io.item_option_seq);
-    if (isRight) return true;
+    const isCurrent = allOpts.find((x) => x.item_option_seq === io.item_option_seq);
+    if (isCurrent) return true;
     return false;
   }, [io.item_option_seq, orderItems]);
   return (
@@ -150,7 +150,7 @@ export function OrderDetailExportInfoItem({
         )}
         <Text ml={io.image ? 2 : 0}>{io.goods_name} </Text>
       </Flex>
-      {bundleExportCode && !isBundledAndRightOrder && (
+      {bundleExportCode && !isBundledAndCurrenSeeingOrder && (
         <Text color={emphasizeColor}>합포장(묶음배송) 상품</Text>
       )}
       <OrderDetailOptionListItem key={io.item_option_seq} option={io} />

--- a/libs/components/src/lib/settlement/AdminSettlementDoneList.tsx
+++ b/libs/components/src/lib/settlement/AdminSettlementDoneList.tsx
@@ -34,6 +34,8 @@ export function AdminSettlementDoneList(): JSX.Element | null {
           <Th>총 정산상품 개수</Th>
           <Th>총 금액</Th>
           <Th>전자결제 수수료</Th>
+          <Th>결제방법</Th>
+          <Th>pg</Th>
           <Th>배송비</Th>
           <Th>총 수수료액</Th>
           <Th>총정산금액</Th>
@@ -51,6 +53,8 @@ export function AdminSettlementDoneList(): JSX.Element | null {
             <Td>{history.totalEa}</Td>
             <Td>{history.totalPrice.toLocaleString()}</Td>
             <Td>{history.pgCommission.toLocaleString()}</Td>
+            <Td>{history.paymentMethod}</Td>
+            <Td>{history.pg}</Td>
             <Td>{history.shippingCost}</Td>
             <Td>{history.totalCommission.toLocaleString()}</Td>
             <Td>{history.totalAmount.toLocaleString()}</Td>

--- a/libs/components/src/lib/settlement/SettlementInfoDialog.tsx
+++ b/libs/components/src/lib/settlement/SettlementInfoDialog.tsx
@@ -208,7 +208,9 @@ export function SettlementInfoItem({
       </GridItem>
       <GridItem>전자결제수수료</GridItem>
       <GridItem>{`${pgCommission.commission.toLocaleString()} (${
-        pgCommission.rate
+        pgCommission.rate === '0'
+          ? pgCommission.description
+          : pgCommission.rate + pgCommission.description
       })`}</GridItem>
       {settlementItem.liveShoppingId ? (
         <>

--- a/libs/components/src/lib/settlement/SettlementList.tsx
+++ b/libs/components/src/lib/settlement/SettlementList.tsx
@@ -1,5 +1,5 @@
-import { DownloadIcon } from '@chakra-ui/icons';
-import { Box, Button, Stack, useDisclosure } from '@chakra-ui/react';
+import { DownloadIcon, InfoIcon } from '@chakra-ui/icons';
+import { Text, Box, Button, Kbd, Stack, useDisclosure } from '@chakra-ui/react';
 import {
   GridColumns,
   GridToolbarContainer,
@@ -19,7 +19,7 @@ import { SettlementInfoDialog } from './SettlementInfoDialog';
 
 // 정산 내역을 보여주는 데이터 그리드
 export function SettlementList(): JSX.Element | null {
-  const { isDesktopSize } = useDisplaySize();
+  const { isDesktopSize, isMobileSize } = useDisplaySize();
 
   const { onOpen, isOpen, onClose } = useDisclosure();
   const selectedRound = settlementHistoryStore((s) => s.selectedRound);
@@ -52,7 +52,7 @@ export function SettlementList(): JSX.Element | null {
         </NextLink>
       ),
     },
-    { field: 'round', headerName: '회차' },
+    { field: 'round', headerName: '회차', minWidth: 100 },
     {
       field: 'startDate',
       headerName: '출고일',
@@ -117,13 +117,30 @@ export function SettlementList(): JSX.Element | null {
   if (!data) return null;
 
   return (
-    <Box px={{ base: 2, sm: 7 }} height="400px">
+    <Box px={{ base: 2, sm: 7 }} height="400px" mb={12}>
+      {data.length > 0 && (
+        <Text mb={2}>
+          <InfoIcon color="blue.500" mr={2} />
+          {isMobileSize ? (
+            <Text as="span">목록을 좌,우로 슬라이드 할 수 있습니다.</Text>
+          ) : (
+            <Text as="span">
+              <Kbd>shift</Kbd> + <Kbd>마우스스크롤</Kbd> 을 통해 목록을 좌,우로 스크롤할
+              수 있습니다.
+            </Text>
+          )}
+        </Text>
+      )}
       <ChakraDataGrid
         minHeight={120}
         headerHeight={50}
         hideFooter
         density="compact"
-        columns={columns.map((x) => ({ ...x, flex: isDesktopSize ? 1 : undefined }))}
+        columns={columns.map((x) => ({
+          ...x,
+          flex: isDesktopSize ? 1 : undefined,
+          minWidth: 100,
+        }))}
         rows={data || []}
         rowCount={5}
         rowsPerPageOptions={[25, 50]}

--- a/libs/components/src/lib/settlement/SettlementTargetList.tsx
+++ b/libs/components/src/lib/settlement/SettlementTargetList.tsx
@@ -356,7 +356,9 @@ function SettlementItemOptionDetail({
       <GridItem>{settlementTarget.pg || '-'}</GridItem>
 
       <GridItem>전자결제수수료</GridItem>
-      <GridItem>{`${pgCommission.commission}(${pgCommission.rate})`}</GridItem>
+      <GridItem>{`${pgCommission.commission}(${
+        pgCommission.rate + pgCommission.description
+      }`}</GridItem>
 
       <GridItem>라이브쇼핑 주문 여부</GridItem>
       <GridItem>

--- a/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.spec.ts
+++ b/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.spec.ts
@@ -7,7 +7,6 @@ import {
   orderDetailOptionsSample,
   orderDetailRefundsSample,
   orderDetailReturnsSample,
-  orderMetaInfoSample,
 } from '../../__tests__/orderDetailSample';
 import { ordersSample } from '../../__tests__/ordersSample';
 import { FirstmallDbService } from '../firstmall-db.service';
@@ -40,7 +39,7 @@ describe('FmOrdersService', () => {
         searchDateType: '주문일',
         searchStartDate: '2020-08-23',
         searchEndDate: '2020-08-24',
-        searchStatuses: ['45', '55'],
+        searchStatuses: ['25', '45', '55'],
       };
       const { sql, params } = service['createFindOrdersQuery'](testGoodsIds, dto);
 
@@ -143,7 +142,6 @@ describe('FmOrdersService', () => {
     expect(sql).toContain('WHERE fm_order_item.goods_seq IN (41)');
 
     // where 구문이 올바르게 들어갔는 지 검사
-    expect(sql).toContain('AND IF(step IN (40, 50, 60, 70');
 
     // params 길이, 내용 검사
     expect(params.length).toBe(0);
@@ -165,7 +163,6 @@ describe('FmOrdersService', () => {
 
     // where 구문이 올바르게 들어갔는 지 검사
     expect(sql).toContain('AND DATE(regist_date) <= ?');
-    expect(sql).toContain('AND IF(step IN (40, 50, 60, 70');
 
     // params 길이, 내용 검사
     expect(params.length).toBe(1);
@@ -179,7 +176,7 @@ describe('FmOrdersService', () => {
         searchDateType: '주문일',
         searchStartDate: '2020-08-23',
         searchEndDate: '2020-08-24',
-        searchStatuses: ['45', '55'],
+        searchStatuses: ['25', '45', '55'],
       };
 
       // db.query를 mocking + spyon 하여 db.query 함수 요청 정보를 트래킹 + 실제 호출되지 않도록

--- a/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.ts
+++ b/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.ts
@@ -306,9 +306,9 @@ export class FmOrdersService {
     `;
     const result: FmOrderMetaInfo[] = await this.db.query(sql, [orderId]);
     const order = result.length > 0 ? result[0] : null;
+    if (!order) return null;
     // step이 정상적이지 않은 주문인 경우 조회하지 않음.
     if (!Object.keys(fmOrderStatuses).includes(order.step)) return null;
-    if (!order) return null;
 
     const parser = new FmOrderMemoParser(order.memo);
     return {

--- a/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.ts
+++ b/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.ts
@@ -79,6 +79,9 @@ export class FmOrdersService {
       }),
     );
 
+    if (dto.searchStatuses && dto.searchStatuses.length > 0) {
+      return detailAtteched.filter((x) => dto.searchStatuses.includes(x.step));
+    }
     return detailAtteched;
   }
 
@@ -108,6 +111,8 @@ export class FmOrdersService {
     JOIN (
       SELECT item_seq, MIN(step) AS optionRealStep
       FROM fm_order_item_option
+      JOIN fm_order_item USING(item_seq)
+      WHERE goods_seq IN (${goodsIds.join(',')})
       GROUP BY item_seq
     ) fm_order_item_option USING(item_seq)
     WHERE fm_order_item.goods_seq IN (${goodsIds.join(',')}) AND step IN (
@@ -163,12 +168,6 @@ export class FmOrdersService {
         params = [dto.searchEndDate];
       }
 
-      if (dto.searchStatuses && dto.searchStatuses.length > 0) {
-        whereSql += `\nAND IF(step IN (40, 50, 60, 70), step, optionRealStep) IN (${dto.searchStatuses.join(
-          ',',
-        )}) `;
-      }
-
       if (dto.search) {
         whereSql += `\nAND (${searchSql}) `;
         params = params.concat(new Array(19).fill(`%${dto.search}%`));
@@ -188,12 +187,6 @@ export class FmOrdersService {
       whereSql = `\nAND (${searchSql})`;
       orderSql = `\nORDER BY fm_order.regist_date DESC`;
 
-      if (dto.searchStatuses && dto.searchStatuses.length > 0) {
-        whereSql += `\nAND IF(AND IF(step IN (40, 50, 60, 70), step, optionRealStep) IN (${dto.searchStatuses.join(
-          ',',
-        )}) `;
-      }
-
       return {
         sql: defaultQueryHead + whereSql + groupbySql + orderSql,
         params: new Array(19).fill(`%${dto.search}%`),
@@ -201,9 +194,6 @@ export class FmOrdersService {
     }
 
     if (dto.searchStatuses && dto.searchStatuses.length > 0) {
-      whereSql += `AND IF(step IN (40, 50, 60, 70), step, optionRealStep) IN (${dto.searchStatuses.join(
-        ',',
-      )})`;
       orderSql = `\nORDER BY fm_order.regist_date DESC`;
       return {
         sql: defaultQueryHead + whereSql + groupbySql + orderSql,

--- a/libs/hooks/src/lib/useOrderExportableCheck.tsx
+++ b/libs/hooks/src/lib/useOrderExportableCheck.tsx
@@ -14,6 +14,7 @@ const NON_EXPORTABLE_SATTUS_NAMES: Parameters<typeof getFmOrderStatusByNames>[0]
   '주문무효',
   '결제실패',
   '결제취소',
+  '출고완료',
 ];
 
 export interface OrderExportableCheck {
@@ -59,28 +60,37 @@ export const useOrderShippingItemsExportableCheck = (
   shipping: FmOrderShipping,
 ): OrderExportableCheck => {
   const isDone = useMemo(() => {
-    return shipping.items.every((i) => {
-      return i.options.every((o) => {
-        const rest = getOptionRestEa(o);
-        return (
-          getFmOrderStatusByNames(EXPORT_DONE_SATTUS_NAMES).includes(o.step) || rest <= 0
-        );
-      });
-    });
-  }, [shipping.items]);
+    return checkShippingExportIsDone(shipping);
+  }, [shipping]);
 
   const isExportable = useMemo(() => {
-    return !shipping.items.every((i) => {
-      return i.options.every((o) => {
-        return getFmOrderStatusByNames(NON_EXPORTABLE_SATTUS_NAMES).includes(o.step);
-      });
-    });
-  }, [shipping.items]);
+    return checkShippingCanExport(shipping);
+  }, [shipping]);
 
   return {
     isDone,
     isExportable,
   };
+};
+
+export const checkShippingCanExport = (shipping: FmOrderShipping): boolean => {
+  const isExportable = !shipping.items.every((i) => {
+    return i.options.every((o) => {
+      return getFmOrderStatusByNames(NON_EXPORTABLE_SATTUS_NAMES).includes(o.step);
+    });
+  });
+  return !!isExportable;
+};
+
+export const checkShippingExportIsDone = (shipping: FmOrderShipping): boolean => {
+  return shipping.items.every((i) => {
+    return i.options.every((o) => {
+      const rest = getOptionRestEa(o);
+      return (
+        getFmOrderStatusByNames(EXPORT_DONE_SATTUS_NAMES).includes(o.step) || rest <= 0
+      );
+    });
+  });
 };
 
 function getOptionRestEa(opt: FmOrderOption): number {

--- a/libs/prisma-orm/prisma/migrations/20211029050313_version2/migration.sql
+++ b/libs/prisma-orm/prisma/migrations/20211029050313_version2/migration.sql
@@ -218,7 +218,7 @@ ALTER TABLE `BusinessRegistrationConfirmation` ADD CONSTRAINT `BusinessRegistrat
 ALTER TABLE `SellerSettlementItems` ADD CONSTRAINT `SellerSettlementItems_liveShoppingId_fkey` FOREIGN KEY (`liveShoppingId`) REFERENCES `LiveShopping`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE `SellerSettlementItems` ADD CONSTRAINT `SellerSettlementItems_sellerSettlementsId_fkey` FOREIGN KEY (`sellerSettlementsId`) REFERENCES `SellerSettlements`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE `SellerSettlementItems` ADD CONSTRAINT `SellerSettlementItems_sellerSettlementsId_fkey` FOREIGN KEY (`sellerSettlementsId`) REFERENCES `SellerSettlements`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE `SellerContacts` ADD CONSTRAINT `SellerContacts_sellerId_fkey` FOREIGN KEY (`sellerId`) REFERENCES `Seller`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/libs/prisma-orm/prisma/schema.prisma
+++ b/libs/prisma-orm/prisma/schema.prisma
@@ -116,7 +116,7 @@ model SellerSettlementItems {
   liveShopping   LiveShopping? @relation(fields: [liveShoppingId], references: [id], onDelete: Cascade)
 
   sellerSettlementsId Int?
-  SellerSettlements   SellerSettlements? @relation(fields: [sellerSettlementsId], references: [id])
+  SellerSettlements   SellerSettlements? @relation(fields: [sellerSettlementsId], references: [id], onDelete: Cascade)
 }
 
 // 판매자 정산 계좌 정보
@@ -157,7 +157,7 @@ model SellerSocialAccount {
 model SellerContacts {
   id           Int            @id @default(autoincrement())
   sellerId     Int // 판매자 아이디
-  email        String         @default("") //등록한 이메일
+  email        String         @default("") //등���한 이메일
   phoneNumber  String         @default("") // 등록한 전화번호
   isDefault    Boolean        @default(false) // 기본 연락처 설정 여부
   seller       Seller         @relation(fields: [sellerId], references: [id], onDelete: Cascade)

--- a/libs/utils/src/lib/calcPgCommission.ts
+++ b/libs/utils/src/lib/calcPgCommission.ts
@@ -10,6 +10,7 @@ export type CalcPgCommissionOptions = {
 export function calcPgCommission(opts: CalcPgCommissionOptions): {
   commission: number;
   rate: string;
+  description: string;
 } {
   const { pg, paymentMethod, targetAmount } = opts;
   if (pg === 'npay' || pg === 'npg') {
@@ -20,27 +21,48 @@ export function calcPgCommission(opts: CalcPgCommissionOptions): {
         const fee = targetAmount * (1 / 100);
         return {
           commission: fee > 275 ? 275 : Math.floor(fee),
-          rate: '1.00%(최대275원)',
+          rate: '1.00',
+          description: '% (최대275원)',
         };
       }
       case 'card': // 카드결제
-        return { commission: Math.floor(targetAmount * (2.2 / 100)), rate: '2.2%' };
+        return {
+          commission: Math.floor(targetAmount * (2.2 / 100)),
+          rate: '2.2',
+          description: '%',
+        };
       case 'point': // 네이버페이 포인트
-        return { commission: Math.floor(targetAmount * (3.74 / 100)), rate: '3.74%' };
+        return {
+          commission: Math.floor(targetAmount * (3.74 / 100)),
+          rate: '3.74',
+          description: '%',
+        };
       case 'cellphone': // 휴대폰 결제
-        return { commission: Math.floor(targetAmount * (3.85 / 100)), rate: '3.85%' };
+        return {
+          commission: Math.floor(targetAmount * (3.85 / 100)),
+          rate: '3.85',
+          description: '%',
+        };
       default:
     }
   }
   switch (paymentMethod) {
     case 'account': // 계좌입금
-      return { commission: Math.floor(targetAmount * (1.98 / 100)), rate: '1.98%' };
+      return {
+        commission: Math.floor(targetAmount * (1.98 / 100)),
+        rate: '1.98',
+        description: '%',
+      };
     case 'virtual': // 가상계좌 (고정수수료)
-      return { commission: 330, rate: '330원고정' };
+      return { commission: 330, rate: '330', description: '원 (고정)' };
     case 'cellphone': // 휴대폰결제
-      return { commission: Math.floor(targetAmount * (3.85 / 100)), rate: '3.85%' };
+      return {
+        commission: Math.floor(targetAmount * (3.85 / 100)),
+        rate: '3.85',
+        description: '%',
+      };
     case 'bank': // 무통장입금
     default:
-      return { commission: 0, rate: '무료' };
+      return { commission: 0, rate: '0', description: '무료' };
   }
 }

--- a/tools/ignore-admin-vercel-build.sh
+++ b/tools/ignore-admin-vercel-build.sh
@@ -1,0 +1,24 @@
+
+# Name of the app to check. Change this to your application name!
+APP=admin
+# Determine version of Nx installed
+NX_VERSION=$(node -e "console.log(require('./package.json').devDependencies['@nrwl/workspace'])")
+
+# Install @nrwl/workspace in order to run the affected command
+npm install -D @nrwl/workspace@$NX_VERSION --prefer-offline 
+
+npm install -D typescript
+
+# Run the affected command, comparing latest commit to the one before that
+npx nx affected:apps --plain --base HEAD~1 --head HEAD | grep $APP -q
+
+# Store result of the previous command (grep)
+IS_AFFECTED=$?
+
+if [ $IS_AFFECTED -eq 1 ]; then
+    echo "🛑 - Build cancelled"
+    exit 0
+elif [ $IS_AFFECTED -eq 0 ]; then
+    echo "✅ - Build can proceed"
+    exit 1
+fi


### PR DESCRIPTION
### 인프라
- [x] Route53 Record 개발환경 API, overlay 서버 레코드 추가

### 주문

  - [x]  특정 주문 검색시 쿼리 문법 에러 (검색어와 상태를 동시에 선택,작성했을 때 쿼리 에러 발생)
  - [x]  주문 목록 검색 및 필터링시, 현재 로그인된 판매자의 상품의 상태에 대한 필터링 적용에 대한 미흡된 부분 존재
(ex. 주문에 내 상품이 아닌 상품의 상태가 출고완료고, 내 상품이 결제확인인 경우, 주문목록과 주문상세보기에서 결제확인으로 표시되나, 결제확인으로 필터링(검색)했을 때 뜨지않고 출고완료로 필터링(검색)했을때 뜸)    
    ⇒ 주문목록의 '주문상태' 필터링을 내상품의 옵션의 상태와 주문 상태를 함께 고려한 값인 realStep을 계산한 뒤로 미루는 방식으로 변경하여 해결
    
  - [x]  부분출고가 완료된 주문에서 합포장 출고처리를 하였을 때, 부분출고가 완료된 주문 상품도 함께 출고처리가 되는 문제
    - 하나만 남아서 출고하는 경우에는 합포장 출고처리가 불가능하도록 막야아함.    
  - [x]  주문페이지에서 특정 이름("이지연")으로 검색하는 경우 에러가 발생하였다.
    
    → 조사결과, 주문의 step이 15, 25, 35, 40, 45, 50, 55, 60, 65, 70, 75, 85, 95, 99 가 아닌 값을 가지는 주문이 존재했다. 해당 오류가 발생한 이유도 step이 0으로 처리된 주문이 포함되어 조회되었기 때문이었다.
    
    → 퍼스트몰상에서 step이 범위를 벗어나는 주문에 대해서 어떻게 처리하나 확인했더니, 아예 조회가 불가능했다. 따라서 step 범위를 벗어나지 않는 주문만 조회하도록 처리함.
    
### 정산처리

  - [x]  정산 처리시에 '무료' 문자열 입력 불가 수정
  - [x]  정산 완료 목록에 결제 수단 및 PG사 정보 보여주기 추가
    
### 마이페이지 정산 내역 목록

  - [x]  작은 화면일 때, 컬럼이 줄어들어 데이터가 보이지 않는 경우 처리