### PR TITLE
[fix] 방송인센터 현황창 닫았을때 다시 안열리는 문제 수정

### DIFF
--- a/libs/stores/src/lib/liveShoppingStateBoardWindowStore.tsx
+++ b/libs/stores/src/lib/liveShoppingStateBoardWindowStore.tsx
@@ -2,6 +2,7 @@ import create from 'zustand';
 
 export interface LiveShoppingStateBoardWindowStore {
   _window: Window | null;
+  // windows: Window[];
   openWindow: (url: string, target: string, features: string) => void;
   closeWindow: () => void;
 }
@@ -11,10 +12,13 @@ export const liveShoppingStateBoardWindowStore =
     _window: null,
     openWindow: (url: string, target: string, features: string) => {
       const { _window } = get();
-      if (_window) {
+      if (_window && !_window.closed) {
+        // 윈도우 객체가 존재하고 열려있는 경우
         _window.location.href = url;
         _window.focus();
       } else {
+        // 윈도우 객체가 없거나, 객체는 있지만 닫힌 경우(x 버튼 눌러서 현황창 닫는경우 _window 객체는 존재하나 _window내부 값이 null이 된 경우)
+        // 새 윈도우 객체로 바꾼다
         const w = window.open(url, target, features);
         if (w) set((state) => ({ ...state, _window: w }));
       }


### PR DESCRIPTION
#253 
현황창을 닫았을때 window객체가 null이 될거라 생각했는데
객체는 그대로 있고 객체 내부값이 {window: null, self: null, closed: true, ...} 이 됨

현황창 열때 window 객체 내부 closed 여부도 같이 확인하여
closed인 경우 새로운 window 객체로 갈아끼우도록 수정함

