### PR TITLE
feat(seller): 판매자 - 주문 상세페이지 판매 유형 추가 #236에서 주문 내 상품별 판매유형 표시

### DIFF
--- a/libs/components-seller/src/lib/OrderDetailGoods.tsx
+++ b/libs/components-seller/src/lib/OrderDetailGoods.tsx
@@ -37,24 +37,19 @@ export function OrderDetailGoods({
         />
       )}
       <Box ml={orderItem.image ? 4 : 0}>
-        <Stack direction="row" alignItems="center">
-          {!sellType.isLoading && sellType.data && (
-            <SellTypeBadge sellType={sellType.data} />
-          )}
-          <Text
-            fontWeight="bold"
-            color="blue.500"
-            textDecoration="underline"
-            cursor="pointer"
-            onClick={() =>
-              window.open(
-                `http://whiletrue.firstmall.kr/goods/view?no=${orderItem.goods_seq}`,
-              )
-            }
-          >
-            {orderItem.goods_name}
-          </Text>
-        </Stack>
+        <Text
+          fontWeight="bold"
+          color="blue.500"
+          textDecoration="underline"
+          cursor="pointer"
+          onClick={() =>
+            window.open(
+              `http://whiletrue.firstmall.kr/goods/view?no=${orderItem.goods_seq}`,
+            )
+          }
+        >
+          {orderItem.goods_name}
+        </Text>
 
         {!option ? (
           <Text>총 주문금액 {orderPrice}</Text>
@@ -65,6 +60,13 @@ export function OrderDetailGoods({
               {option.title} {option.value}
             </Text>
           </Text>
+        )}
+
+        {!sellType.isLoading && sellType.data && (
+          <Stack direction="row" align="center">
+            <Text>판매유형</Text>
+            <SellTypeBadge sellType={sellType.data} lineHeight="unset" />
+          </Stack>
         )}
       </Box>
     </Flex>

--- a/libs/components-seller/src/lib/OrderDetailGoods.tsx
+++ b/libs/components-seller/src/lib/OrderDetailGoods.tsx
@@ -1,5 +1,7 @@
-import { Badge, Box, Flex, Text } from '@chakra-ui/react';
+import { Badge, Box, Flex, Stack, Text } from '@chakra-ui/react';
 import { ChakraNextImage } from '@project-lc/components-core/ChakraNextImage';
+import SellTypeBadge from '@project-lc/components-shared/SellTypeBadge';
+import { useSellerSellType } from '@project-lc/hooks';
 import { FindFmOrderDetailRes } from '@project-lc/shared-types';
 import { useMemo } from 'react';
 
@@ -21,6 +23,8 @@ export function OrderDetailGoods({
     return `${reduced.toLocaleString()} 원`;
   }, [orderItem.options]);
 
+  const sellType = useSellerSellType(orderItem.goods_seq || '');
+
   return (
     <Flex>
       {orderItem.image && (
@@ -33,19 +37,24 @@ export function OrderDetailGoods({
         />
       )}
       <Box ml={orderItem.image ? 4 : 0}>
-        <Text
-          fontWeight="bold"
-          color="blue.500"
-          textDecoration="underline"
-          cursor="pointer"
-          onClick={() =>
-            window.open(
-              `http://whiletrue.firstmall.kr/goods/view?no=${orderItem.goods_seq}`,
-            )
-          }
-        >
-          {orderItem.goods_name}
-        </Text>
+        <Stack direction="row" alignItems="center">
+          {!sellType.isLoading && sellType.data && (
+            <SellTypeBadge sellType={sellType.data} />
+          )}
+          <Text
+            fontWeight="bold"
+            color="blue.500"
+            textDecoration="underline"
+            cursor="pointer"
+            onClick={() =>
+              window.open(
+                `http://whiletrue.firstmall.kr/goods/view?no=${orderItem.goods_seq}`,
+              )
+            }
+          >
+            {orderItem.goods_name}
+          </Text>
+        </Stack>
 
         {!option ? (
           <Text>총 주문금액 {orderPrice}</Text>

--- a/libs/components-seller/src/lib/OrderDetailTitle.tsx
+++ b/libs/components-seller/src/lib/OrderDetailTitle.tsx
@@ -3,10 +3,12 @@ import { TextDotConnector } from '@project-lc/components-core/TextDotConnector';
 import FmOrderStatusBadge from '@project-lc/components-shared/FmOrderStatusBadge';
 import FmRefundStatusBadge from '@project-lc/components-shared/FmRefundStatusBadge';
 import FmReturnStatusBadge from '@project-lc/components-shared/FmReturnStatusBadge';
-import { useOrderReturnOrRefundStatus, useSellerSellType } from '@project-lc/hooks';
+import { useOrderReturnOrRefundStatus } from '@project-lc/hooks';
 import { FindFmOrderDetailRes } from '@project-lc/shared-types';
 import dayjs from 'dayjs';
-import { SellTypeBadge } from '@project-lc/components-shared/SellTypeBadge';
+import relativeTime from 'dayjs/plugin/relativeTime';
+
+dayjs.extend(relativeTime);
 
 export interface OrderDetailTitleProps {
   order: FindFmOrderDetailRes;
@@ -16,14 +18,10 @@ export function OrderDetailTitle({ order }: OrderDetailTitleProps): JSX.Element 
   const refundStatus = useOrderReturnOrRefundStatus(order.refunds);
   // 이 주문의 여러 반품 상태 중, 최종 환불 상태 찾기
   const returnStatus = useOrderReturnOrRefundStatus(order.returns);
-  const sellType = useSellerSellType(order.items?.pop()?.goods_seq || '');
   return (
     <>
       <Heading>주문 {order.id}</Heading>
       <Stack direction="row" alignItems="center">
-        {!sellType.isLoading && sellType.data && (
-          <SellTypeBadge sellType={sellType.data} />
-        )}
         <FmOrderStatusBadge orderStatus={order.step} />
         {order.refunds && order.refunds.length > 0 && refundStatus && (
           <FmRefundStatusBadge refundStatus={refundStatus} />

--- a/libs/components-shared/src/lib/SellTypeBadge.tsx
+++ b/libs/components-shared/src/lib/SellTypeBadge.tsx
@@ -1,27 +1,31 @@
-import { Badge, Box } from '@chakra-ui/react';
+import { Badge, BadgeProps, Box } from '@chakra-ui/react';
 import { SellType } from '@prisma/client';
 
 interface SellTypeBadgeProps {
   sellType: SellType;
+  lineHeight?: BadgeProps['lineHeight'];
 }
 
-export function SellTypeBadge({ sellType }: SellTypeBadgeProps): JSX.Element {
+export function SellTypeBadge({
+  sellType,
+  lineHeight = 2,
+}: SellTypeBadgeProps): JSX.Element {
   switch (sellType) {
     case 'liveShopping':
       return (
-        <Box lineHeight={2}>
+        <Box lineHeight={lineHeight}>
           <Badge colorScheme="green">라이브쇼핑</Badge>
         </Box>
       );
     case 'broadcasterPromotionPage':
       return (
-        <Box lineHeight={2}>
-          <Badge colorScheme="red">홍보페이지</Badge>
+        <Box lineHeight={lineHeight}>
+          <Badge colorScheme="red">상품홍보</Badge>
         </Box>
       );
     case 'normal':
       return (
-        <Box lineHeight={2}>
+        <Box lineHeight={lineHeight}>
           <Badge colorScheme="gray">일반판매</Badge>
         </Box>
       );

--- a/libs/nest-core/src/lib/interceptors/http-cache.interceptor.ts
+++ b/libs/nest-core/src/lib/interceptors/http-cache.interceptor.ts
@@ -1,11 +1,14 @@
 import {
   CacheInterceptor,
   CACHE_KEY_METADATA,
+  CACHE_TTL_METADATA,
+  CallHandler,
   ExecutionContext,
   Injectable,
 } from '@nestjs/common';
 import { Request } from 'express';
 import { join } from 'path';
+import { Observable, of, tap } from 'rxjs';
 
 @Injectable()
 export class HttpCacheInterceptor extends CacheInterceptor {
@@ -43,5 +46,41 @@ export class HttpCacheInterceptor extends CacheInterceptor {
     if (!result) result = req.originalUrl;
 
     return result;
+  }
+
+  async intercept(
+    context: ExecutionContext,
+    next: CallHandler<any>,
+  ): Promise<Observable<any>> {
+    const key = this.trackBy(context);
+    const ttlValueOrFactory =
+      this.reflector.get(CACHE_TTL_METADATA, context.getHandler()) ?? null;
+
+    if (!key) {
+      return next.handle();
+    }
+
+    const isNil = <T = any>(v: T): boolean => {
+      return v === null || v === undefined;
+    };
+    try {
+      const value = await this.cacheManager.get(key);
+      if (isNil(value)) return of(value);
+
+      const ttl =
+        typeof ttlValueOrFactory === 'function'
+          ? await ttlValueOrFactory(context)
+          : ttlValueOrFactory;
+      return next.handle().pipe(
+        tap((response) => {
+          if (isNil(response)) {
+            const args = isNil(ttl) ? [key, response] : [key, response, { ttl }];
+            this.cacheManager.set(...args);
+          }
+        }),
+      );
+    } catch {
+      return next.handle();
+    }
   }
 }

--- a/libs/nest-modules-goods/src/goods/goods.service.ts
+++ b/libs/nest-modules-goods/src/goods/goods.service.ts
@@ -72,14 +72,19 @@ export class GoodsService extends ServiceBaseWithCache {
             fmGoodsSeq: true,
           },
         },
+        productPromotion: {
+          select: { fmGoodsSeq: true },
+        },
       },
     });
 
     const allMyGoodsIds = goodsIds.reduce((prev, goods) => {
       const lsGoodsIds = goods.LiveShopping.map((l) => l.fmGoodsSeq);
+      const productPromotionGoodsIds = goods.productPromotion.map((p) => p.fmGoodsSeq);
       return prev
         .concat(goods.confirmation.firstmallGoodsConnectionId)
-        .concat(lsGoodsIds);
+        .concat(lsGoodsIds)
+        .concat(productPromotionGoodsIds);
     }, []);
 
     return [...new Set(allMyGoodsIds)];


### PR DESCRIPTION
- 주문 상세페이지에서 주문에 대한 판매유형이 아닌 주문 내 포함된 상품별 판매유형 표시
- 판매자의 승인된 상품id 목록 조회 함수에 상품홍보(productPromotion)의 fmGoodsSeq도 추가

음바쿠님이 작업하신 바탕으로 주문 전체의 판매유형 표시하던 것에서
주문 내 포함된 상품의 판매유형 표시하는 방식으로 수정해봤습니다 
판매자 주문 조회시 자신의 상품만 확인하는 부분에서 상품홍보의 fmGoodsSeq가 조회가 안되길래 그부분도 추가하였습니다
이렇게 하면 어떨지?? 확인 부탁드립니다
