### PR TITLE
[2차 스프린트 피드백 반영] 상품 등록 관련 사용성 개선 피드백 반영

### DIFF
--- a/libs/components/src/constants/navigation.ts
+++ b/libs/components/src/constants/navigation.ts
@@ -4,6 +4,7 @@ export interface NavItem {
   // children?: Array<NavItem>;
   href: string;
   needLogin?: boolean;
+  isExternal?: boolean;
 }
 
 export const mainNavItems: Array<NavItem> = [
@@ -15,6 +16,7 @@ export const mainNavItems: Array<NavItem> = [
   {
     label: '크크마켓',
     href: 'https://k-kmarket.com/',
+    isExternal: true,
   },
 ];
 

--- a/libs/components/src/lib/GoodsRegistCommonInfo.tsx
+++ b/libs/components/src/lib/GoodsRegistCommonInfo.tsx
@@ -242,23 +242,29 @@ export function GoodsRegistCommonInfo(): JSX.Element {
           </Stack>
         </RadioGroup>
 
-        <Box>
-          {watch('common_contents_type') === 'new' ? (
-            <Button
-              aria-label="Search database"
-              rightIcon={<EditIcon />}
-              onClick={onOpen}
-            >
-              공통정보쓰기
-            </Button>
-          ) : (
-            <GoodsCommonInfoList
-              goodsInfoId={commonInfoId}
-              onCommonInfoChange={onCommonInfoChange}
-              onGoodsInfoDelete={clearGoodsInfoForNewInfo}
-            />
-          )}
-        </Box>
+        {watch('common_contents_type') === 'new' ? (
+          <Stack>
+            <Text>
+              ** 신규 등록 으로 작성한 상품 공통 정보는 상품 등록을 완료 할 시 기존 정보
+              리스트에 자동 추가됩니다.
+            </Text>
+            <Box>
+              <Button
+                aria-label="Search database"
+                rightIcon={<EditIcon />}
+                onClick={onOpen}
+              >
+                공통정보쓰기
+              </Button>
+            </Box>
+          </Stack>
+        ) : (
+          <GoodsCommonInfoList
+            goodsInfoId={commonInfoId}
+            onCommonInfoChange={onCommonInfoChange}
+            onGoodsInfoDelete={clearGoodsInfoForNewInfo}
+          />
+        )}
 
         <Box
           ref={viewer}

--- a/libs/components/src/lib/GoodsRegistDescription.tsx
+++ b/libs/components/src/lib/GoodsRegistDescription.tsx
@@ -13,6 +13,7 @@ import {
   Spinner,
   Stack,
   useDisclosure,
+  Text,
 } from '@chakra-ui/react';
 import dynamic from 'next/dynamic';
 import { useEffect, useRef } from 'react';
@@ -63,6 +64,7 @@ export function GoodsRegistDescription(): JSX.Element {
   return (
     <SectionWithTitle title="상세설명 *" variant="outlined">
       <Stack>
+        <Text>제품 상세 내용이 담긴 대형 이미지는 이곳에 첨부해주세요.</Text>
         <Box>
           <Button rightIcon={<EditIcon />} onClick={onOpen}>
             설명 쓰기

--- a/libs/components/src/lib/GoodsRegistForm.tsx
+++ b/libs/components/src/lib/GoodsRegistForm.tsx
@@ -7,6 +7,9 @@ import {
   theme,
   useColorModeValue,
   useToast,
+  useDisclosure,
+  Alert,
+  AlertIcon,
 } from '@chakra-ui/react';
 import {
   s3,
@@ -27,6 +30,7 @@ import GoodsRegistExtraInfo from './GoodsRegistExtraInfo';
 import GoodsRegistMemo from './GoodsRegistMemo';
 import GoodsRegistPictures from './GoodsRegistPictures';
 import GoodsRegistShippingPolicy from './GoodsRegistShippingPolicy';
+import { ConfirmDialog } from './ConfirmDialog';
 
 export type GoodsFormOption = Omit<GoodsOptionDto, 'default_option'> & {
   id?: number;
@@ -109,6 +113,7 @@ export function GoodsRegistForm(): JSX.Element {
   const { mutateAsync: createGoodsCommonInfo } = useCreateGoodsCommonInfo();
   const toast = useToast();
   const router = useRouter();
+  const goBackAlertDialog = useDisclosure();
 
   const methods = useForm<GoodsFormValues>({
     defaultValues: {
@@ -265,10 +270,7 @@ export function GoodsRegistForm(): JSX.Element {
           justifyContent="space-between"
           zIndex={theme.zIndices.sticky}
         >
-          <Button
-            leftIcon={<ChevronLeftIcon />}
-            onClick={() => router.push('/mypage/goods')}
-          >
+          <Button leftIcon={<ChevronLeftIcon />} onClick={goBackAlertDialog.onOpen}>
             상품목록 돌아가기
           </Button>
           <Button type="submit" colorScheme="blue" isLoading={isLoading}>
@@ -303,6 +305,25 @@ export function GoodsRegistForm(): JSX.Element {
 
         {/* 메모 - textArea */}
         <GoodsRegistMemo />
+
+        {/* 뒤로가기 - 입력된 정보 사라짐 안내 다이얼로그 */}
+        <ConfirmDialog
+          title="상품 목록으로 돌아가기"
+          isOpen={goBackAlertDialog.isOpen}
+          onClose={goBackAlertDialog.onClose}
+          onConfirm={async () => {
+            router.push('/mypage/goods');
+          }}
+        >
+          <Alert status="warning">
+            <AlertIcon />
+            <Stack spacing={1}>
+              <Text> 목록으로 이동시 입력했던 정보는 모두 사라집니다!</Text>
+              <Text>상품 정보를 모두 입력했다면 등록 버튼을 눌러 완료해주세요</Text>
+            </Stack>
+          </Alert>
+          <Text mt={3}>정말 상품 목록으로 이동하시겠습니까?</Text>
+        </ConfirmDialog>
 
         {isLoading && (
           <Center

--- a/libs/components/src/lib/GoodsRegistPictures.tsx
+++ b/libs/components/src/lib/GoodsRegistPictures.tsx
@@ -249,6 +249,7 @@ export function GoodsRegistPictures(): JSX.Element {
   return (
     <SectionWithTitle title="상품사진 *" variant="outlined">
       <Stack spacing={4}>
+        <Text>썸네일 이미지로 사용됩니다. 가로세로 1:1 비율인 이미지를 추천합니다.</Text>
         <Box>
           <Button onClick={onOpen}>사진 등록하기</Button>
         </Box>

--- a/libs/components/src/lib/Navbar.tsx
+++ b/libs/components/src/lib/Navbar.tsx
@@ -172,6 +172,7 @@ const DesktopNav = (): JSX.Element => {
                 textDecoration: 'none',
                 color: linkHoverColor,
               }}
+              isExternal={navItem.isExternal}
             >
               {navItem.label}
             </Link>

--- a/libs/components/src/lib/ShippingOptionFixedApply.tsx
+++ b/libs/components/src/lib/ShippingOptionFixedApply.tsx
@@ -7,7 +7,13 @@ import { Controller, useForm } from 'react-hook-form';
 import { KOREA_PROVINCES } from '../constants/address';
 import { ErrorText } from './ShippingOptionIntervalApply';
 
-// 배송비 고정 옵션 적용
+/** 지역선택 셀렉트박스 강조 스타일 */
+export const areaSelectStyle = {
+  bg: 'orange.100',
+  color: 'black',
+};
+
+/** 배송비 고정 옵션 적용 */
 export function ShippingOptionFixedApply({
   shippingSetType,
 }: {
@@ -110,7 +116,7 @@ export function ShippingOptionFixedApply({
           }}
           render={({ field }) => {
             return (
-              <Select w={120} {...field}>
+              <Select w={120} {...field} {...areaSelectStyle}>
                 {deliveryLimit === 'limit' || shippingSetType === 'add' ? (
                   ['지역 선택', ...KOREA_PROVINCES].map((area) => (
                     <option key={area} value={area}>

--- a/libs/components/src/lib/ShippingOptionIntervalApply.tsx
+++ b/libs/components/src/lib/ShippingOptionIntervalApply.tsx
@@ -8,6 +8,7 @@ import { KOREA_PROVINCES } from '../constants/address';
 import { boxStyle } from '../constants/commonStyleProps';
 import FormControlInputWrapper from './FormControlInputWrapper';
 import { ResponsiveDivider } from './ResponsiveDivider';
+import { areaSelectStyle } from './ShippingOptionFixedApply';
 
 export function ErrorText({ children }: { children: React.ReactNode }): JSX.Element {
   return (
@@ -170,7 +171,7 @@ export function ShippingOptionIntervalApply({
               }}
               render={({ field }) => {
                 return (
-                  <Select w={120} {...field}>
+                  <Select w={120} {...field} {...areaSelectStyle}>
                     {deliveryLimit === 'limit' || shippingSetType === 'add' ? (
                       ['지역 선택', ...KOREA_PROVINCES].map((area) => (
                         <option key={area} value={area}>

--- a/libs/components/src/lib/ShippingOptionRepeatApply.tsx
+++ b/libs/components/src/lib/ShippingOptionRepeatApply.tsx
@@ -8,6 +8,7 @@ import { KOREA_PROVINCES } from '../constants/address';
 import { boxStyle } from '../constants/commonStyleProps';
 import FormControlInputWrapper from './FormControlInputWrapper';
 import { ResponsiveDivider } from './ResponsiveDivider';
+import { areaSelectStyle } from './ShippingOptionFixedApply';
 import { ErrorText } from './ShippingOptionIntervalApply';
 
 // 퍼스트몰 구간입력 동작
@@ -172,7 +173,7 @@ export function ShippingOptionRepeatApply({
             }}
             render={({ field }) => {
               return (
-                <Select w={120} {...field}>
+                <Select w={120} {...field} {...areaSelectStyle}>
                   {deliveryLimit === 'limit' || shippingSetType === 'add' ? (
                     ['지역 선택', ...KOREA_PROVINCES].map((area) => (
                       <option key={area} value={area}>

--- a/libs/shared-types/src/lib/constants/shippingTypes.ts
+++ b/libs/shared-types/src/lib/constants/shippingTypes.ts
@@ -28,6 +28,23 @@ export const ShippingCalculTypeOptions: Record<
   },
 };
 
+// 배송비 추가설정 선택지 ------------------
+/** 배송비 추가설정 선택지 */
+export type ShippingAdditionalSettingOptionValue =
+  | 'bothFree'
+  | 'stdOnlyFree'
+  | 'addOnlyFree'
+  | 'bothCharge';
+export const shippingAdditionalSettingOptions: {
+  value: ShippingAdditionalSettingOptionValue;
+  label: string;
+}[] = [
+  { value: 'bothCharge', label: '기본 배송비, 추가 배송비 모두 부과' }, // 기본값
+  { value: 'stdOnlyFree', label: '기본 배송비만 무료로 계산 (추가 배송비는 부과됨) ' },
+  { value: 'addOnlyFree', label: '추가 배송비만 무료로 계산 (기본 배송비는 부과됨)' },
+  { value: 'bothFree', label: '기본 배송비, 추가 배송비 모두 무료로 계산' },
+];
+
 // 최대 배송비 입력값-----------------------------------------------
 export const MAX_COST = 999999999;
 

--- a/libs/stores/src/lib/shippingGroupItemStore.tsx
+++ b/libs/stores/src/lib/shippingGroupItemStore.tsx
@@ -1,14 +1,17 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { ShippingCalculType } from '@prisma/client';
-import { ShippingGroupDto, ShippingSetDto } from '@project-lc/shared-types';
+import {
+  ShippingAdditionalSettingOptionValue,
+  ShippingGroupDto,
+  ShippingSetDto,
+} from '@project-lc/shared-types';
 import create from 'zustand';
 
 export interface ShippingGroupItemStoreState extends ShippingGroupDto {
   setGroupName: (e: React.ChangeEvent<HTMLInputElement>) => void;
   setShippingCalculType: (type: ShippingCalculType) => void;
   clearShippingAdditionalSetting: () => void;
-  setShippingStdFree: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  setShippingAddFree: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  setShippingAdditionalSetting: (type: ShippingAdditionalSettingOptionValue) => void;
   setAddress: (postalCode: string, baseAddress: string) => void;
   setDetailAddress: (e: React.ChangeEvent<HTMLInputElement>) => void;
   addShippingSet: (item: ShippingSetDto) => void;
@@ -55,23 +58,41 @@ export const useShippingGroupItemStore = create<ShippingGroupItemStoreState>(
         shipping_calcul_free_yn: 'N',
       }));
     },
-    setShippingStdFree: (e: React.ChangeEvent<HTMLInputElement>) => {
-      const { shipping_add_free_yn } = get();
-      set((state) => ({
-        ...state,
-        shipping_std_free_yn: e.currentTarget.checked ? 'Y' : 'N',
-        shipping_calcul_free_yn:
-          shipping_add_free_yn === 'Y' || e.currentTarget.checked ? 'Y' : 'N',
-      }));
-    },
-    setShippingAddFree: (e: React.ChangeEvent<HTMLInputElement>) => {
-      const { shipping_std_free_yn } = get();
-      set((state) => ({
-        ...state,
-        shipping_add_free_yn: e.currentTarget.checked ? 'Y' : 'N',
-        shipping_calcul_free_yn:
-          shipping_std_free_yn === 'Y' || e.currentTarget.checked ? 'Y' : 'N',
-      }));
+    setShippingAdditionalSetting: (type: ShippingAdditionalSettingOptionValue) => {
+      switch (type) {
+        case 'addOnlyFree':
+          set((state) => ({
+            ...state,
+            shipping_std_free_yn: 'N',
+            shipping_add_free_yn: 'Y',
+            shipping_calcul_free_yn: 'Y',
+          }));
+          break;
+        case 'stdOnlyFree':
+          set((state) => ({
+            ...state,
+            shipping_std_free_yn: 'Y',
+            shipping_add_free_yn: 'N',
+            shipping_calcul_free_yn: 'Y',
+          }));
+          break;
+        case 'bothFree':
+          set((state) => ({
+            ...state,
+            shipping_std_free_yn: 'Y',
+            shipping_add_free_yn: 'Y',
+            shipping_calcul_free_yn: 'Y',
+          }));
+          break;
+        case 'bothCharge':
+        default:
+          set((state) => ({
+            ...state,
+            shipping_std_free_yn: 'N',
+            shipping_add_free_yn: 'N',
+            shipping_calcul_free_yn: 'N',
+          }));
+      }
     },
     setAddress: (postalCode: string, baseAddress: string) => {
       set((state) => ({


### PR DESCRIPTION
- [x]  상품등록 페이지 - '뒤로가기 버튼' 클릭 - 입력된 정보 소실됨 알림 다이얼로그 추가
![스크린샷 2021-11-11 오후 3 17 46](https://user-images.githubusercontent.com/18395475/141247764-28b7beff-53f3-4b28-841f-a5572a64f82d.png)
- [x]  상품사진 - 문구추가 `상품사진 * - 썸네일 이미지로 사용됩니다. 가로세로 1:1 비율인 이미지를 추천합니다.`
- [x]  상세설명 - 문구추가 `상세설명 * - 제품 상세 내용이 담긴 대형 이미지는 이곳에 첨부해주세요.`
- [x]  상품공통정보 - 문구추가 `** <신규 등록> 으로 작성한 상품 공통 정보는 상품 등록을 완료 할 시 <기존 정보> 리스트에 자동 추가됩니다.`
![스크린샷 2021-11-11 오후 3 20 08](https://user-images.githubusercontent.com/18395475/141248053-9255f64b-b6a4-4eb8-8330-795d58816cea.png)
- [x]  배송비 추가 설정 - 라디오 버튼으로 변경, 옵션변경, 연결 데이터 변경
    - 기본 배송비, 추가 배송비 모두 무료.
    - 기본 배송비만 무료. (추가 배송비는 부과됨)
    - 추가 배송비만 무료. (기본 배송비는 부과됨)
    - 기본 배송비, 추가 배송비 모두 부과
![스크린샷 2021-11-11 오후 3 21 25](https://user-images.githubusercontent.com/18395475/141248172-109f5567-7ca5-4e2e-a740-58fe906bb1ed.png)

- [x]  배송비 금액 지역선택 셀렉트박스 강조 (밝은 색 채움 제안)
![스크린샷 2021-11-11 오후 3 22 11](https://user-images.githubusercontent.com/18395475/141248241-ed41346d-3980-46d8-81ca-af75225b549d.png)

- [x]  네비바 크크마켓 링크 새창으로 이동