### PR TITLE
fix : 방송인센터 로그인 컴포넌트 appType 수정

### DIFF
--- a/apps/web-broadcaster-center/pages/signup.tsx
+++ b/apps/web-broadcaster-center/pages/signup.tsx
@@ -9,7 +9,7 @@ export function SignUp(): JSX.Element {
   return (
     <Box>
       <BroadcasterNavbar />
-      <SignupProcess appType="seller" />
+      <SignupProcess appType="broadcaster" />
     </Box>
   );
 }

--- a/libs/components-shared/src/lib/MypageBreadCrumb.tsx
+++ b/libs/components-shared/src/lib/MypageBreadCrumb.tsx
@@ -15,6 +15,8 @@ export function MypageBreadcrumb(): JSX.Element {
     switch (pathname) {
       case 'mypage':
         return '마이페이지';
+      case 'mypage#':
+        return '마이페이지';
       case 'goods':
         return '상품';
       case 'regist':


### PR DESCRIPTION
버그 제보 : 방송인센터 소셜 회원가입시 판매자 센터가 가입이 됩니다. 리다이렉트도 판매자 센터

원인 : 방송인센터와 판매자센터에서 각자 사용되던 로그인 컴포넌트를 공용컴포넌트로 만들면서 appType을 props로 넘겨줌
복사 붙여넣기 하다가 방송인센터 로그인 컴포넌트에도 appType = 'seller'로 잘못 넘김

수정사항 : 방송인센터 로그인 컴포넌트  appType = 'broadcaster'로 수정함