### PR TITLE
[2차 스프린트 피드백 반영] 판매자페이지 상품 옵션 입력 폼 수정

### DIFF
--- a/libs/components/src/lib/GoodsEditForm.tsx
+++ b/libs/components/src/lib/GoodsEditForm.tsx
@@ -58,11 +58,13 @@ export function GoodsEditForm({ goodsData }: { goodsData: GoodsByIdRes }): JSX.E
       cancel_type: goodsData ? goodsData.cancel_type : '0', // 청약철회, 기본 - 청약철회가능 0
       // 판매옵션
       option_use: goodsData ? goodsData.option_use : '1', // 옵션사용여부, 기본 - 옵션사용 1
-      option_title: goodsData?.options[0].option_title || '',
+      option_title: '',
+      option_values: '',
       options: goodsData
         ? goodsData.options.map((opt) => ({
             id: opt.id,
             option_type: opt.option_type,
+            option_title: opt.option_title || '',
             option1: opt.option1 || '',
             consumer_price: Number(opt.consumer_price),
             price: Number(opt.price),
@@ -71,18 +73,7 @@ export function GoodsEditForm({ goodsData }: { goodsData: GoodsByIdRes }): JSX.E
               stock: opt.supply.stock,
             },
           }))
-        : [
-            {
-              option_type: 'direct',
-              option1: '',
-              consumer_price: 0,
-              price: 0,
-              option_view: 'Y',
-              supply: {
-                stock: 0,
-              },
-            },
-          ],
+        : [],
       // 상품사진
       image: goodsData?.image || [],
       // 상세설명
@@ -121,6 +112,7 @@ export function GoodsEditForm({ goodsData }: { goodsData: GoodsByIdRes }): JSX.E
       id,
       options,
       option_title,
+      option_values,
       common_contents_name,
       common_contents_type,
       common_contents,
@@ -137,7 +129,7 @@ export function GoodsEditForm({ goodsData }: { goodsData: GoodsByIdRes }): JSX.E
     let goodsDto: RegistGoodsDto = {
       ...goodsFormData,
       image,
-      options: addGoodsOptionInfo(options, option_title),
+      options: addGoodsOptionInfo(options),
       option_use: options.length > 1 ? '1' : '0',
       max_purchase_ea: Number(max_purchase_ea) || 0,
       min_purchase_ea: Number(min_purchase_ea) || 0,
@@ -157,6 +149,15 @@ export function GoodsEditForm({ goodsData }: { goodsData: GoodsByIdRes }): JSX.E
       // 등록된 사진이 없는 경우
       toast({
         title: '상품 사진을 1개 이상 등록해주세요',
+        status: 'warning',
+      });
+      return;
+    }
+
+    if (options.length === 0) {
+      // 등록된 옵션이 없는 경우
+      toast({
+        title: '상품 옵션을 1개 이상 등록해주세요',
         status: 'warning',
       });
       return;

--- a/libs/components/src/lib/GoodsEditForm.tsx
+++ b/libs/components/src/lib/GoodsEditForm.tsx
@@ -242,7 +242,6 @@ export function GoodsEditForm({ goodsData }: { goodsData: GoodsByIdRes }): JSX.E
       <Stack p={2} spacing={5} as="form" onSubmit={handleSubmit(editGoods)}>
         <Stack
           py={4}
-          mx={-2}
           direction="row"
           position="sticky"
           bgColor={fixedStackBgColor}

--- a/libs/components/src/lib/GoodsRegistCommonInfo.tsx
+++ b/libs/components/src/lib/GoodsRegistCommonInfo.tsx
@@ -222,7 +222,7 @@ export function GoodsRegistCommonInfo(): JSX.Element {
   const commonContentsType = watch('common_contents_type');
 
   return (
-    <SectionWithTitle title="상품 공통 정보 *">
+    <SectionWithTitle title="상품 공통 정보 *" variant="outlined">
       <Stack>
         <RadioGroup
           onChange={(value) => {

--- a/libs/components/src/lib/GoodsRegistCommonInfo.tsx
+++ b/libs/components/src/lib/GoodsRegistCommonInfo.tsx
@@ -42,6 +42,11 @@ import SectionWithTitle from './SectionWithTitle';
 
 const SunEditor = dynamic(() => import('suneditor-react'), {
   ssr: false,
+  loading: () => (
+    <Center>
+      <Spinner />
+    </Center>
+  ),
 });
 
 /** 상품공통정보목록 셀렉트박스 *********************** */

--- a/libs/components/src/lib/GoodsRegistDataBasic.tsx
+++ b/libs/components/src/lib/GoodsRegistDataBasic.tsx
@@ -20,7 +20,7 @@ export function GoodsRegistDataBasic(): JSX.Element {
     formState: { errors },
   } = useFormContext<RegistGoodsDto>();
   return (
-    <SectionWithTitle title="기본정보">
+    <SectionWithTitle title="기본정보" variant="outlined">
       <Stack>
         <FormControl id="goods_name" isInvalid={!!errors.goods_name}>
           <FormLabel>

--- a/libs/components/src/lib/GoodsRegistDataOptions.tsx
+++ b/libs/components/src/lib/GoodsRegistDataOptions.tsx
@@ -238,7 +238,7 @@ function UseOptionInput(): JSX.Element {
           flexWrap="wrap"
         >
           {/* 삭제버튼과 옵션명:옵션값 */}
-          <HStack mr={1} flex={0.5}>
+          <HStack mr={1} flex={0.5} minWidth={150}>
             <CloseButton onClick={() => remove(index)} />
             <Text minWidth="60px">
               {`${getValues(`options.${index}.option_title`)} : ${getValues(
@@ -350,7 +350,7 @@ export function GoodsRegistDataOptions(): JSX.Element {
   );
 
   return (
-    <SectionWithTitle title="판매 옵션">
+    <SectionWithTitle title="판매 옵션" variant="outlined">
       <Text fontWeight="bold">옵션 사용 여부</Text>
       {/* onChange 시 옵션초기화 */}
       <Box mb={4}>

--- a/libs/components/src/lib/GoodsRegistDataOptions.tsx
+++ b/libs/components/src/lib/GoodsRegistDataOptions.tsx
@@ -238,7 +238,7 @@ function UseOptionInput(): JSX.Element {
           flexWrap="wrap"
         >
           {/* 삭제버튼과 옵션명:옵션값 */}
-          <HStack mr={1}>
+          <HStack mr={1} flex={0.5}>
             <CloseButton onClick={() => remove(index)} />
             <Text minWidth="60px">
               {`${getValues(`options.${index}.option_title`)} : ${getValues(

--- a/libs/components/src/lib/GoodsRegistDataOptions.tsx
+++ b/libs/components/src/lib/GoodsRegistDataOptions.tsx
@@ -12,14 +12,17 @@ import {
   RadioGroup,
   Stack,
   Text,
+  Kbd,
 } from '@chakra-ui/react';
 import { useDisplaySize } from '@project-lc/hooks';
 import { useCallback } from 'react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
+import { InfoIcon } from '@chakra-ui/icons';
 import { boxStyle } from '../constants/commonStyleProps';
 import { GoodsRegistRadio } from './GoodsRegistDataSales';
 import { GoodsFormOption, GoodsFormValues } from './GoodsRegistForm';
 import SectionWithTitle from './SectionWithTitle';
+import TextWithPopperButton from './TextWithPopperButton';
 
 export function GoodsOptionInput({
   label,
@@ -178,8 +181,8 @@ function UseOptionInput(): JSX.Element {
         isInvalid={!!errors.option_title || !!errors.option_values}
       >
         <HStack flexWrap="wrap">
-          <HStack>
-            <FormLabel>옵션명</FormLabel>
+          <HStack mr={2}>
+            <FormLabel m={0}>옵션명</FormLabel>
             <Input
               {...register('option_title')}
               size="sm"
@@ -190,7 +193,18 @@ function UseOptionInput(): JSX.Element {
           </HStack>
 
           <HStack>
-            <FormLabel>옵션값</FormLabel>
+            <FormLabel m={0}>
+              <TextWithPopperButton
+                title="옵션값"
+                iconAriaLabel="옵션값 설명"
+                icon={<InfoIcon />}
+              >
+                <Text>
+                  <Kbd>,</Kbd> 로 옵션값을 구분하여 입력하면 <br />
+                  여러 옵션값을 한 번에 입력할 수 있습니다
+                </Text>
+              </TextWithPopperButton>
+            </FormLabel>
             <Input
               isInvalid={!!errors.option_values}
               {...register('option_values')}

--- a/libs/components/src/lib/GoodsRegistDataOptions.tsx
+++ b/libs/components/src/lib/GoodsRegistDataOptions.tsx
@@ -14,11 +14,11 @@ import {
   Text,
 } from '@chakra-ui/react';
 import { useDisplaySize } from '@project-lc/hooks';
+import { useCallback } from 'react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { boxStyle } from '../constants/commonStyleProps';
-import { RequiredMark } from './GoodsRegistDataBasic';
 import { GoodsRegistRadio } from './GoodsRegistDataSales';
-import { GoodsFormValues } from './GoodsRegistForm';
+import { GoodsFormOption, GoodsFormValues } from './GoodsRegistForm';
 import SectionWithTitle from './SectionWithTitle';
 
 export function GoodsOptionInput({
@@ -81,8 +81,12 @@ function NoOptionInput(): JSX.Element {
 function UseOptionInput(): JSX.Element {
   const {
     watch,
+    getValues,
+    setValue,
     control,
     register,
+    setError,
+    clearErrors,
     formState: { errors },
   } = useFormContext<GoodsFormValues>();
   const { fields, append, remove } = useFieldArray<GoodsFormValues, 'options', 'fieldId'>(
@@ -97,8 +101,59 @@ function UseOptionInput(): JSX.Element {
   const inputWidth = isMobileSize ? '74px' : 'auto';
 
   const addOption = (): void => {
-    append({
-      option1: '',
+    // 1. 옵션명, 옵션값 체크 ----------------------------------
+    const optionTitle = getValues('option_title').trim();
+    const optionValues = getValues('option_values').trim();
+
+    const existOptions = getValues('options');
+
+    // 옵션명은 최대 5개까지 등록 가능(퍼스트몰 제한)
+    const existOptionUniqueTitles = [
+      ...new Set(existOptions.map((opt) => opt.option_title)),
+    ];
+    const overMaxOptionTitleCount =
+      existOptionUniqueTitles.length >= 5 &&
+      !existOptionUniqueTitles.includes(optionTitle);
+
+    const hasError = !optionTitle || !optionValues || overMaxOptionTitleCount;
+
+    if (!optionTitle) {
+      setError('option_title', {
+        type: 'validate',
+        message: '옵션명을 입력해주세요',
+      });
+    }
+    if (!optionValues) {
+      setError('option_values', {
+        type: 'validate',
+        message: '옵션값을 입력해주세요',
+      });
+    }
+    if (overMaxOptionTitleCount) {
+      setError('option_title', {
+        type: 'error',
+        message: '옵션명은 최대 5개까지 등록 가능합니다',
+      });
+    }
+
+    if (hasError) return;
+
+    // 2. 중복되는 옵션값 제거 ----------------------
+    const validOptionValues = optionValues
+      .split(',')
+      .map((value) => value.trim())
+      .filter(
+        (value) =>
+          !existOptions.find(
+            (existOpt) =>
+              existOpt.option_title === optionTitle && existOpt.option1 === value,
+          ),
+      );
+
+    // 3. 옵션값 등록 ------------------
+    const willBeAppendedValues: GoodsFormOption[] = validOptionValues.map((optValue) => ({
+      option_title: optionTitle,
+      option1: optValue,
       consumer_price: 0,
       price: 0,
       option_view: 'Y',
@@ -106,34 +161,60 @@ function UseOptionInput(): JSX.Element {
       supply: {
         stock: 0,
       },
-    });
+    }));
+    append(willBeAppendedValues);
+
+    // 4. 오류, 옵션명, 옵션값  초기화  ------------------
+    clearErrors(['option_title', 'option_values']);
+    setValue('option_title', '');
+    setValue('option_values', '');
   };
 
   return (
     <Stack>
-      <HStack>
-        <FormControl id="option_title" isInvalid={!!errors.option_title}>
+      {/* 옵션명 & 옵션값 입력부분 */}
+      <FormControl
+        id="option_title_values"
+        isInvalid={!!errors.option_title || !!errors.option_values}
+      >
+        <HStack flexWrap="wrap">
           <HStack>
-            <FormLabel>
-              옵션명 <RequiredMark />
-            </FormLabel>
-
+            <FormLabel>옵션명</FormLabel>
             <Input
-              {...register('option_title', { required: '옵션명을 입력해주세요.' })}
+              {...register('option_title')}
               size="sm"
               w={150}
-              placeholder="옵션명을 입력해주세요"
+              isInvalid={!!errors.option_title}
+              placeholder="색상"
             />
           </HStack>
-          {errors.option_title && (
-            <FormErrorMessage>{errors.option_title.message}</FormErrorMessage>
-          )}
-        </FormControl>
-        <Button onClick={addOption} ml={2}>
-          옵션값 추가
-        </Button>
-      </HStack>
 
+          <HStack>
+            <FormLabel>옵션값</FormLabel>
+            <Input
+              isInvalid={!!errors.option_values}
+              {...register('option_values')}
+              size="sm"
+              w={150}
+              placeholder="검정, 노랑, 파랑"
+            />
+          </HStack>
+
+          <Button size="sm" onClick={addOption} ml={2}>
+            옵션값 추가
+          </Button>
+        </HStack>
+
+        {errors.option_title && (
+          <FormErrorMessage>{errors.option_title.message}</FormErrorMessage>
+        )}
+        {errors.option_values && (
+          <FormErrorMessage>{errors.option_values.message}</FormErrorMessage>
+        )}
+      </FormControl>
+
+      {/* 입력된 옵션값 표시부분 - 가격, 노출여부 조절 */}
+      {fields.length === 0 && <Text>상품 옵션을 추가해주세요</Text>}
       {fields.map((field, index) => (
         <Stack
           key={field.fieldId}
@@ -142,23 +223,15 @@ function UseOptionInput(): JSX.Element {
           spacing={1}
           flexWrap="wrap"
         >
-          {/* 옵션값 */}
-          <HStack mb={1}>
+          {/* 삭제버튼과 옵션명:옵션값 */}
+          <HStack mr={1}>
             <CloseButton onClick={() => remove(index)} />
-
-            <HStack>
-              <Text minWidth="60px">
-                옵션값 <RequiredMark />
-              </Text>
-              <Input
-                {...register(`options.${index}.option1` as const, {
-                  required: '옵션값을 입력해주세요',
-                })}
-                size="sm"
-              />
-            </HStack>
+            <Text minWidth="60px">
+              {`${getValues(`options.${index}.option_title`)} : ${getValues(
+                `options.${index}.option1`,
+              )} ,`}
+            </Text>
           </HStack>
-          {/* 옵션값 */}
 
           <HStack mb={1}>
             {/* 정가 */}
@@ -237,6 +310,31 @@ const OPTION_USE = [
 export function GoodsRegistDataOptions(): JSX.Element {
   const { watch, setValue } = useFormContext<GoodsFormValues>();
 
+  const initializeOptions = useCallback(
+    (value: string) => {
+      if (value === '1') {
+        // 옵션 사용하는 경우
+        setValue('options', []);
+      } else {
+        // 옵션 사용 안하는 경우
+        setValue('options', [
+          {
+            option_type: 'direct',
+            option1: '',
+            option_title: '',
+            consumer_price: 0,
+            price: 0,
+            option_view: 'Y',
+            supply: {
+              stock: 0,
+            },
+          },
+        ]);
+      }
+    },
+    [setValue],
+  );
+
   return (
     <SectionWithTitle title="판매 옵션">
       <Text fontWeight="bold">옵션 사용 여부</Text>
@@ -245,21 +343,7 @@ export function GoodsRegistDataOptions(): JSX.Element {
         <GoodsRegistRadio
           name="option_use"
           values={OPTION_USE}
-          onChange={() => {
-            setValue('option_title', '');
-            setValue('options', [
-              {
-                option_type: 'direct',
-                option1: '',
-                consumer_price: 0,
-                price: 0,
-                option_view: 'Y',
-                supply: {
-                  stock: 0,
-                },
-              },
-            ]);
-          }}
+          onChange={initializeOptions}
         />
         <Text fontWeight="normal" as="span" color="gray.500" fontSize="sm">
           (사용 여부 변경시 기존에 추가했던 옵션은 모두 사라집니다.)

--- a/libs/components/src/lib/GoodsRegistDataOptions.tsx
+++ b/libs/components/src/lib/GoodsRegistDataOptions.tsx
@@ -238,13 +238,12 @@ function UseOptionInput(): JSX.Element {
           flexWrap="wrap"
         >
           {/* 삭제버튼과 옵션명:옵션값 */}
-          <HStack mr={1} flex={0.5} minWidth={150}>
+          <HStack mr={1} flexGrow={0.5} flexShrink={0} minWidth={150}>
             <CloseButton onClick={() => remove(index)} />
             <Text minWidth="60px">
-              {`${getValues(`options.${index}.option_title`)} : ${getValues(
-                `options.${index}.option1`,
-              )} ,`}
+              {`${getValues(`options.${index}.option_title`)} :`}
             </Text>
+            <Input {...register(`options.${index}.option1` as const)} size="sm" />
           </HStack>
 
           <HStack mb={1}>

--- a/libs/components/src/lib/GoodsRegistDataSales.tsx
+++ b/libs/components/src/lib/GoodsRegistDataSales.tsx
@@ -52,7 +52,7 @@ export function GoodsRegistRadio({
 
 export function GoodsRegistDataSales(): JSX.Element {
   return (
-    <SectionWithTitle title="판매정보">
+    <SectionWithTitle title="판매정보" variant="outlined">
       <Stack>
         <Stack spacing={{ base: 2, sm: 6 }} direction={{ base: 'column', sm: 'row' }}>
           <Text mr="24px">판매상태</Text>

--- a/libs/components/src/lib/GoodsRegistDescription.tsx
+++ b/libs/components/src/lib/GoodsRegistDescription.tsx
@@ -3,12 +3,14 @@ import { EditIcon } from '@chakra-ui/icons';
 import {
   Box,
   Button,
+  Center,
   Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalHeader,
   ModalOverlay,
+  Spinner,
   Stack,
   useDisclosure,
 } from '@chakra-ui/react';
@@ -24,6 +26,11 @@ import SectionWithTitle from './SectionWithTitle'; // Import Sun Editor's CSS Fi
 
 const SunEditor = dynamic(() => import('suneditor-react'), {
   ssr: false,
+  loading: () => (
+    <Center>
+      <Spinner />
+    </Center>
+  ),
 });
 
 export function GoodsRegistDescription(): JSX.Element {

--- a/libs/components/src/lib/GoodsRegistDescription.tsx
+++ b/libs/components/src/lib/GoodsRegistDescription.tsx
@@ -61,7 +61,7 @@ export function GoodsRegistDescription(): JSX.Element {
   }, [detailContents]);
 
   return (
-    <SectionWithTitle title="상세설명 *">
+    <SectionWithTitle title="상세설명 *" variant="outlined">
       <Stack>
         <Box>
           <Button rightIcon={<EditIcon />} onClick={onOpen}>

--- a/libs/components/src/lib/GoodsRegistExtraInfo.tsx
+++ b/libs/components/src/lib/GoodsRegistExtraInfo.tsx
@@ -20,7 +20,7 @@ export function GoodsRegistExtraInfo(): JSX.Element {
     formState: { errors },
   } = useFormContext<RegistGoodsDto>();
   return (
-    <SectionWithTitle title="기타정보">
+    <SectionWithTitle title="기타정보" variant="outlined">
       {/* 최소 구매 수량 */}
       <FormControl mb={2}>
         <FormLabel fontWeight="bold">최소 구매 수량</FormLabel>

--- a/libs/components/src/lib/GoodsRegistMemo.tsx
+++ b/libs/components/src/lib/GoodsRegistMemo.tsx
@@ -6,7 +6,7 @@ import SectionWithTitle from './SectionWithTitle';
 export function GoodsRegistMemo(): JSX.Element {
   const { register } = useFormContext<RegistGoodsDto>();
   return (
-    <SectionWithTitle title="메모">
+    <SectionWithTitle title="메모" variant="outlined">
       <Textarea {...register('admin_memo')} resize="none" maxLength={500} />
     </SectionWithTitle>
   );

--- a/libs/components/src/lib/GoodsRegistPictures.tsx
+++ b/libs/components/src/lib/GoodsRegistPictures.tsx
@@ -247,7 +247,7 @@ export function GoodsRegistPictures(): JSX.Element {
   const goodsId = watch('id');
 
   return (
-    <SectionWithTitle title="상품사진 *">
+    <SectionWithTitle title="상품사진 *" variant="outlined">
       <Stack spacing={4}>
         <Box>
           <Button onClick={onOpen}>사진 등록하기</Button>

--- a/libs/components/src/lib/GoodsRegistShippingPolicy.tsx
+++ b/libs/components/src/lib/GoodsRegistShippingPolicy.tsx
@@ -416,7 +416,7 @@ export function GoodsRegistShippingPolicy(): JSX.Element {
   };
 
   return (
-    <SectionWithTitle title="배송비 *">
+    <SectionWithTitle title="배송비 *" variant="outlined">
       <HStack mb={4}>
         <Text>배송비 정책을 {data && data.length === 0 ? '생성' : '선택'}해주세요</Text>
         <Button onClick={onRegistModalOpen}>생성하기</Button>

--- a/libs/components/src/lib/SectionWithTitle.tsx
+++ b/libs/components/src/lib/SectionWithTitle.tsx
@@ -5,11 +5,23 @@ export function SectionWithTitle({
   title,
   children,
   disableDivider = false,
+  variant = 'unstyle',
 }: {
   children: React.ReactNode;
   title: string;
   disableDivider?: boolean;
+  variant?: 'unstyle' | 'outlined';
 }): JSX.Element {
+  if (variant === 'outlined') {
+    return (
+      <Box as="section" id={title} borderWidth="1px" borderRadius="sm" p={4}>
+        <Heading as="h4" size="md" isTruncated my={2}>
+          {title}
+        </Heading>
+        {children}
+      </Box>
+    );
+  }
   return (
     <>
       {disableDivider ? null : <Divider />}


### PR DESCRIPTION
로버트님 피드백 반영
- [x]  구성별 바운더리가 조금 더 명확, 선명
- [x]  옵션 값에 예시 데이터 추가
- [x]  옵션명 또한 옵션 값 옆에 포함되도록



- 옵션명 추가할 수 있도록 수정(최대 5개 - 퍼스트몰 옵션명 5개 제한)
  - (옵션명 = `<select>` 컴포넌트 1개, 옵션값 = `<select>`안에 렌더링되는 `<option>` 과 유사)
- 옵션값을 `,`로 구분하여 입력할 수 있는 형태로 수정
  - 옵션값 옆에 i 버튼으로 설명 추가함
  - 옵션값을 콤마로 구분하여 입력하는 형태는 쇼핑몰 옵션 입력시 일반적인 형태로 보임 - 퍼스트몰, 네이버 스마트스토어 옵션입력부분 참고하였음)
- 옵션명, 옵션값 placeholder 추가
- 상품등록, 수정페이지 섹션 스타일 수정(테두리 추가하여 각 영역별 구분을 명확하게 함


---
1. 옵션명, 옵션값 입력 후 버튼을 누르면
<img width="583" alt="스크린샷 2021-11-09 오후 2 42 52" src="https://user-images.githubusercontent.com/18395475/140869446-3d3d7879-0e73-4411-8e0e-5e0ccba1f5a2.png">
2. 옵션명:옵션값 형태의 옵션이 생성. 여기서 가격, 노출정보 입력하는 형태
<img width="864" alt="스크린샷 2021-11-09 오후 2 43 01" src="https://user-images.githubusercontent.com/18395475/140869440-1958546c-9e21-44d0-b102-61dbc06f27e3.png">


