### PR TITLE
공지사항 삭제

### DIFF
--- a/libs/hooks/src/index.ts
+++ b/libs/hooks/src/index.ts
@@ -17,6 +17,7 @@ export * from './lib/mutation/useCreateShippingGroup';
 export * from './lib/mutation/useDeleteBroadcasterContactsMutation';
 export * from './lib/mutation/useDeleteGoodsCommonInfo';
 export * from './lib/mutation/useDeleteLiveShoppingMutation';
+export * from './lib/mutation/useDeleteNoticeMutation';
 export * from './lib/mutation/useDeleteSellerGoods';
 export * from './lib/mutation/useDeleteSellerMutation';
 export * from './lib/mutation/useDeleteShippingGroup';

--- a/libs/hooks/src/lib/mutation/useDeleteNoticeMutation.tsx
+++ b/libs/hooks/src/lib/mutation/useDeleteNoticeMutation.tsx
@@ -1,0 +1,23 @@
+import { Notice } from '@prisma/client';
+import { AxiosError } from 'axios';
+import { useQueryClient, useMutation, UseMutationResult } from 'react-query';
+import axios from '../../axios';
+
+export type useDeleteNoticeMutationRes = Notice;
+
+export const useDeleteNoticeMutation = (): UseMutationResult<
+  useDeleteNoticeMutationRes,
+  AxiosError,
+  number
+> => {
+  const queryClient = useQueryClient();
+  return useMutation<useDeleteNoticeMutationRes, AxiosError, number>(
+    (id: number) =>
+      axios.delete<useDeleteNoticeMutationRes>(`/notice/${id}`).then((res) => res.data),
+    {
+      onSuccess: (data) => {
+        queryClient.invalidateQueries('Notice');
+      },
+    },
+  );
+};

--- a/libs/nest-modules/src/lib/notice/notice.controller.ts
+++ b/libs/nest-modules/src/lib/notice/notice.controller.ts
@@ -6,6 +6,9 @@ import {
   Body,
   Patch,
   UseGuards,
+  Delete,
+  Param,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { Notice } from '@prisma/client';
 import { NoticePostDto, NoticePatchDto } from '@project-lc/shared-types';
@@ -40,5 +43,12 @@ export class NoticeController {
   @Patch()
   patchNotice(@Body(ValidationPipe) dto: NoticePatchDto): Promise<Notice> {
     return this.noticeService.patchNotice(dto);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @UseGuards(AdminGuard)
+  @Delete(':id')
+  deleteNotice(@Param('id', ParseIntPipe) id: number): Promise<Notice> {
+    return this.noticeService.deleteNotice(id);
   }
 }

--- a/libs/nest-modules/src/lib/notice/notice.service.ts
+++ b/libs/nest-modules/src/lib/notice/notice.service.ts
@@ -53,4 +53,11 @@ export class NoticeService {
 
     return notice;
   }
+
+  // 공지사항 삭제
+  public async deleteNotice(id: Notice['id']): Promise<Notice> {
+    return this.prisma.notice.delete({
+      where: { id },
+    });
+  }
 }


### PR DESCRIPTION
# 개요

관리자 페이지에서 공지사항 리스트 기능들 중에서 온오프는 있지만 수정, 삭제는 존재하지 않음.

많아지게되면 수정이나 삭제가 필요하지 않을까 생각하고 있음.

- 사실, 글은 노션에 작성하기 때문에 글에 대한 변경은 언제든지 가능하다.
- 노션글 삭제는 관리자가 알아서, 공지사항 테이블 행만 삭제

# 할일

- [x]  공지사항 삭제
    - [x]  컨트롤러
    - [x]  서비스
- [x]  관리자페이지 공지사항 삭제 요청 구성
    - [x]  삭제 버튼
    - [x]  삭제 요청
    - [x]  삭제성공,실패 알림