### PR TITLE
fix: nav 디자인 및 admin 레이아웃 수정

### DIFF
--- a/libs/components-admin/src/lib/AdminPageLayout.tsx
+++ b/libs/components-admin/src/lib/AdminPageLayout.tsx
@@ -18,7 +18,7 @@ export function AdminPageLayout({ children }: MypageLayoutProps): JSX.Element {
   const { isOpen, onClose, onToggle } = useDisclosure({ defaultIsOpen: true });
 
   return (
-    <Box position="relative">
+    <Box position="relative" maxH="100vh" overflowY="hidden">
       <AdminNav
         toggleButton={
           isOpen ? null : <NavbarToggleButton isOpen={isOpen} onToggle={onToggle} />
@@ -30,7 +30,7 @@ export function AdminPageLayout({ children }: MypageLayoutProps): JSX.Element {
 
       <Flex as="main" minH="calc(100vh - 60px - 60px - 60px)" direction="row">
         <AdminSidebar isOpen={isOpen} onClose={onClose} onToggle={onToggle} />
-        <Box flex="1" borderWidth="1px" borderRadius="lg" p={7} height="100%">
+        <Box flex="1" p={4} h="calc(100vh - 60px)" overflow="auto">
           {children}
         </Box>
       </Flex>

--- a/libs/components-admin/src/lib/AdminSidebar.tsx
+++ b/libs/components-admin/src/lib/AdminSidebar.tsx
@@ -19,7 +19,7 @@ import { useRouter } from 'next/router';
 import React, { useMemo } from 'react';
 
 const sidebarVaraints: Variants = {
-  open: { width: '200px', opacity: 1 },
+  open: { width: '240px', opacity: 1 },
   close: { width: '0px', opacity: 0 },
 };
 
@@ -39,9 +39,10 @@ export function SlideSidebar({ isOpen, children }: SlideSidebarProps): JSX.Eleme
   return (
     <motion.nav
       style={{
-        position: 'sticky',
-        height: '100%',
+        
+        height: '100vh',
         top: 0,
+        overflowY: 'auto',
       }}
       initial="open"
       animate={isOpen ? 'open' : 'close'}
@@ -112,15 +113,15 @@ function SidebarMenuGroup({ menu }: { menu: SidebarMenuLink }): JSX.Element {
 export function AdminSidebar({ isOpen, onToggle }: AdminSidebarProps): JSX.Element {
   return (
     <SlideSidebar isOpen={isOpen}>
-      <Box borderWidth="1px" p={2}>
+      <Box  p={2} borderRightWidth="1px" height="inherit">
         {isOpen && (
-          <Flex justifyContent="space-between" alignItems="center">
+          <Flex justifyContent="space-between" alignItems="center" pb={2}>
             <Text fontWeight="extrabold">관리 메뉴</Text>
             <NavbarToggleButton isOpen={isOpen} onToggle={onToggle} />
           </Flex>
         )}
 
-        <Stack>
+        <Stack pb={40}>
           {adminSidebarMenuList.map((menu) => (
             <SidebarMenuGroup key={menu.href} menu={menu} />
           ))}


### PR DESCRIPTION
사이드바와 상단 네비바, 메인화면을 고정해둔 채 메인화면 overflow 시 스크롤이 생기도록 구성했습니다

상단 네비바도 화면에 고정되어 있으면 좋겠다 싶어서요

내일 확인해 보시고 피드백 부탁드립니다.

판매자센터, 방송인센터, 크크쇼 페이지에서는 태블릿,모바일 화면에서는 기본으로 사이드바가 닫혀있는 형태이면서, 메인화면의 크기를 줄이지 않고 모달 + 오버레이 형태로 뜨는 식으로 구현해야 할 것 같습니다. (chakra-ui 에서 제공하는 Drawer 와 비슷하게) 