### PR TITLE
fix : 이메일 validation 방식 수정

### DIFF
--- a/libs/components-seller/src/lib/BusinessRegistrationForm.tsx
+++ b/libs/components-seller/src/lib/BusinessRegistrationForm.tsx
@@ -13,6 +13,7 @@ import {
   useDialogHeaderConfig,
   useDialogValueConfig,
 } from '@project-lc/components-layout/GridTableItem';
+import { emailRegisterOptions } from '@project-lc/shared-types';
 import { forwardRef, MutableRefObject } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { BusinessRegistrationFormDto } from './BusinessRegistrationDialog';
@@ -216,10 +217,7 @@ function BusinessRegistrationFormTag(props: BusinessRegistrationFormProps): JSX.
             maxW={['inherit', 300, 300, 300]}
             {...register('taxInvoiceMail', {
               required: '전자계산서 발급을 위한 이메일을 입력해주세요.',
-              pattern: {
-                value: /^[\w]+@[\w]+\.[\w][\w]+$/,
-                message: '이메일 형식이 올바르지 않습니다.',
-              },
+              validate: emailRegisterOptions.validate,
             })}
           />
           <FormErrorMessage ml={3} mt={0}>

--- a/libs/shared-types/src/lib/constants/signupRegisterOptions.ts
+++ b/libs/shared-types/src/lib/constants/signupRegisterOptions.ts
@@ -1,16 +1,20 @@
-export const emailPattern = /^[\w]+@[\w]+\.[\w][\w]+$/;
+import * as Joi from 'joi';
 
 export const passwordPattern = /^(?=.*[a-zA-Z0-9])(?=.*[!@#$%^*+=-]).{8,20}$/;
 
 export const emailRegisterOptions = {
   required: '이메일을 작성해주세요.',
-  pattern: {
-    value: emailPattern,
-    message: '이메일 형식이 올바르지 않습니다.',
-  },
   validate: {
     noUppercase: (v: string) =>
       v.toLowerCase() === v || '영문 대문자는 사용할 수 없습니다.',
+    isValidEmail: (v: string) => {
+      const schema = Joi.object({
+        email: Joi.string().email({ tlds: { allow: false } }), // IANA 등록안된 top level domain 허용 => false로 안하면 오류남 https://github.com/sideway/joi/issues/2390
+      });
+      const { error, value } = schema.validate({ email: v });
+      if (!error) return true;
+      return `유효하지 않은 이메일 형식입니다. ${JSON.stringify(value.email)}`;
+    },
   },
 };
 

--- a/libs/shared-types/src/lib/constants/signupRegisterOptions.ts
+++ b/libs/shared-types/src/lib/constants/signupRegisterOptions.ts
@@ -11,9 +11,9 @@ export const emailRegisterOptions = {
       const schema = Joi.object({
         email: Joi.string().email({ tlds: { allow: false } }), // IANA 등록안된 top level domain 허용 => false로 안하면 오류남 https://github.com/sideway/joi/issues/2390
       });
-      const { error, value } = schema.validate({ email: v });
+      const { error } = schema.validate({ email: v });
       if (!error) return true;
-      return `유효하지 않은 이메일 형식입니다. ${JSON.stringify(value.email)}`;
+      return `유효하지 않은 이메일 형식입니다.`;
     },
   },
 };


### PR DESCRIPTION
#230 

원인 : 이메일이 유효한지 확인하는 정규표현식이 @test.co.kr 와 같은 도메인을 포함하지 못함

접근 : 정규표현식 패턴으로 확인하는 대신 validate 함수에서 Joi 스키마 이용, 이메일 검증 필요한 부분(회원가입, 전자계산서발급 이메일)에 동일한 emailRegisterOptions 적용
 - email regex validation으로 검색한 결과 정규표현식 자체가 너무 길고 이해하기 어려웠음
 - config validation 위해 Joi 라이브러리를 이미 사용하고 있으므로 가져와서 사용함

=> 이메일 검증 필요한 부분에서 @test.co.kr 와 같은 도메인도 입력할 수 있음