### PR TITLE
[판매자센터] 라이브쇼핑 등록시 입력정보 추가

### DIFF
--- a/apps/admin/pages/live-shopping/[liveShoppingId].tsx
+++ b/apps/admin/pages/live-shopping/[liveShoppingId].tsx
@@ -255,6 +255,21 @@ export function GoodsDetail(): JSX.Element {
 
             <Divider />
             <Stack direction="row" alignItems="center">
+              <Text as="span">희망 판매 수수료: </Text>
+              <Text as="span" fontWeight="bold">
+                {liveShopping[0].desiredCommission} %
+              </Text>
+            </Stack>
+
+            <Stack direction="row" alignItems="center">
+              <Text as="span">희망 진행 기간: </Text>
+              <Text as="span" fontWeight="bold">
+                {liveShopping[0].desiredPeriod}
+              </Text>
+            </Stack>
+
+            <Divider />
+            <Stack direction="row" alignItems="center">
               <Text as="span">방송인 수수료: </Text>
               <Text as="span" fontWeight="bold">
                 {liveShopping[0].broadcasterCommissionRate
@@ -273,6 +288,7 @@ export function GoodsDetail(): JSX.Element {
             </Stack>
 
             <Box>
+              <Text>요청사항</Text>
               <Textarea
                 resize="none"
                 rows={10}

--- a/libs/components/src/lib/ChakraAutoComplete.tsx
+++ b/libs/components/src/lib/ChakraAutoComplete.tsx
@@ -66,7 +66,7 @@ export function ChakraAutoComplete<T = any>({
       <Box {...getRootProps()}>
         {label ? (
           <FormLabel {...getInputLabelProps()}>
-            <Heading as="h6" size="xs">
+            <Heading as="h6" size="sm">
               {label}
             </Heading>
           </FormLabel>

--- a/libs/components/src/lib/LiveShoppingList.tsx
+++ b/libs/components/src/lib/LiveShoppingList.tsx
@@ -367,6 +367,20 @@ export function LiveShoppingList(): JSX.Element {
                     </Text>
                   </Stack>
 
+                  <Stack direction="row" alignItems="center">
+                    <Text as="span">희망 판매 수수료: </Text>
+                    <Text as="span" fontWeight="bold">
+                      {data[liveShoppingId].desiredCommission} %
+                    </Text>
+                  </Stack>
+
+                  <Stack direction="row" alignItems="center">
+                    <Text as="span">희망 진행 기간: </Text>
+                    <Text as="span" fontWeight="bold">
+                      {data[liveShoppingId].desiredPeriod}
+                    </Text>
+                  </Stack>
+
                   <Stack>
                     <Text>요청사항</Text>
                     <Textarea

--- a/libs/components/src/lib/LiveShoppingRegistForm.tsx
+++ b/libs/components/src/lib/LiveShoppingRegistForm.tsx
@@ -175,9 +175,9 @@ export function LiveShoppingRegist(): JSX.Element {
               {/* 담당자 연락처 */}
               <LiveShoppingManagerPhoneNumber />
               {/* 희망 진행 기간 */}
-              <liveShoppingDesiredPeriod />
+              <LiveShoppingDesiredPeriod />
               {/* 희망 판매 수수료 */}
-              <liveShoppingDesiredCommission />
+              <LiveShoppingDesiredCommission />
               {/* 요청사항 */}
               <LiveShoppingRequestInput />
               {/* 완료 버튼 */}
@@ -201,7 +201,7 @@ export function LiveShoppingRegist(): JSX.Element {
 
 export default LiveShoppingRegist;
 
-function liveShoppingDesiredPeriod(): JSX.Element {
+function LiveShoppingDesiredPeriod(): JSX.Element {
   const {
     register,
     setValue,
@@ -270,7 +270,7 @@ function liveShoppingDesiredPeriod(): JSX.Element {
   );
 }
 
-function liveShoppingDesiredCommission(): JSX.Element {
+function LiveShoppingDesiredCommission(): JSX.Element {
   const {
     register,
     formState: { errors },

--- a/libs/components/src/lib/LiveShoppingRegistForm.tsx
+++ b/libs/components/src/lib/LiveShoppingRegistForm.tsx
@@ -3,13 +3,23 @@ import {
   AlertIcon,
   Box,
   Button,
+  Collapse,
   Flex,
+  FormControl,
+  FormErrorMessage,
+  Heading,
   Image,
+  Input,
+  InputGroup,
+  InputRightAddon,
+  Radio,
+  RadioGroup,
   Spinner,
   Stack,
   Text,
+  useDisclosure,
+  useMergeRefs,
   useToast,
-  Heading,
 } from '@chakra-ui/react';
 import {
   useApprovedGoodsList,
@@ -21,15 +31,15 @@ import {
 } from '@project-lc/hooks';
 import {
   ApprovedGoodsListItem,
-  LiveShoppingRegistDTO,
   LiveShoppingInput,
+  LiveShoppingRegistDTO,
   LIVE_SHOPPING_PROGRESS,
 } from '@project-lc/shared-types';
 import { liveShoppingRegist } from '@project-lc/stores';
 import dayjs from 'dayjs';
 import { useRouter } from 'next/router';
-import { useMemo } from 'react';
-import { FormProvider, useForm } from 'react-hook-form';
+import { useEffect, useMemo, useRef } from 'react';
+import { FormProvider, useForm, useFormContext } from 'react-hook-form';
 import { Goods } from '.prisma/client';
 import { ChakraAutoComplete } from '..';
 import LiveShoppingManagerPhoneNumber from './LiveShoppingRegistManagerContacts';
@@ -59,6 +69,7 @@ export function LiveShoppingRegist(): JSX.Element {
       contactId: 0,
       email: '',
       requests: '',
+      desiredPeriod: '무관',
     },
   });
 
@@ -66,7 +77,7 @@ export function LiveShoppingRegist(): JSX.Element {
 
   const onSuccess = (): void => {
     toast({
-      title: '상품을 성공적으로 등록하였습니다',
+      title: '라이브쇼핑을 성공적으로 등록하였습니다',
       status: 'success',
     });
     handleGoodsSelect(null);
@@ -75,7 +86,7 @@ export function LiveShoppingRegist(): JSX.Element {
 
   const onFail = (): void => {
     toast({
-      title: '상품 등록 중 오류가 발생하였습니다',
+      title: '라이브쇼핑 등록 중 오류가 발생하였습니다',
       status: 'error',
     });
   };
@@ -89,6 +100,8 @@ export function LiveShoppingRegist(): JSX.Element {
       contactId: 0,
       streamId: '',
       progress: LIVE_SHOPPING_PROGRESS.등록됨,
+      desiredCommission: data.desiredCommission,
+      desiredPeriod: data.desiredPeriod,
     };
 
     if (contacts.data) {
@@ -161,6 +174,10 @@ export function LiveShoppingRegist(): JSX.Element {
               </Stack>
               {/* 담당자 연락처 */}
               <LiveShoppingManagerPhoneNumber />
+              {/* 희망 진행 기간 */}
+              <LiveShoopingDesiredPeriod />
+              {/* 희망 판매 수수료 */}
+              <LiveShoopingDesiredCommission />
               {/* 요청사항 */}
               <LiveShoppingRequestInput />
               {/* 완료 버튼 */}
@@ -183,6 +200,107 @@ export function LiveShoppingRegist(): JSX.Element {
 }
 
 export default LiveShoppingRegist;
+
+function LiveShoopingDesiredPeriod(): JSX.Element {
+  const {
+    register,
+    setValue,
+    watch,
+    formState: { errors },
+  } = useFormContext<LiveShoppingInput>();
+  const { onOpen, isOpen, onClose } = useDisclosure();
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const registeredDesiredPeriod = register('desiredPeriod', {
+    maxLength: {
+      value: 30,
+      message: '30자 이내로 작성해주세요.',
+    },
+  });
+  const mergedRef = useMergeRefs(registeredDesiredPeriod.ref, inputRef);
+  useEffect(() => {
+    if (inputRef.current && isOpen) inputRef.current.focus();
+  }, [isOpen]);
+  return (
+    <Stack>
+      <Heading as="h6" size="sm">
+        희망 진행 기간
+      </Heading>
+      <RadioGroup
+        value={watch('desiredPeriod')}
+        onChange={(newV) => {
+          onClose();
+          setValue('desiredPeriod', newV);
+        }}
+      >
+        <Stack direction="row">
+          <Radio value="무관">무관</Radio>
+          <Radio value="가능한 빠른 일정">가능한 빠른 일정</Radio>
+          <Radio value="4주 이내">4주 이내</Radio>
+        </Stack>
+      </RadioGroup>
+
+      <Box mt={3}>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            if (!isOpen) {
+              onOpen();
+              setValue('desiredPeriod', '');
+            } else {
+              onClose();
+              setValue('desiredPeriod', '무관');
+            }
+          }}
+        >
+          직접입력
+        </Button>
+      </Box>
+
+      <Collapse in={isOpen} animateOpacity unmountOnExit>
+        <Box maxW="200px">
+          <FormControl isInvalid={!!errors.desiredPeriod}>
+            <Input {...registeredDesiredPeriod} ref={mergedRef} />
+            <FormErrorMessage>{errors.desiredPeriod?.message}</FormErrorMessage>
+          </FormControl>
+        </Box>
+      </Collapse>
+    </Stack>
+  );
+}
+
+function LiveShoopingDesiredCommission(): JSX.Element {
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext<LiveShoppingInput>();
+
+  return (
+    <FormControl isInvalid={!!errors.desiredCommission}>
+      <Heading as="h6" size="sm">
+        희망 판매 수수료
+      </Heading>
+      <Text color="gray.500" fontSize="sm">
+        판매수수료가 높을수록 방송인 매칭 조율이 원만하며, 진행이 빠를 수 있습니다.
+      </Text>
+      <Box maxW={140} mt={2}>
+        <InputGroup>
+          <Input
+            placeholder="30"
+            type="number"
+            {...register('desiredCommission', {
+              max: { value: 100, message: '100을 넘을 수 없습니다.' },
+              min: { value: 0, message: '0보다 낮을 수 없습니다.' },
+            })}
+          />
+          <InputRightAddon>%</InputRightAddon>
+        </InputGroup>
+        <FormErrorMessage>{errors.desiredCommission?.message}</FormErrorMessage>
+      </Box>
+    </FormControl>
+  );
+}
 
 interface GoodsSummaryProps {
   goodsId: Goods['id'];

--- a/libs/components/src/lib/LiveShoppingRegistForm.tsx
+++ b/libs/components/src/lib/LiveShoppingRegistForm.tsx
@@ -175,9 +175,9 @@ export function LiveShoppingRegist(): JSX.Element {
               {/* 담당자 연락처 */}
               <LiveShoppingManagerPhoneNumber />
               {/* 희망 진행 기간 */}
-              <LiveShoopingDesiredPeriod />
+              <liveShoppingDesiredPeriod />
               {/* 희망 판매 수수료 */}
-              <LiveShoopingDesiredCommission />
+              <liveShoppingDesiredCommission />
               {/* 요청사항 */}
               <LiveShoppingRequestInput />
               {/* 완료 버튼 */}
@@ -201,7 +201,7 @@ export function LiveShoppingRegist(): JSX.Element {
 
 export default LiveShoppingRegist;
 
-function LiveShoopingDesiredPeriod(): JSX.Element {
+function liveShoppingDesiredPeriod(): JSX.Element {
   const {
     register,
     setValue,
@@ -270,7 +270,7 @@ function LiveShoopingDesiredPeriod(): JSX.Element {
   );
 }
 
-function LiveShoopingDesiredCommission(): JSX.Element {
+function liveShoppingDesiredCommission(): JSX.Element {
   const {
     register,
     formState: { errors },

--- a/libs/components/src/lib/LiveShoppingRegistManagerContacts.tsx
+++ b/libs/components/src/lib/LiveShoppingRegistManagerContacts.tsx
@@ -58,7 +58,7 @@ export function LiveShoppingManagerPhoneNumber(): JSX.Element {
 
   return (
     <Stack spacing={2}>
-      <Heading as="h6" size="xs">
+      <Heading as="h6" size="sm">
         담당자 연락처
       </Heading>
 

--- a/libs/components/src/lib/LiveShoppingRegistRequestField.tsx
+++ b/libs/components/src/lib/LiveShoppingRegistRequestField.tsx
@@ -19,7 +19,7 @@ export function LiveShoppingRequestInput(): JSX.Element {
     <Box w="100%">
       <Stack spacing={2}>
         <Stack direction="row">
-          <Heading as="h6" size="xs">
+          <Heading as="h6" size="sm">
             요청사항
           </Heading>
           <Text fontSize="xs">(최대 500자)</Text>

--- a/libs/nest-modules/src/lib/live-shopping/live-shopping.service.ts
+++ b/libs/nest-modules/src/lib/live-shopping/live-shopping.service.ts
@@ -20,15 +20,15 @@ export class LiveShoppingService {
 
     const userId = await this.prisma.seller.findFirst({
       where: { email },
-      select: {
-        id: true,
-      },
+      select: { id: true },
     });
     const liveShopping = await this.prisma.liveShopping.create({
       data: {
         seller: { connect: { id: userId.id } },
         streamId,
         requests: dto.requests,
+        desiredPeriod: dto.desiredPeriod,
+        desiredCommission: dto.desiredCommission || '0.00',
         goods: { connect: { id: dto.goods_id } },
         sellerContacts: { connect: { id: dto.contactId } },
       },
@@ -53,7 +53,7 @@ export class LiveShoppingService {
     email: UserPayload['sub'],
     dto: LiveShoppingParamsDto,
   ): Promise<LiveShoppingWithConfirmation[]> {
-    // 자신의 id를 반환하는 쿼리 수행하기
+    // 자신의 id를 반환하는 쿼리 수행하기
     const { id, goodsIds } = dto;
     return this.prisma.liveShopping.findMany({
       where: {

--- a/libs/prisma-orm/prisma/migrations/20211206063831_/migration.sql
+++ b/libs/prisma-orm/prisma/migrations/20211206063831_/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE `LiveShopping` ADD COLUMN `desiredCommission` DECIMAL(10, 2) NULL DEFAULT 0,
+    ADD COLUMN `desiredPeriod` VARCHAR(191) NULL DEFAULT '무관';

--- a/libs/prisma-orm/prisma/schema.prisma
+++ b/libs/prisma-orm/prisma/schema.prisma
@@ -546,6 +546,8 @@ model LiveShopping {
   rejectionReason           String?                   @db.Text // 방송 취소 또는 거절 사유
   broadcasterCommissionRate Decimal                   @default("0") @db.Decimal(10, 2) // 판매금 중, 방송인이 가져가는 수수료 (0%~100% 사이값)
   whiletrueCommissionRate   Decimal                   @default("0") @db.Decimal(10, 2) // 판매금 중, project-lc(와일트루)가 가져가는 수수료 (0%~100% 사이값)
+  desiredCommission         Decimal?                  @default("0") @db.Decimal(10, 2) // 희망판매수수료
+  desiredPeriod             String?                   @default("무관") // 희망 진행 기간
 
   sellerContacts        SellerContacts          @relation(fields: [contactId], references: [id])
   seller                Seller                  @relation(fields: [sellerId], references: [id])

--- a/libs/shared-types/src/lib/dto/liveShopping.dto.ts
+++ b/libs/shared-types/src/lib/dto/liveShopping.dto.ts
@@ -10,6 +10,7 @@ import {
 import { LiveShopping, LiveShopppingProgressType } from '@prisma/client';
 
 import { LIVE_SHOPPING_PROGRESS } from '../constants/liveShoppingProgress';
+import { LiveShoppingInput } from '../..';
 
 export class LiveShoppingDTO {
   @IsNumber()
@@ -79,7 +80,8 @@ export class LiveShoppingDTO {
 export type LiveShoppingRegistDTO = Pick<
   LiveShoppingDTO,
   'requests' | 'goods_id' | 'contactId' | 'streamId' | 'progress'
->;
+> &
+  Pick<LiveShoppingInput, 'desiredPeriod' | 'desiredCommission'>;
 
 export type LiveShoppingWithSales = Pick<
   LiveShoppingDTO,

--- a/libs/shared-types/src/lib/front-type/liveShoppingInputType.ts
+++ b/libs/shared-types/src/lib/front-type/liveShoppingInputType.ts
@@ -9,4 +9,9 @@ export interface LiveShoppingInput {
   setDefault: boolean;
   thirdNumber: string;
   useContact: string;
+
+  // 희망 진행 기간
+  desiredPeriod: string;
+  // 희망 판매 수수료
+  desiredCommission: string;
 }

--- a/libs/utils/src/lib/checkOrderDuringLiveShopping.spec.ts
+++ b/libs/utils/src/lib/checkOrderDuringLiveShopping.spec.ts
@@ -23,6 +23,8 @@ const liveShopping: LiveShopping = {
   rejectionReason: null,
   requests: null,
   videoId: null,
+  desiredCommission: new Decimal('30'),
+  desiredPeriod: '무관',
 };
 
 describe('FmOrderMemoParser', () => {

--- a/libs/utils/src/lib/getHostUrl.ts
+++ b/libs/utils/src/lib/getHostUrl.ts
@@ -20,6 +20,16 @@ export const getWebHost = (): string => {
   }
 };
 
+export const getBroadcasterCenterHost = (): string => {
+  switch (process.env.NODE_ENV) {
+    case 'production':
+    case 'test': // return process.env.NEXT_PUBLIC_WEB_HOST || process.env.SELLER_WEB_HOST;
+    case 'development':
+    default:
+      return 'http://localhost:4300';
+  }
+};
+
 export const getAdminHost = (): string => {
   switch (process.env.NODE_ENV) {
     case 'production':
@@ -27,6 +37,6 @@ export const getAdminHost = (): string => {
       return process.env.NEXT_PUBLIC_ADMIN_HOST;
     case 'development':
     default:
-      return 'http://localhost:4200';
+      return 'http://localhost:4250';
   }
 };


### PR DESCRIPTION
### 라이브쇼핑 희망 입력 필드 추가
- 희망진행기간
- 희망판매수수료

### TODO
- 라이브쇼핑 등록시
    - [x]  희망 진행 기간 필드 추가
        - [x]  직접입력
        - [x]  라디오버튼
    - [x]  희망 판매 수수료 필드 추가
        - [x]  0보다 작지 않게, 100보다 크지 않게 제한
- 라이브쇼핑 조회시
    - [x]  희망 진행 기간 조회 추가
    - [x]  희망 판매 수수료 조회 추가
- 관리자페이지
    - [x]  희망 진행 기간 조회 추가
    - [x]  희망 판매 수수료 조회 추가