### PR TITLE
[Refactor] fmGoodsSeq 기준으로 라이브 쇼핑 - 상품 연결을 판단하도록 수정

### DIFF
--- a/libs/components-seller/src/lib/LiveShoppingList.tsx
+++ b/libs/components-seller/src/lib/LiveShoppingList.tsx
@@ -115,23 +115,27 @@ export function LiveShoppingList(): JSX.Element {
         }
       });
   };
-
   const columns: GridColumns = [
     {
-      field: 'goods.confirmation.firstmallGoodsConnectionId',
+      field: 'fmGoodsSeq',
       headerName: '상품명',
       minWidth: 350,
       flex: 1,
-      renderCell: ({ row }) => (
-        <Tooltip label="상품페이지로 이동">
-          <Link
-            href={`http://whiletrue.firstmall.kr/goods/view?no=${row.goods.confirmation.firstmallGoodsConnectionId}`}
-            isExternal
-          >
-            {row.goods.goods_name} <ExternalLinkIcon mx="2px" />
-          </Link>
-        </Tooltip>
-      ),
+      renderCell: ({ row }) => {
+        if (row.fmGoodsSeq) {
+          return (
+            <Tooltip label="상품페이지로 이동">
+              <Link
+                href={`http://whiletrue.firstmall.kr/goods/view?no=${row.fmGoodsSeq}`}
+                isExternal
+              >
+                {row.goods.goods_name} <ExternalLinkIcon mx="2px" />
+              </Link>
+            </Tooltip>
+          );
+        }
+        return <Text>{row.goods.goods_name}</Text>;
+      },
     },
     {
       field: 'progress',

--- a/libs/components-web-bc/src/lib/BroadcasterLiveShoppingList.tsx
+++ b/libs/components-web-bc/src/lib/BroadcasterLiveShoppingList.tsx
@@ -55,15 +55,15 @@ export function BroadcasterLiveShoppingList({
 
   const columns: GridColumns = [
     {
-      field: 'goods.confirmation.firstmallGoodsConnectionId',
+      field: 'fmGoodsSeq',
       headerName: '상품명',
       minWidth: 350,
       flex: 1,
       renderCell: ({ row }) =>
-        new Date(row.sellEndDate) > new Date() ? (
+        new Date(row.sellEndDate) > new Date() && row.fmGoodsSeq ? (
           <Tooltip label="상품페이지로 이동">
             <Link
-              href={`http://whiletrue.firstmall.kr/goods/view?no=${row.goods.confirmation.firstmallGoodsConnectionId}`}
+              href={`http://whiletrue.firstmall.kr/goods/view?no=${row.fmGoodsSeq}`}
               isExternal
             >
               {row.goods.goods_name} <ExternalLinkIcon mx="2px" />

--- a/libs/firstmall-db/src/lib/fm-orders/fm-orders.controller.ts
+++ b/libs/firstmall-db/src/lib/fm-orders/fm-orders.controller.ts
@@ -113,7 +113,7 @@ export class FmOrdersController {
           if (val.sellStartDate && val.sellEndDate) {
             return {
               id: val.id,
-              firstmallGoodsConnectionId: `${val.goods.confirmation.firstmallGoodsConnectionId}`,
+              fmGoodsSeq: val.fmGoodsSeq,
               sellStartDate: dayjs(val.sellStartDate).toString(),
               sellEndDate: dayjs(val.sellEndDate).toString(),
             };
@@ -137,7 +137,7 @@ export class FmOrdersController {
           if (val.sellStartDate && val.sellEndDate) {
             return {
               id: val.id,
-              firstmallGoodsConnectionId: `${val.goods.confirmation.firstmallGoodsConnectionId}`,
+              fmGoodsSeq: val.fmGoodsSeq,
               sellStartDate: dayjs(val.sellStartDate).toString(),
               sellEndDate: dayjs(val.sellEndDate).toString(),
             };

--- a/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.ts
+++ b/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.ts
@@ -24,7 +24,7 @@ import {
   FmOrderStatusNumString,
   getFmOrderStatusByNames,
   GoodsConfirmationDtoOnlyConnectionId,
-  LiveShoppingWithSalesAndFmId,
+  LiveShoppingWithSales,
   OrderStatsRes,
 } from '@project-lc/shared-types';
 import dayjs from 'dayjs';
@@ -827,7 +827,7 @@ export class FmOrdersService {
   }
 
   public async getOrdersStatsDuringLiveShoppingSales(
-    dto: LiveShoppingWithSalesAndFmId[],
+    dto: LiveShoppingWithSales[],
   ): Promise<{ id: number; sales: string }[]> {
     const salesPrice = [];
 
@@ -845,7 +845,7 @@ export class FmOrdersService {
         const sellStartDate = dayjs(val.sellStartDate).format('YYYY-MM-DD HH:mm:ss');
         const sellEndDate = dayjs(val.sellEndDate).format('YYYY-MM-DD HH:mm:ss');
         const salesSum = await this.db.query(sql, [
-          val.firstmallGoodsConnectionId,
+          val.fmGoodsSeq,
           sellStartDate,
           sellEndDate,
         ]);

--- a/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.ts
+++ b/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.ts
@@ -23,7 +23,7 @@ import {
   fmOrderStatuses,
   FmOrderStatusNumString,
   getFmOrderStatusByNames,
-  GoodsConfirmationDtoOnlyConnectionId,
+  LiveShoppingFmGoodsSeq,
   LiveShoppingWithSales,
   OrderStatsRes,
 } from '@project-lc/shared-types';
@@ -910,7 +910,7 @@ export class FmOrdersService {
   }
 
   public async getPurchaseDoneOrderDuringLiveShopping(
-    goods: GoodsConfirmationDtoOnlyConnectionId[],
+    goods: LiveShoppingFmGoodsSeq[],
   ): Promise<BroacasterPurchaseWithDivdedMessageDto> {
     const sql = `
     SELECT fo.order_seq as id, foi.goods_name, fo.settleprice, fo.regist_date, group_concat(distinct CONCAT_WS("&&",foii.title, foii.value) SEPARATOR "||") AS message
@@ -927,8 +927,8 @@ export class FmOrdersService {
     ORDER BY fo.regist_date desc
 `;
     const purchaseList = await Promise.all(
-      goods.map(async (value: GoodsConfirmationDtoOnlyConnectionId) => {
-        const connectionId = value.firstmallGoodsConnectionId;
+      goods.map(async (value: LiveShoppingFmGoodsSeq) => {
+        const connectionId = value.fmGoodsSeq;
         return this.db.query(sql, [connectionId]);
       }),
     );

--- a/libs/firstmall-db/src/lib/fm-settlements/fm-settlements.service.ts
+++ b/libs/firstmall-db/src/lib/fm-settlements/fm-settlements.service.ts
@@ -63,14 +63,14 @@ export class FmSettlementService {
     // 각 출고아이템의 상품번호를 통해 project-lc seller 정보 조회 (goodsConfirmation)
     const goods_seq_arr = exportOptions.map((o) => o.goods_seq);
 
-    const lcGoodsList = await this.prisma.goodsConfirmation.findMany({
+    const lcGoodsList = await this.prisma.liveShopping.findMany({
       where: {
-        firstmallGoodsConnectionId: {
+        fmGoodsSeq: {
           in: goods_seq_arr,
         },
       },
       select: {
-        firstmallGoodsConnectionId: true,
+        fmGoodsSeq: true,
         goods: {
           include: {
             LiveShopping: true,
@@ -102,9 +102,7 @@ export class FmSettlementService {
       options: exportOptions
         .filter((o) => o.export_code === r.export_code)
         .map((o) => {
-          const lcgoods = lcGoodsList.find(
-            (g) => g.firstmallGoodsConnectionId === o.goods_seq,
-          );
+          const lcgoods = lcGoodsList.find((g) => g.fmGoodsSeq === o.goods_seq);
           if (lcgoods) {
             return {
               ...o,

--- a/libs/hooks/src/lib/queries/useBroadcasterFmOrdersDuringLiveShoppingSales.tsx
+++ b/libs/hooks/src/lib/queries/useBroadcasterFmOrdersDuringLiveShoppingSales.tsx
@@ -1,13 +1,13 @@
 import { useQuery, UseQueryResult } from 'react-query';
-import { LiveShoppingWithSalesAndFmId } from '@project-lc/shared-types';
+import { LiveShopping } from '@prisma/client';
 import { AxiosError } from 'axios';
 import axios from '../../axios';
 
 export const getBroadcasterFmOrdersDuringLiveShoppingSales = async (
   broadcasterId: number | undefined,
-): Promise<LiveShoppingWithSalesAndFmId[]> => {
+): Promise<LiveShopping[]> => {
   return axios
-    .get<LiveShoppingWithSalesAndFmId[]>('/fm-orders/broadcaster/per-live-shopping', {
+    .get<LiveShopping[]>('/fm-orders/broadcaster/per-live-shopping', {
       params: { broadcasterId },
     })
     .then((res) => res.data);
@@ -17,8 +17,8 @@ export const useBroadcasterFmOrdersDuringLiveShoppingSales = ({
   broadcasterId,
 }: {
   broadcasterId: number | undefined;
-}): UseQueryResult<LiveShoppingWithSalesAndFmId[], AxiosError> => {
-  return useQuery<LiveShoppingWithSalesAndFmId[], AxiosError>(
+}): UseQueryResult<LiveShopping[], AxiosError> => {
+  return useQuery<LiveShopping[], AxiosError>(
     'broadCasterFmOrdersDuringLiveShoppingSales',
     () => getBroadcasterFmOrdersDuringLiveShoppingSales(broadcasterId),
     { enabled: !!broadcasterId },

--- a/libs/hooks/src/lib/queries/useFmOrdersDuringLiveShoppingSales.tsx
+++ b/libs/hooks/src/lib/queries/useFmOrdersDuringLiveShoppingSales.tsx
@@ -1,20 +1,18 @@
 import { useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
-import { LiveShoppingWithSalesAndFmId } from '@project-lc/shared-types';
+import { LiveShopping } from '@prisma/client';
 import { AxiosError } from 'axios';
 import axios from '../../axios';
 
-export const getFmOrdersDuringLiveShoppingSales = async (): Promise<
-  LiveShoppingWithSalesAndFmId[]
-> => {
+export const getFmOrdersDuringLiveShoppingSales = async (): Promise<LiveShopping[]> => {
   return axios
-    .get<LiveShoppingWithSalesAndFmId[]>('/fm-orders/per-live-shopping')
+    .get<LiveShopping[]>('/fm-orders/per-live-shopping')
     .then((res) => res.data);
 };
 
 export const useFmOrdersDuringLiveShoppingSales = (
-  options?: UseQueryOptions<LiveShoppingWithSalesAndFmId[], AxiosError>,
-): UseQueryResult<LiveShoppingWithSalesAndFmId[], AxiosError> => {
-  return useQuery<LiveShoppingWithSalesAndFmId[], AxiosError>(
+  options?: UseQueryOptions<LiveShopping[], AxiosError>,
+): UseQueryResult<LiveShopping[], AxiosError> => {
+  return useQuery<LiveShopping[], AxiosError>(
     'FmOrdersDuringLiveShoppingSales',
     getFmOrdersDuringLiveShoppingSales,
     options,
@@ -23,9 +21,9 @@ export const useFmOrdersDuringLiveShoppingSales = (
 
 export const getFmOrdersDuringLiveShoppingSalesPurchaseDone = async (
   broadcasterId: number | undefined,
-): Promise<LiveShoppingWithSalesAndFmId[]> => {
+): Promise<LiveShopping[]> => {
   return axios
-    .get<LiveShoppingWithSalesAndFmId[]>('/fm-orders/broadcaster/purchases', {
+    .get<LiveShopping[]>('/fm-orders/broadcaster/purchases', {
       params: { broadcasterId },
     })
     .then((res) => res.data);
@@ -33,8 +31,8 @@ export const getFmOrdersDuringLiveShoppingSalesPurchaseDone = async (
 
 export const useFmOrdersDuringLiveShoppingSalesPurchaseDone = (
   broadcasterId: number | undefined,
-): UseQueryResult<LiveShoppingWithSalesAndFmId[], AxiosError> => {
-  return useQuery<LiveShoppingWithSalesAndFmId[], AxiosError>(
+): UseQueryResult<LiveShopping[], AxiosError> => {
+  return useQuery<LiveShopping[], AxiosError>(
     'getFmOrdersDuringLiveShoppingSalesPurchaseDone',
     () => getFmOrdersDuringLiveShoppingSalesPurchaseDone(broadcasterId),
     { enabled: !!broadcasterId },

--- a/libs/nest-modules-liveshopping/src/live-shopping/live-shopping.controller.ts
+++ b/libs/nest-modules-liveshopping/src/live-shopping/live-shopping.controller.ts
@@ -16,8 +16,8 @@ import {
   ApprovedGoodsNameAndId,
   LiveShoppingParamsDto,
   LiveShoppingRegistDTO,
-  LiveShoppingWithConfirmation,
 } from '@project-lc/shared-types';
+import { LiveShopping } from '@prisma/client';
 import { LiveShoppingService } from './live-shopping.service';
 
 @UseGuards(JwtAuthGuard)
@@ -32,7 +32,7 @@ export class LiveShoppingController {
   getLiveShoppings(
     @SellerInfo() seller: UserPayload,
     @Query(ValidationPipe) dto?: LiveShoppingParamsDto,
-  ): Promise<LiveShoppingWithConfirmation[]> {
+  ): Promise<LiveShopping[]> {
     return this.liveShoppingService.getRegisteredLiveShoppings(seller.sub, dto);
   }
 
@@ -63,7 +63,7 @@ export class LiveShoppingController {
   @Get('/broadcaster')
   getBroadcasterLiveShoppings(
     @Query('broadcasterId', ParseIntPipe) broadcasterId: number,
-  ): Promise<LiveShoppingWithConfirmation[]> {
+  ): Promise<LiveShopping[]> {
     return this.liveShoppingService.getBroadcasterRegisteredLiveShoppings(broadcasterId);
   }
 }

--- a/libs/nest-modules-liveshopping/src/live-shopping/live-shopping.service.ts
+++ b/libs/nest-modules-liveshopping/src/live-shopping/live-shopping.service.ts
@@ -6,10 +6,9 @@ import {
   LiveShoppingParamsDto,
   LiveShoppingRegistDTO,
   LiveShoppingsWithBroadcasterAndGoodsName,
-  LiveShoppingWithConfirmation,
 } from '@project-lc/shared-types';
 import { throwError } from 'rxjs';
-
+import { LiveShopping } from '@prisma/client';
 @Injectable()
 export class LiveShoppingService {
   constructor(private readonly prisma: PrismaService) {}
@@ -54,7 +53,7 @@ export class LiveShoppingService {
   async getRegisteredLiveShoppings(
     email: UserPayload['sub'],
     dto: LiveShoppingParamsDto,
-  ): Promise<LiveShoppingWithConfirmation[]> {
+  ): Promise<LiveShopping[]> {
     // 자신의 id를 반환하는 쿼리 수행하기
     const { id, goodsIds } = dto;
     return this.prisma.liveShopping.findMany({
@@ -73,11 +72,6 @@ export class LiveShoppingService {
           select: {
             goods_name: true,
             summary: true,
-            confirmation: {
-              select: {
-                firstmallGoodsConnectionId: true,
-              },
-            },
           },
         },
         seller: {
@@ -133,7 +127,7 @@ export class LiveShoppingService {
 
   async getBroadcasterRegisteredLiveShoppings(
     broadcasterId: number,
-  ): Promise<LiveShoppingWithConfirmation[]> {
+  ): Promise<LiveShopping[]> {
     // 자신의 id를 반환하는 쿼리 수행하기
     return this.prisma.liveShopping.findMany({
       where: {
@@ -144,11 +138,6 @@ export class LiveShoppingService {
           select: {
             goods_name: true,
             summary: true,
-            confirmation: {
-              select: {
-                firstmallGoodsConnectionId: true,
-              },
-            },
           },
         },
         seller: {

--- a/libs/nest-modules-liveshopping/src/live-shopping/live-shopping.service.ts
+++ b/libs/nest-modules-liveshopping/src/live-shopping/live-shopping.service.ts
@@ -92,9 +92,9 @@ export class LiveShoppingService {
   /**
    *
    * @author m'baku
-   * @description 해당 방송인에게 매칭된 모든 라이브 쇼핑에 연결된 상품들의 FirstmallGoodsConnectionId를 반환받는다
+   * @description 해당 방송인에게 매칭된 모든 라이브 쇼핑에 연결된 상품들의 fmGoodsSeq 반환받는다
    * @param broadcasterId
-   * @returns firstmallGoodsConnectionIds
+   * @returns fmGoodsSeq
    */
   async getFmGoodsConnectionIdLinkedToLiveShoppings(
     broadcasterId: number,

--- a/libs/shared-types/src/lib/dto/goodsConfirmation.dto.ts
+++ b/libs/shared-types/src/lib/dto/goodsConfirmation.dto.ts
@@ -27,8 +27,3 @@ export class GoodsRejectionDto {
   @IsString()
   rejectionReason: string;
 }
-
-export type GoodsConfirmationDtoOnlyConnectionId = Omit<
-  GoodsConfirmationDto,
-  'goodsId' | 'status'
->;

--- a/libs/shared-types/src/lib/dto/liveShopping.dto.ts
+++ b/libs/shared-types/src/lib/dto/liveShopping.dto.ts
@@ -90,15 +90,6 @@ export class LiveShoppingParamsDto {
   @IsOptional() @IsString() id?: string;
   @IsOptional() @IsArray() goodsIds?: number[];
 }
-
-export interface LiveShoppingWithConfirmation extends LiveShopping {
-  goods: {
-    confirmation: {
-      firstmallGoodsConnectionId: number;
-    };
-  };
-}
-
 export type LiveShoppingBroadcastDate = Pick<
   LiveShoppingDTO,
   'broadcastStartDate' | 'broadcastEndDate'

--- a/libs/shared-types/src/lib/dto/liveShopping.dto.ts
+++ b/libs/shared-types/src/lib/dto/liveShopping.dto.ts
@@ -117,3 +117,5 @@ export type LiveShoppingsWithBroadcasterAndGoodsName = Pick<
     goods_name: string;
   };
 };
+
+export type LiveShoppingFmGoodsSeq = Pick<LiveShopping, 'fmGoodsSeq'>;

--- a/libs/shared-types/src/lib/dto/liveShopping.dto.ts
+++ b/libs/shared-types/src/lib/dto/liveShopping.dto.ts
@@ -84,13 +84,8 @@ export type LiveShoppingRegistDTO = Pick<
 
 export type LiveShoppingWithSales = Pick<
   LiveShoppingDTO,
-  'id' | 'sellStartDate' | 'sellEndDate'
+  'id' | 'sellStartDate' | 'sellEndDate' | 'fmGoodsSeq'
 >;
-
-export interface LiveShoppingWithSalesAndFmId extends LiveShoppingWithSales {
-  firstmallGoodsConnectionId: string;
-}
-
 export class LiveShoppingParamsDto {
   @IsOptional() @IsString() id?: string;
   @IsOptional() @IsArray() goodsIds?: number[];


### PR DESCRIPTION
## 수정한 곳

### 방송인 페이지
- [x] 방송인 - 구매현황 조회
- [x] 방송인 - 라이브 쇼핑 조회 테이블 
- 상품명 fmGoodSeq 있어야 상품 페이지로 이동 가능하도록 변경
- 상세보기
- 매출

### 판매자 페이지
- [x] 판매자 - 라이브 쇼핑 조회 테이블
- 상품명 fmGoodSeq 있어야 상품 페이지로 이동 가능하도록 변경
- 상세보기
- 매출

### 관리자 페이지
- [x] 관리자 - 정산내역 판매자 정보 

### 남은 곳
https://www.notion.so/whiletrue/1-1-1-2-b03110204c144c7686617eecb15e8880