### PR TITLE
feat: 퍼스트몰 상품 번호 중복입력되지않도록 처리

### DIFF
--- a/apps/admin/pages/live-shopping/[liveShoppingId].tsx
+++ b/apps/admin/pages/live-shopping/[liveShoppingId].tsx
@@ -53,6 +53,7 @@ import dayjs from 'dayjs';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
+import { AxiosError } from 'axios';
 
 function getDuration(startDate: Date, endDate: Date): string {
   if (startDate && startDate) {
@@ -125,8 +126,12 @@ export function LiveShoppingDetail(): JSX.Element {
     toast({ title: '변경 완료', status: 'success' });
   };
 
-  const onFail = (): void => {
-    toast({ title: '변경 실패', status: 'error' });
+  const onFail = (err?: AxiosError): void => {
+    toast({
+      title: '변경 실패',
+      description: err.response.status === 400 ? err?.response?.data?.message : undefined,
+      status: 'error',
+    });
   };
 
   const { handleSubmit, register, watch, reset } = methods;

--- a/libs/components-admin/src/lib/AdminGoodsConfirmationDialog.tsx
+++ b/libs/components-admin/src/lib/AdminGoodsConfirmationDialog.tsx
@@ -23,6 +23,7 @@ import {
   Stack,
   useMergeRefs,
   useToast,
+  HStack,
 } from '@chakra-ui/react';
 import { GridRowData } from '@material-ui/data-grid';
 import { GridTableItem } from '@project-lc/components-layout/GridTableItem';
@@ -83,12 +84,6 @@ export function AdminGoodsConfirmationDialog(
   });
   const connectionIdRefs = useMergeRefs(initialRef, ref);
 
-  function useClose(): void {
-    reset();
-    onClose();
-    callback();
-  }
-
   const mutation = useGoodConfirmationMutation();
   async function useSubmit(submitData: {
     firstmallGoodsConnectionId: string;
@@ -103,14 +98,15 @@ export function AdminGoodsConfirmationDialog(
         title: '상품 검수 승인이 완료되었습니다.',
         status: 'success',
       });
+      reset();
+      onClose();
+      callback();
     } catch (error) {
       toast({
         title: '상품 검수 승인이 실패하였습니다.',
         description: (error as AxiosError).response?.data.message,
         status: 'error',
       });
-    } finally {
-      useClose();
     }
   }
 
@@ -133,10 +129,12 @@ export function AdminGoodsConfirmationDialog(
             <GridTableItem title="현재 상품명" value={row?.goods_name} />
           </Grid>
           {!row?.agreementFlag && (
-            <Alert status="error">
+            <Alert status="error" mt={2}>
               <Stack>
-                <AlertIcon />
-                <AlertTitle>이용동의를 하지 않은 사용자입니다</AlertTitle>
+                <HStack>
+                  <AlertIcon />
+                  <AlertTitle>이용동의를 하지 않은 사용자입니다</AlertTitle>
+                </HStack>
                 <AlertDescription>
                   해당 판매자(<b>{row?.name}</b>)는 이용 약관에 동의를 하지 않았으므로
                   상품 승인을 할 수 없습니다.

--- a/libs/components-admin/src/lib/AdminGoodsList.tsx
+++ b/libs/components-admin/src/lib/AdminGoodsList.tsx
@@ -38,6 +38,47 @@ function formatDate(date: Date): string {
 // * 상품목록 datagrid 컬럼 ***********************************************
 const columns: GridColumns = [
   {
+    field: 'confirmation',
+    headerName: '검수승인',
+    width: 100,
+    renderCell: () => <Button size="xs">승인하기</Button>,
+    sortable: false,
+  },
+  {
+    field: 'rejection',
+    headerName: '검수반려',
+    width: 100,
+    renderCell: () => <Button size="xs">반려하기</Button>,
+    sortable: false,
+  },
+  {
+    field: 'goods_status',
+    headerName: '상품상태',
+    minWidth: 50,
+    valueGetter: ({ row }) => {
+      return GOODS_STATUS[row.goods_status as GoodsStatus];
+    },
+    sortable: false,
+  },
+  {
+    field: 'confirm_status',
+    headerName: '검수상태',
+    minWidth: 50,
+    renderCell: ({ row }) => {
+      const confirmStatus = row.confirmation.status as GoodsConfirmationStatuses;
+      return <Text>{GOODS_CONFIRMATION_STATUS[confirmStatus].label}</Text>;
+    },
+    sortable: false,
+  },
+  {
+    field: 'businessRegistrationStatus',
+    headerName: '사업자등록정보검수상태',
+    minWidth: 200,
+    renderCell: (params) => (
+      <ConfirmationBadge status={params.row.businessRegistrationStatus} />
+    ),
+  },
+  {
     field: 'name',
     headerName: '판매자 ID',
     minWidth: 110,
@@ -103,47 +144,6 @@ const columns: GridColumns = [
       );
     },
     sortable: false,
-  },
-  {
-    field: 'goods_status',
-    headerName: '상품상태',
-    minWidth: 50,
-    valueGetter: ({ row }) => {
-      return GOODS_STATUS[row.goods_status as GoodsStatus];
-    },
-    sortable: false,
-  },
-  {
-    field: 'confirm_status',
-    headerName: '검수상태',
-    minWidth: 50,
-    renderCell: ({ row }) => {
-      const confirmStatus = row.confirmation.status as GoodsConfirmationStatuses;
-      return <Text>{GOODS_CONFIRMATION_STATUS[confirmStatus].label}</Text>;
-    },
-    sortable: false,
-  },
-  {
-    field: 'confirmation',
-    headerName: '검수승인',
-    width: 100,
-    renderCell: () => <Button size="xs">승인하기</Button>,
-    sortable: false,
-  },
-  {
-    field: 'rejection',
-    headerName: '검수반려',
-    width: 100,
-    renderCell: () => <Button size="xs">반려하기</Button>,
-    sortable: false,
-  },
-  {
-    field: 'businessRegistrationStatus',
-    headerName: '사업자등록정보검수상태',
-    minWidth: 200,
-    renderCell: (params) => (
-      <ConfirmationBadge status={params.row.businessRegistrationStatus} />
-    ),
   },
 ];
 // * 상품목록 datagrid 컬럼 끝*********************************************


### PR DESCRIPTION
[관리자] lc상품, 라이브쇼핑, 상품홍보의  들어가지 않도록 처리


lc상품, 라이브쇼핑, 상품홍보의 연결된 퍼스트몰 고유 상품 번호 (goodsSeq)를 입력할 때, 기존에 입력된 고유상품번호라면 입력되지 않도록 처리 필요

- project-lc 상품 검수 과정
- 라이브쇼핑 정보 수정 과정
- 상품홍보페이지 상품 등록/수정 과정 ⇒ [관리자] 방송인 상품홍보페이지 관리 에서 진행함