### PR TITLE
[버그수정] 라이브 쇼핑 관리 페이지

### DIFF
--- a/apps/admin/pages/live-shopping/[liveShoppingId].tsx
+++ b/apps/admin/pages/live-shopping/[liveShoppingId].tsx
@@ -16,6 +16,7 @@ import {
   Divider,
   Input,
   Textarea,
+  Link,
 } from '@chakra-ui/react';
 import {
   AdminPageLayout,
@@ -117,8 +118,9 @@ export function GoodsDetail(): JSX.Element {
       'streamId' | 'sellerId' | 'goods_id' | 'contactId' | 'requests'
     >,
   ): Promise<void> => {
+    const videoUrlExist = Boolean(liveShopping[0]?.liveShoppingVideo.youtubeUrl);
     const dto = Object.assign(data, { id: liveShoppingId });
-    mutateAsync(dto).then(onSuccess).catch(onFail);
+    mutateAsync({ dto, videoUrlExist }).then(onSuccess).catch(onFail);
   };
 
   if (liveShoppingIsLoading || goods.isLoading)
@@ -202,6 +204,24 @@ export function GoodsDetail(): JSX.Element {
                 )}
               </Text>
             </Stack>
+            {liveShopping[0].progress === 'confirmed' &&
+              liveShopping[0].liveShoppingVideo && (
+                <Stack direction="row" alignItems="center">
+                  <Text as="span">영상 URL: </Text>
+                  <Text as="span" fontWeight="bold">
+                    <Link
+                      isTruncated
+                      href={liveShopping[0].liveShoppingVideo.youtubeUrl || ''}
+                      fontWeight="bold"
+                      colorScheme="blue"
+                      textDecoration="underline"
+                      isExternal
+                    >
+                      {liveShopping[0].liveShoppingVideo.youtubeUrl || ''}
+                    </Link>
+                  </Text>
+                </Stack>
+              )}
 
             <Divider />
 

--- a/libs/components/src/lib/BroadcasterChannelButton.tsx
+++ b/libs/components/src/lib/BroadcasterChannelButton.tsx
@@ -2,7 +2,7 @@ import { ExternalLinkIcon } from '@chakra-ui/icons';
 import { Tooltip, IconButton, ButtonProps } from '@chakra-ui/react';
 
 export type BroadcasterChannelButtonProps = {
-  channelUrl: string;
+  channelUrl: string | undefined;
 } & ButtonProps;
 export function BroadcasterChannelButton({
   channelUrl,
@@ -10,15 +10,19 @@ export function BroadcasterChannelButton({
   ...buttonProps
 }: BroadcasterChannelButtonProps): JSX.Element {
   return (
-    <Tooltip label="방송인 채널로 이동">
-      <IconButton
-        aria-label="open-broadcaster-channel-button"
-        icon={<ExternalLinkIcon />}
-        onClick={() => window.open(channelUrl, '_blank')}
-        size={size}
-        {...buttonProps}
-      />
-    </Tooltip>
+    <>
+      {channelUrl && (
+        <Tooltip label="방송인 채널로 이동">
+          <IconButton
+            aria-label="open-broadcaster-channel-button"
+            icon={<ExternalLinkIcon />}
+            onClick={() => window.open(channelUrl, '_blank')}
+            size={size}
+            {...buttonProps}
+          />
+        </Tooltip>
+      )}
+    </>
   );
 }
 

--- a/libs/components/src/lib/LiveShoppingDatePicker.tsx
+++ b/libs/components/src/lib/LiveShoppingDatePicker.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from '@chakra-ui/react';
+import { Box, Text, useColorModeValue } from '@chakra-ui/react';
 import TextField from '@material-ui/core/TextField';
 import { useFormContext } from 'react-hook-form';
 import dayjs from 'dayjs';
@@ -12,7 +12,7 @@ export function LiveShoppingDatePicker(props: {
   const { register } = useFormContext();
   const now = dayjs().format('YYYY-MM-DDThh:mm');
   return (
-    <Box>
+    <Box bg={useColorModeValue('inherit', 'gray.600')}>
       <Text>{title}</Text>
       <TextField
         {...register(`${registerName}`, { min: min || now })}

--- a/libs/components/src/lib/LiveShoppingList.tsx
+++ b/libs/components/src/lib/LiveShoppingList.tsx
@@ -5,7 +5,6 @@ import {
   Center,
   Divider,
   Flex,
-  IconButton,
   Link,
   Modal,
   ModalBody,
@@ -22,9 +21,7 @@ import {
   Textarea,
   Th,
   Thead,
-  Tooltip,
   Tr,
-  useColorModeValue,
   useDisclosure,
   useToast,
 } from '@chakra-ui/react';
@@ -41,7 +38,6 @@ import {
 } from '@project-lc/shared-types';
 import dayjs from 'dayjs';
 import { useState } from 'react';
-import { useQueryClient } from 'react-query';
 import { BroadcasterChannelButton } from '..';
 import { BroadcasterName } from './BroadcasterName';
 import { ConfirmDialog } from './ConfirmDialog';
@@ -64,9 +60,7 @@ export interface LiveShoppingWithSalesFrontType extends LiveShoppingWithoutDate 
 }
 
 export function LiveShoppingList(): JSX.Element {
-  const queryClient = useQueryClient();
   const toast = useToast();
-  const rowHoverColor = useColorModeValue('gray.100', 'gray.700');
   const { data: profileData } = useProfile();
 
   const { data, isLoading } = useLiveShoppingList({});
@@ -114,7 +108,6 @@ export function LiveShoppingList(): JSX.Element {
     mutateAsync(toDeleteLiveShoppingId)
       .then((isDeleted) => {
         if (isDeleted) {
-          queryClient.invalidateQueries('LiveShoppingList');
           toast({
             title: '삭제 완료하였습니다',
             status: 'success',
@@ -161,14 +154,7 @@ export function LiveShoppingList(): JSX.Element {
           !isSalesLoading &&
           liveShoppingWithSales.length !== 0 ? (
             liveShoppingWithSales.map((row, index) => (
-              <Tr
-                key={row.id}
-                onClick={() => handleDetailOnOpen(index)}
-                cursor="pointer"
-                _hover={{
-                  backgroundColor: rowHoverColor,
-                }}
-              >
+              <Tr key={row.id}>
                 <Td>{index + 1}</Td>
                 <Td>{row.goods.goods_name}</Td>
                 <Td>
@@ -236,17 +222,27 @@ export function LiveShoppingList(): JSX.Element {
                   )}
                 </Td>
                 <Td onClick={(e) => e.stopPropagation()}>
-                  {row.progress === 'registered' ? (
+                  <Stack>
                     <Button
                       size="xs"
-                      colorScheme="orange"
-                      onClick={() => {
-                        handleModalOpen(row.id);
-                      }}
+                      colorScheme="blue"
+                      onClick={() => handleDetailOnOpen(index)}
                     >
-                      삭제
+                      상세보기
                     </Button>
-                  ) : null}
+
+                    {row.progress === 'registered' ? (
+                      <Button
+                        size="xs"
+                        colorScheme="orange"
+                        onClick={() => {
+                          handleModalOpen(row.id);
+                        }}
+                      >
+                        삭제
+                      </Button>
+                    ) : null}
+                  </Stack>
                 </Td>
               </Tr>
             ))
@@ -259,130 +255,136 @@ export function LiveShoppingList(): JSX.Element {
           )}
         </Tbody>
       </Table>
-      {data && data.length !== 0 && !isLoading && (
-        <Modal isOpen={detailIsOpen} onClose={detailOnClose} size="lg">
-          <ModalOverlay />
-          <ModalContent>
-            <ModalHeader>상세정보</ModalHeader>
-            <ModalCloseButton />
-            <ModalBody>
-              <Stack spacing={4}>
-                {data[liveShoppingId].seller.sellerShop && (
-                  <Text as="span">
-                    판매자 : {data[liveShoppingId].seller.sellerShop.shopName}
-                  </Text>
-                )}
-
-                <Stack direction="row" alignItems="center">
-                  <Text as="span">진행상태</Text>
-                  <LiveShoppingProgressBadge
-                    progress={data[liveShoppingId].progress}
-                    broadcastStartDate={data[liveShoppingId].broadcastStartDate}
-                    broadcastEndDate={data[liveShoppingId].broadcastEndDate}
-                    sellEndDate={data[liveShoppingId].sellEndDate}
-                  />
-                  {data[liveShoppingId].progress === LIVE_SHOPPING_PROGRESS.취소됨 ? (
-                    <Text>사유 : {data[liveShoppingId].rejectionReason}</Text>
-                  ) : null}
-                </Stack>
-                <Divider />
-                <Stack direction="row" alignItems="center">
-                  <Text as="span">방송인: </Text>
-                  {data[liveShoppingId].broadcaster ? (
-                    <>
-                      <BroadcasterName data={data[liveShoppingId].broadcaster} />
-                      {data[liveShoppingId].broadcaster.channelUrl && (
-                        <BroadcasterChannelButton
-                          channelUrl={data[liveShoppingId].broadcaster.channelUrl}
-                        />
-                      )}
-                    </>
-                  ) : (
-                    <Text fontWeight="bold">미정</Text>
+      {data &&
+        data.length !== 0 &&
+        !isLoading &&
+        liveShoppingWithSales &&
+        !isSalesLoading && (
+          <Modal isOpen={detailIsOpen} onClose={detailOnClose} size="lg">
+            <ModalOverlay />
+            <ModalContent>
+              <ModalHeader>상세정보</ModalHeader>
+              <ModalCloseButton />
+              <ModalBody>
+                <Stack spacing={4}>
+                  {data[liveShoppingId]?.seller.sellerShop && (
+                    <Text as="span">
+                      판매자 : {data[liveShoppingId].seller.sellerShop.shopName}
+                    </Text>
                   )}
-                </Stack>
-                <Stack direction="row" alignItems="center">
-                  <Text as="span">방송시작 시간: </Text>
-                  <Text as="span" fontWeight="bold">
-                    {data[liveShoppingId].broadcastStartDate
-                      ? dayjs(data[liveShoppingId].broadcastStartDate).format(
-                          'YYYY/MM/DD HH:mm',
-                        )
-                      : '미정'}
-                  </Text>
-                </Stack>
 
-                <Stack direction="row" alignItems="center">
-                  <Text as="span">방송종료 시간: </Text>
-                  <Text as="span" fontWeight="bold">
-                    {data[liveShoppingId].broadcastEndDate
-                      ? dayjs(data[liveShoppingId].broadcastEndDate).format(
-                          'YYYY/MM/DD HH:mm',
-                        )
-                      : '미정'}
-                  </Text>
-                </Stack>
+                  <Stack direction="row" alignItems="center">
+                    <Text as="span">진행상태</Text>
+                    <LiveShoppingProgressBadge
+                      progress={data[liveShoppingId].progress}
+                      broadcastStartDate={data[liveShoppingId].broadcastStartDate}
+                      broadcastEndDate={data[liveShoppingId].broadcastEndDate}
+                      sellEndDate={data[liveShoppingId].sellEndDate}
+                    />
+                    {data[liveShoppingId].progress === LIVE_SHOPPING_PROGRESS.취소됨 ? (
+                      <Text>사유 : {data[liveShoppingId].rejectionReason}</Text>
+                    ) : null}
+                  </Stack>
+                  <Divider />
+                  <Stack direction="row" alignItems="center">
+                    <Text as="span">방송인: </Text>
+                    {data[liveShoppingId].broadcaster ? (
+                      <>
+                        <BroadcasterName data={data[liveShoppingId].broadcaster} />
+                        {data[liveShoppingId].broadcaster.channelUrl && (
+                          <BroadcasterChannelButton
+                            channelUrl={data[liveShoppingId].broadcaster.channelUrl}
+                          />
+                        )}
+                      </>
+                    ) : (
+                      <Text fontWeight="bold">미정</Text>
+                    )}
+                  </Stack>
+                  <Stack direction="row" alignItems="center">
+                    <Text as="span">방송시작 시간: </Text>
+                    <Text as="span" fontWeight="bold">
+                      {data[liveShoppingId].broadcastStartDate
+                        ? dayjs(data[liveShoppingId].broadcastStartDate).format(
+                            'YYYY/MM/DD HH:mm',
+                          )
+                        : '미정'}
+                    </Text>
+                  </Stack>
 
-                <Divider />
-                <Stack direction="row" alignItems="center">
-                  <Text as="span">판매시작 시간: </Text>
-                  <Text as="span" fontWeight="bold">
-                    {data[liveShoppingId].sellStartDate
-                      ? dayjs(data[liveShoppingId].sellStartDate).format(
-                          'YYYY/MM/DD HH:mm',
-                        )
-                      : '미정'}
-                  </Text>
-                </Stack>
+                  <Stack direction="row" alignItems="center">
+                    <Text as="span">방송종료 시간: </Text>
+                    <Text as="span" fontWeight="bold">
+                      {data[liveShoppingId].broadcastEndDate
+                        ? dayjs(data[liveShoppingId].broadcastEndDate).format(
+                            'YYYY/MM/DD HH:mm',
+                          )
+                        : '미정'}
+                    </Text>
+                  </Stack>
 
-                <Stack direction="row" alignItems="center">
-                  <Text as="span">판매종료 시간: </Text>
-                  <Text as="span" fontWeight="bold">
-                    {data[liveShoppingId].sellEndDate
-                      ? dayjs(data[liveShoppingId].sellEndDate).format('YYYY/MM/DD HH:mm')
-                      : '미정'}
-                  </Text>
-                </Stack>
+                  <Divider />
+                  <Stack direction="row" alignItems="center">
+                    <Text as="span">판매시작 시간: </Text>
+                    <Text as="span" fontWeight="bold">
+                      {data[liveShoppingId].sellStartDate
+                        ? dayjs(data[liveShoppingId].sellStartDate).format(
+                            'YYYY/MM/DD HH:mm',
+                          )
+                        : '미정'}
+                    </Text>
+                  </Stack>
 
-                <Divider />
-                <Stack direction="row" alignItems="center">
-                  <Text as="span">방송인 수수료: </Text>
-                  <Text as="span" fontWeight="bold">
-                    {data[liveShoppingId].broadcasterCommissionRate
-                      ? `${data[liveShoppingId].broadcasterCommissionRate}%`
-                      : '미정'}
-                  </Text>
-                </Stack>
+                  <Stack direction="row" alignItems="center">
+                    <Text as="span">판매종료 시간: </Text>
+                    <Text as="span" fontWeight="bold">
+                      {data[liveShoppingId].sellEndDate
+                        ? dayjs(data[liveShoppingId].sellEndDate).format(
+                            'YYYY/MM/DD HH:mm',
+                          )
+                        : '미정'}
+                    </Text>
+                  </Stack>
 
-                <Stack direction="row" alignItems="center">
-                  <Text as="span">판매 수수료: </Text>
-                  <Text as="span" fontWeight="bold">
-                    {data[liveShoppingId].whiletrueCommissionRate
-                      ? `${data[liveShoppingId].whiletrueCommissionRate}%`
-                      : '미정'}
-                  </Text>
-                </Stack>
+                  <Divider />
+                  <Stack direction="row" alignItems="center">
+                    <Text as="span">방송인 수수료: </Text>
+                    <Text as="span" fontWeight="bold">
+                      {data[liveShoppingId].broadcasterCommissionRate
+                        ? `${data[liveShoppingId].broadcasterCommissionRate}%`
+                        : '미정'}
+                    </Text>
+                  </Stack>
 
-                <Stack>
-                  <Text>요청사항</Text>
-                  <Textarea
-                    resize="none"
-                    rows={10}
-                    value={data[liveShoppingId].requests || ''}
-                    readOnly
-                  />
-                </Stack>
-              </Stack>
-            </ModalBody>
+                  <Stack direction="row" alignItems="center">
+                    <Text as="span">판매 수수료: </Text>
+                    <Text as="span" fontWeight="bold">
+                      {data[liveShoppingId].whiletrueCommissionRate
+                        ? `${data[liveShoppingId].whiletrueCommissionRate}%`
+                        : '미정'}
+                    </Text>
+                  </Stack>
 
-            <ModalFooter>
-              <Button colorScheme="blue" onClick={detailOnClose}>
-                닫기
-              </Button>
-            </ModalFooter>
-          </ModalContent>
-        </Modal>
-      )}
+                  <Stack>
+                    <Text>요청사항</Text>
+                    <Textarea
+                      resize="none"
+                      rows={10}
+                      value={data[liveShoppingId].requests || ''}
+                      readOnly
+                    />
+                  </Stack>
+                </Stack>
+              </ModalBody>
+
+              <ModalFooter>
+                <Button colorScheme="blue" onClick={detailOnClose}>
+                  닫기
+                </Button>
+              </ModalFooter>
+            </ModalContent>
+          </Modal>
+        )}
 
       <ConfirmDialog
         title="라이브 쇼핑 삭제"

--- a/libs/components/src/lib/LiveShoppingList.tsx
+++ b/libs/components/src/lib/LiveShoppingList.tsx
@@ -239,6 +239,7 @@ export function LiveShoppingList(): JSX.Element {
                   {row.progress === 'registered' ? (
                     <Button
                       size="xs"
+                      colorScheme="orange"
                       onClick={() => {
                         handleModalOpen(row.id);
                       }}

--- a/libs/components/src/lib/LiveShoppingList.tsx
+++ b/libs/components/src/lib/LiveShoppingList.tsx
@@ -179,14 +179,12 @@ export function LiveShoppingList(): JSX.Element {
                     sellEndDate={row.sellEndDate}
                   />
                 </Td>
-                <Td>
+                <Td onClick={(e) => e.stopPropagation()}>
                   <Flex alignItems="center">
                     <Box mr={1}>
                       <BroadcasterName data={row.broadcaster} />
                     </Box>
-                    <BroadcasterChannelButton
-                      channelUrl={data[liveShoppingId].broadcaster.channelUrl}
-                    />
+                    <BroadcasterChannelButton channelUrl={row.broadcaster?.channelUrl} />
                   </Flex>
                 </Td>
                 <Td>

--- a/libs/components/src/lib/OrderReturnStatusDialog.tsx
+++ b/libs/components/src/lib/OrderReturnStatusDialog.tsx
@@ -23,13 +23,11 @@ import {
   useToast,
 } from '@chakra-ui/react';
 import { useUpdateReturnStatusMutation } from '@project-lc/hooks';
-import {
-  convertFmReturnStatusToString,
-  FmOrderReturnBase,
-} from '@project-lc/shared-types';
+import { FmOrderReturnBase } from '@project-lc/shared-types';
 import { useForm } from 'react-hook-form';
 import { AiFillWarning } from 'react-icons/ai';
 import { RiErrorWarningFill } from 'react-icons/ri';
+import { FmReturnStatusBadge } from './FmReturnStatusBadge';
 
 interface OrderRetusnStatusForm {
   status: FmOrderReturnBase['status'];
@@ -84,7 +82,7 @@ export function OrderReturnStatusDialog({
           <ModalCloseButton />
           <ModalBody>
             <Text size="lg" mb={4}>
-              현재 반품 상태 : {convertFmReturnStatusToString(data.status)}
+              현재 반품 상태 : <FmReturnStatusBadge returnStatus={data.status} />
             </Text>
             {watch('status') === 'complete' && (
               <Alert mb={2} status="warning">

--- a/libs/hooks/src/lib/mutation/useCreateLiveShopping.tsx
+++ b/libs/hooks/src/lib/mutation/useCreateLiveShopping.tsx
@@ -16,7 +16,10 @@ export const useCreateLiveShoppingMutation = (): UseMutationResult<
     },
     {
       onSuccess: () => {
-        queryClient.invalidateQueries('Profile');
+        queryClient.invalidateQueries('LiveShoppingList', { refetchInactive: true });
+        queryClient.invalidateQueries('FmOrdersDuringLiveShoppingSales', {
+          refetchInactive: true,
+        });
       },
     },
   );

--- a/libs/hooks/src/lib/mutation/useDeleteLiveShoppingMutation.tsx
+++ b/libs/hooks/src/lib/mutation/useDeleteLiveShoppingMutation.tsx
@@ -1,5 +1,5 @@
 import { AxiosError } from 'axios';
-import { useMutation, UseMutationResult } from 'react-query';
+import { useMutation, UseMutationResult, useQueryClient } from 'react-query';
 import axios from '../../axios';
 
 export const deleteLiveShopping = async (liveShoppingId: number): Promise<boolean> => {
@@ -14,5 +14,14 @@ export const useDeleteLiveShopping = (): UseMutationResult<
   AxiosError,
   number
 > => {
-  return useMutation(deleteLiveShopping);
+  const queryClient = useQueryClient();
+
+  return useMutation(deleteLiveShopping, {
+    onSuccess: () => {
+      queryClient.invalidateQueries('LiveShoppingList', { refetchInactive: true });
+      queryClient.invalidateQueries('FmOrdersDuringLiveShoppingSales', {
+        refetchInactive: true,
+      });
+    },
+  });
 };

--- a/libs/hooks/src/lib/mutation/useUpdateLiveShoppingManageMutation.tsx
+++ b/libs/hooks/src/lib/mutation/useUpdateLiveShoppingManageMutation.tsx
@@ -12,9 +12,11 @@ type LiveShoppingManage = Omit<
 export const useUpdateLiveShoppingManageMutation = (): UseMutationResult<
   LiveShopping,
   AxiosError,
-  LiveShoppingManage
+  { dto: LiveShoppingManage; videoUrlExist?: boolean }
 > => {
-  return useMutation((dto: LiveShoppingManage) =>
-    axios.patch('/admin/live-shopping', dto).then((res) => res.data),
+  return useMutation((data: { dto: LiveShoppingManage; videoUrlExist?: boolean }) =>
+    axios
+      .patch('/admin/live-shopping', { dto: data.dto, videoUrlExist: data.videoUrlExist })
+      .then((res) => res.data),
   );
 };

--- a/libs/nest-modules/src/lib/admin/admin.controller.ts
+++ b/libs/nest-modules/src/lib/admin/admin.controller.ts
@@ -121,12 +121,17 @@ export class AdminController {
 
   @Patch('/live-shopping')
   @Header('Cache-Control', 'no-cache, no-store, must-revalidate')
-  async updateLiveShoppings(@Body() dto: LiveShoppingDTO): Promise<boolean> {
+  async updateLiveShoppings(
+    @Body() data: { dto: LiveShoppingDTO; videoUrlExist?: boolean },
+  ): Promise<boolean> {
     let videoId;
-    if (dto.videoUrl) {
-      videoId = await this.adminService.registVideoUrl(dto.videoUrl);
+    if (data.dto.videoUrl) {
+      if (data.videoUrlExist) {
+        await this.adminService.deleteVideoUrl(data.dto.id);
+      }
+      videoId = await this.adminService.registVideoUrl(data.dto.videoUrl);
     }
-    return this.adminService.updateLiveShoppings(dto, videoId);
+    return this.adminService.updateLiveShoppings(data.dto, videoId);
   }
 
   @Get('/live-shopping/broadcasters')

--- a/libs/nest-modules/src/lib/admin/admin.service.ts
+++ b/libs/nest-modules/src/lib/admin/admin.service.ts
@@ -265,6 +265,7 @@ export class AdminService {
           select: { youtubeUrl: true },
         },
       },
+      orderBy: { createDate: 'desc' },
     });
   }
 
@@ -309,8 +310,24 @@ export class AdminService {
     if (!videoUrl) {
       throw new Error(`비디오 등록 실패`);
     }
-
     return videoUrl.id;
+  }
+
+  public async deleteVideoUrl(liveShoppingId: number): Promise<boolean> {
+    const videoUrl = await this.prisma.liveShopping.update({
+      where: {
+        id: Number(liveShoppingId),
+      },
+      data: {
+        liveShoppingVideo: {
+          delete: true,
+        },
+      },
+    });
+    if (!videoUrl) {
+      throw new Error(`비디오 삭제 실패`);
+    }
+    return true;
   }
 
   /**


### PR DESCRIPTION
**라이브쇼핑**
- [x]  라이브 쇼핑 목록에서 방송인이 존재하지 않는 경우, Url을 조회하는 오류
- [x]  라이브 쇼핑 목록 테이블 내의 버튼 색상 변경하기
- [x]  방송인이 없는 경우, 방송국으로 이동하기 버튼 삭제
- [x] 행클릭에서 버튼식으로 변경

**반품**
- [x] 반품 상태 관리 다이얼로그에서 현재 반품 상태를 뱃지로 변경

**관리자**
- [x] 라이브 쇼핑에 등록된 비디오가 있을 때, 새로운 비디오를 등록하는 경우 기존 비디오 url은 삭제 처리
- [x] 다크모드에서 날짜 입력칸 안보이는 현상 수정