### PR TITLE
[Add] 관리자 -> 방송인 / 판매자 로그인 유지 삭제

### DIFF
--- a/libs/nest-modules/src/lib/admin/admin.controller.ts
+++ b/libs/nest-modules/src/lib/admin/admin.controller.ts
@@ -85,7 +85,6 @@ export class AdminController {
     @Body(ValidationPipe) dto: AdminSignUpDto,
   ): Promise<Administrator> {
     const ip = (req.headers['x-forwarded-for'] as string) || req.socket.remoteAddress;
-    console.log(ip);
     if (!this.allowedIpAddresses.includes(ip)) {
       throw new ForbiddenException(`unexpected ip address - ${ip}`);
     }

--- a/libs/nest-modules/src/lib/auth/auth.service.ts
+++ b/libs/nest-modules/src/lib/auth/auth.service.ts
@@ -190,6 +190,9 @@ export class AuthService {
     }
     // 관리자 정보 조회
     if (['admin'].includes(type)) {
+      if (appType !== 'admin') {
+        throw new UnauthorizedException();
+      }
       user = await this.adminAccountService.findOne({ email: sub });
     }
 


### PR DESCRIPTION
로그인 관련 로직을 구현하였으나 로컬 환경에서는 로그인 유지 상태를 구현할 수 없어서 테스트는 불가. 
배포 후, 확인 필요.