### PR TITLE
fix: 라이브 쇼핑 매출 결제취소액 제외 및 쿼리 오류 수정

### DIFF
--- a/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.ts
+++ b/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.ts
@@ -837,8 +837,9 @@ export class FmOrdersService {
     FROM fm_order
     JOIN fm_order_item USING(order_seq)
     WHERE fm_order_item.goods_seq IN (?)
+    AND fm_order.step != 85 AND fm_order.step != 0
     AND
-    DATE(regist_date) BETWEEN ? AND ?;
+    regist_date BETWEEN ? AND ?;
     `;
     await Promise.all(
       dto.map(async (val) => {


### PR DESCRIPTION
- 라이브 쇼핑 매출 결제취소액 제외 및 쿼리 오류 수정