### PR TITLE
[판매자센터 상품 등록] 사진 업로드시 이미지 1:1 비율로 잘라내는 기능, 등록한 이미지 순서변경 기능 추가

### DIFF
--- a/libs/components-seller/src/lib/GoodsRegistPictureDialog.tsx
+++ b/libs/components-seller/src/lib/GoodsRegistPictureDialog.tsx
@@ -1,5 +1,11 @@
 import { ChevronLeftIcon, ChevronRightIcon } from '@chakra-ui/icons';
 import {
+  Accordion,
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
+  Box,
   Button,
   Divider,
   IconButton,
@@ -273,33 +279,42 @@ export function GoodsRegistPictureDialog({
               )}
             </Stack>
 
-            <Divider />
-
             {/* 크롭 영역 */}
 
             {currentPreview && (
-              <Stack alignItems="center">
-                <Text textAlign="center">
-                  원하는 부분을 선택한 후 적용하기 버튼을 누르면 미리보기 영역에
-                  반영됩니다
-                </Text>
-                <Stack direction="row">
-                  <Button
-                    disabled={!croppedImageBase64Url}
-                    onClick={saveCroppedCurrentPreview}
-                  >
-                    적용하기
-                  </Button>
-                  <Button onClick={revertCurrentPreview}>원래 이미지로 되돌리기</Button>
-                </Stack>
-                <ReactCrop
-                  src={currentPreview.url as string}
-                  crop={crop}
-                  onChange={(newCrop) => setCrop(newCrop)}
-                  onImageLoaded={onImageLoadedHandler}
-                  onComplete={onCropComplete}
-                />
-              </Stack>
+              <Accordion allowToggle defaultIndex={0}>
+                <AccordionItem>
+                  <AccordionButton>
+                    <Box flex="1" textAlign="center">
+                      <AccordionIcon mr={1} />
+                      원하는 부분을 선택한 후 적용하기 버튼을 누르면 미리보기 영역에
+                      반영됩니다
+                    </Box>
+                  </AccordionButton>
+                  <AccordionPanel pb={4}>
+                    <Stack alignItems="center">
+                      <Stack direction="row">
+                        <Button
+                          disabled={!croppedImageBase64Url}
+                          onClick={saveCroppedCurrentPreview}
+                        >
+                          적용하기
+                        </Button>
+                        <Button onClick={revertCurrentPreview}>
+                          원래 이미지로 되돌리기
+                        </Button>
+                      </Stack>
+                      <ReactCrop
+                        src={currentPreview.url as string}
+                        crop={crop}
+                        onChange={(newCrop) => setCrop(newCrop)}
+                        onImageLoaded={onImageLoadedHandler}
+                        onComplete={onCropComplete}
+                      />
+                    </Stack>
+                  </AccordionPanel>
+                </AccordionItem>
+              </Accordion>
             )}
           </Stack>
         </ModalBody>

--- a/libs/components-seller/src/lib/GoodsRegistPictureDialog.tsx
+++ b/libs/components-seller/src/lib/GoodsRegistPictureDialog.tsx
@@ -227,7 +227,7 @@ export function GoodsRegistPictureDialog({
               </Stack>
 
               {/* 미리보기 영역 - 이미지 목록 */}
-              <Stack direction="row">
+              <Stack direction="row" overflowX="auto" p={1}>
                 {previews.length !== 0 &&
                   previews.map((preview, index) => {
                     const { id, filename, url } = preview;
@@ -238,8 +238,6 @@ export function GoodsRegistPictureDialog({
                         filename={filename}
                         url={(url as string) || ''}
                         {...PREVIEW_SIZE}
-                        width={80}
-                        height={80}
                         onDelete={() => deletePreview(id)}
                         onImageClick={() => onImageClick(preview)}
                         selected={currentPreview?.id === preview.id}

--- a/libs/components-seller/src/lib/GoodsRegistPictureDialog.tsx
+++ b/libs/components-seller/src/lib/GoodsRegistPictureDialog.tsx
@@ -1,28 +1,32 @@
-import { ChevronDownIcon, ChevronUpIcon } from '@chakra-ui/icons';
+import { ChevronLeftIcon, ChevronRightIcon } from '@chakra-ui/icons';
 import {
-  Box,
-  Button, Divider, IconButton,
+  Button,
+  Divider,
+  IconButton,
   Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
-  ModalFooter,
   ModalHeader,
   ModalOverlay,
   Stack,
-  Text, useToast
+  Text,
+  useToast,
 } from '@chakra-ui/react';
 import { ImageInput, ImageInputErrorTypes } from '@project-lc/components-core/ImageInput';
 import { Preview, readAsDataURL } from '@project-lc/components-core/ImageInputDialog';
 import { drawImageOnCanvas } from '@project-lc/components-shared/AvatarChangeButton';
 import { useEffect, useRef, useState } from 'react';
 import ReactCrop, { Crop } from 'react-image-crop';
-import { MAX_PICTURE_COUNT, GoodsPreviewItem, PREVIEW_SIZE } from './GoodsRegistPictures';
+import { GoodsPreviewItem, MAX_PICTURE_COUNT, PREVIEW_SIZE } from './GoodsRegistPictures';
 
 // * 상품사진 등록 모달 다이얼로그
 
 export function GoodsRegistPictureDialog({
-  isOpen, onClose, onSave, isLoading,
+  isOpen,
+  onClose,
+  onSave,
+  isLoading,
 }: {
   isOpen: boolean;
   onClose: () => void;
@@ -32,7 +36,7 @@ export function GoodsRegistPictureDialog({
   const toast = useToast();
   const [previews, setPreviews] = useState<Preview[]>([]);
   const [currentPreview, setCurrentPreview] = useState<Preview | null>(
-    previews[0] || null
+    previews[0] || null,
   );
 
   // 잘린 이미지
@@ -116,34 +120,32 @@ export function GoodsRegistPictureDialog({
     aspect: 1,
   });
 
-  const canvasRef = useRef<HTMLCanvasElement|null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
   useEffect(() => {
     if (document) {
       // 마운트 된 후 (document 존재할 때) 1회만 진행
       canvasRef.current = document.createElement('canvas');
     }
-    
-  },[]);
+  }, []);
 
   const imageRef = useRef<HTMLImageElement | null>(null);
   // 이미지파일 불러왔을때 핸들러
   const onImageLoadedHandler = (imgElem: HTMLImageElement): void => {
     imageRef.current = imgElem;
-   
   };
 
   // 크롭영역 선택 핸들러 -> 크롭된 이미지 state에 저장
   const onCropComplete = (_crop: Crop): void => {
     if (imageRef.current && canvasRef.current && _crop.width && _crop.height) {
-      setCrop((crop) => ({ ...crop, height: _crop.height, width: _crop.width }));
-      
+      setCrop((exCrop) => ({ ...exCrop, height: _crop.height, width: _crop.width }));
+
       // 캔버스 요소에 크롭된 영역 이미지를 저장
       drawImageOnCanvas({ canvas: canvasRef.current, image: imageRef.current, _crop });
 
       // 크롭된 이미지를 dataURL형태로 저장
       const url = canvasRef.current.toDataURL();
       setCroppedImageBase64Url(url);
-    };
+    }
   };
 
   const saveCroppedCurrentPreview = (): void => {
@@ -152,30 +154,28 @@ export function GoodsRegistPictureDialog({
     // 크롭된 영역 이미지를 파일로 저장하기 위해 blob으로 변경
     canvasRef.current.toBlob((blob) => {
       if (!blob) {
-        console.error('canvas empty'); 
+        console.error('canvas empty');
         return;
       }
       setPreviews((list) => {
-        return list.map((item) => (
-          item.id === currentPreview.id 
+        return list.map((item) =>
+          item.id === currentPreview.id
             ? {
-              ...item, 
-              url: croppedImageBase64Url, 
-              file: new File(
-                [blob], 
-                item.filename, 
-                { lastModified: new Date().getTime(), type: blob.type }
-                ) // s3에 저장할때는 잘린 이미지의 파일이 필요
-            } 
-            : item
-        ));
+                ...item,
+                url: croppedImageBase64Url,
+                file: new File([blob], item.filename, {
+                  lastModified: new Date().getTime(),
+                  type: blob.type,
+                }), // s3에 저장할때는 잘린 이미지의 파일이 필요
+              }
+            : item,
+        );
       });
     });
   };
 
   const revertCurrentPreview = (): void => {
-    if (!currentPreview || !croppedImageBase64Url)
-      return;
+    if (!currentPreview || !croppedImageBase64Url) return;
     setPreviews((list) => {
       return list.map((item) => {
         if (item.id === currentPreview.id) {
@@ -188,8 +188,8 @@ export function GoodsRegistPictureDialog({
 
   const onImageClick = (preview: Preview): void => {
     setCurrentPreview(preview);
-    setCrop({ unit: '%', width: 100, aspect: 1, x: 0, y: 0});
-  }
+    setCrop({ unit: '%', width: 100, aspect: 1, x: 0, y: 0 });
+  };
 
   return (
     <Modal isOpen={isOpen} onClose={handleClose} size="6xl">
@@ -204,16 +204,30 @@ export function GoodsRegistPictureDialog({
                 multiple
                 handleSuccess={handleSuccess}
                 handleError={handleError}
-                variant="chakra" />
+                variant="chakra"
+              />
             </Stack>
 
             <Divider />
 
-
-            <Stack direction="row">
-              {/* 이미지 미리보기 목록 */}
-              <Stack spacing={2} minW="140px">
+            {/* 미리보기 영역 */}
+            <Stack spacing={2} minH="150px">
+              <Stack direction="row" alignItems="center">
                 <Text>등록할 상품 사진 미리보기</Text>
+                {previews.length > 0 && (
+                  <Button
+                    mr={3}
+                    onClick={() => onSave(previews, handleClose)}
+                    isLoading={isLoading}
+                    colorScheme="blue"
+                  >
+                    모두 등록하기
+                  </Button>
+                )}
+              </Stack>
+
+              {/* 미리보기 영역 - 이미지 목록 */}
+              <Stack direction="row">
                 {previews.length !== 0 &&
                   previews.map((preview, index) => {
                     const { id, filename, url } = preview;
@@ -228,62 +242,69 @@ export function GoodsRegistPictureDialog({
                         height={80}
                         onDelete={() => deletePreview(id)}
                         onImageClick={() => onImageClick(preview)}
-                        selected={currentPreview === preview}
-                        actionButtons={<>
-                          <IconButton
-                            icon={<ChevronUpIcon />}
-                            size="sm"
-                            disabled={index === 0}
-                            onClick={() => {
-                              swap(index - 1, index);
-                            }}
-                            aria-label="위" />
-                          <IconButton
-                            icon={<ChevronDownIcon />}
-                            size="sm"
-                            disabled={index >= previews.length - 1}
-                            onClick={() => {
-                              swap(index + 1, index);
-                            }}
-                            aria-label="아래" />
-                        </>} />
+                        selected={currentPreview?.id === preview.id}
+                        actionButtons={
+                          <>
+                            <IconButton
+                              icon={<ChevronLeftIcon />}
+                              size="sm"
+                              disabled={index === 0}
+                              onClick={() => {
+                                swap(index - 1, index);
+                              }}
+                              aria-label="위"
+                            />
+                            <IconButton
+                              icon={<ChevronRightIcon />}
+                              size="sm"
+                              disabled={index >= previews.length - 1}
+                              onClick={() => {
+                                swap(index + 1, index);
+                              }}
+                              aria-label="아래"
+                            />
+                          </>
+                        }
+                      />
                     );
                   })}
               </Stack>
-              {/* 크롭 */}
-              <Box flexGrow={0}>
-                <Text textAlign="center">크롭영역</Text>
-                {currentPreview && (
-                  <Stack>
-                    <ReactCrop
-                      src={currentPreview.url as string}
-                      crop={crop}
-                      onChange={(newCrop) => setCrop(newCrop)}
-                      onImageLoaded={onImageLoadedHandler}
-                      onComplete={onCropComplete} 
-                    />
-                    <Stack direction="row">
-                      <Button
-                        disabled={!croppedImageBase64Url}
-                        onClick={saveCroppedCurrentPreview}
-                      >
-                        적용하기
-                      </Button>
-                      <Button onClick={revertCurrentPreview}>원래 이미지로 되돌리기</Button>
-                    </Stack>
 
-                  </Stack>
-                )}
-              </Box>
+              {previews.length > 0 && (
+                <Text>이미지를 클릭하여 1:1비율로 자를 수 있습니다</Text>
+              )}
             </Stack>
+
+            <Divider />
+
+            {/* 크롭 영역 */}
+
+            {currentPreview && (
+              <Stack alignItems="center">
+                <Text textAlign="center">
+                  원하는 부분을 선택한 후 적용하기 버튼을 누르면 미리보기 영역에
+                  반영됩니다
+                </Text>
+                <Stack direction="row">
+                  <Button
+                    disabled={!croppedImageBase64Url}
+                    onClick={saveCroppedCurrentPreview}
+                  >
+                    적용하기
+                  </Button>
+                  <Button onClick={revertCurrentPreview}>원래 이미지로 되돌리기</Button>
+                </Stack>
+                <ReactCrop
+                  src={currentPreview.url as string}
+                  crop={crop}
+                  onChange={(newCrop) => setCrop(newCrop)}
+                  onImageLoaded={onImageLoadedHandler}
+                  onComplete={onCropComplete}
+                />
+              </Stack>
+            )}
           </Stack>
         </ModalBody>
-        <ModalFooter>
-          <Button mr={3} onClick={() => onSave(previews, handleClose)} isLoading={isLoading}>
-            저장
-          </Button>
-          <Button onClick={handleClose}>취소</Button>
-        </ModalFooter>
       </ModalContent>
     </Modal>
   );

--- a/libs/components-seller/src/lib/GoodsRegistPictureDialog.tsx
+++ b/libs/components-seller/src/lib/GoodsRegistPictureDialog.tsx
@@ -1,0 +1,290 @@
+import { ChevronDownIcon, ChevronUpIcon } from '@chakra-ui/icons';
+import {
+  Box,
+  Button, Divider, IconButton,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Stack,
+  Text, useToast
+} from '@chakra-ui/react';
+import { ImageInput, ImageInputErrorTypes } from '@project-lc/components-core/ImageInput';
+import { Preview, readAsDataURL } from '@project-lc/components-core/ImageInputDialog';
+import { drawImageOnCanvas } from '@project-lc/components-shared/AvatarChangeButton';
+import { useEffect, useRef, useState } from 'react';
+import ReactCrop, { Crop } from 'react-image-crop';
+import { MAX_PICTURE_COUNT, GoodsPreviewItem, PREVIEW_SIZE } from './GoodsRegistPictures';
+
+// * 상품사진 등록 모달 다이얼로그
+
+export function GoodsRegistPictureDialog({
+  isOpen, onClose, onSave, isLoading,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (previews: Preview[], onSuccess?: () => void) => Promise<void>;
+  isLoading: boolean;
+}): JSX.Element {
+  const toast = useToast();
+  const [previews, setPreviews] = useState<Preview[]>([]);
+  const [currentPreview, setCurrentPreview] = useState<Preview | null>(
+    previews[0] || null
+  );
+
+  // 잘린 이미지
+  const [croppedImageBase64Url, setCroppedImageBase64Url] = useState<string>('');
+
+  // 사진 등록하기 다이얼로그 - 미리보기 이미지 삭제 핸들러
+  const deletePreview = (id: number): void => {
+    if (id === currentPreview?.id) {
+      setCurrentPreview(null);
+    }
+    setPreviews((list) => {
+      const filtered = list.filter((item) => item.id !== id);
+      return [...filtered];
+    });
+  };
+
+  // 사진 등록하기 다이얼로그 - 파일업로드 인풋 성공 핸들러 -> 미리보기 previews에 이미지 추가
+  const handleSuccess = (fileName: string, file: File): void => {
+    // 이미지 최대 8개 등록 가능
+    if (previews.length >= MAX_PICTURE_COUNT) {
+      toast({
+        title: `이미지는 최대 ${MAX_PICTURE_COUNT}개 등록 가능`,
+        status: 'warning',
+      });
+      return;
+    }
+
+    readAsDataURL(file).then(({ data }) => {
+      setPreviews((list) => {
+        const id = list.length === 0 ? 0 : list[list.length - 1].id + 1;
+        const newList = [...list, { id, url: data, filename: fileName, file }];
+        return newList;
+      });
+    });
+  };
+
+  // 사진 등록하기 다일얼로그 - 파일업로드 인풋 에러 핸들러
+  const handleError = (errorType?: ImageInputErrorTypes): void => {
+    switch (errorType) {
+      case 'invalid-format': {
+        toast({
+          title: `이미지 파일을 선택해주세요`,
+          status: 'warning',
+        });
+        return;
+      }
+      case 'over-size': {
+        toast({
+          title: `이미지 파일은 10MB 이하여야 합니다`,
+          status: 'warning',
+        });
+        return;
+      }
+      default: {
+        toast({
+          title: `이미지 파일을 선택해주세요`,
+          status: 'warning',
+        });
+      }
+    }
+  };
+
+  // 사진 등록 다이얼로그 - 닫기 핸들러
+  const handleClose = (): void => {
+    setPreviews([]);
+    setCurrentPreview(null);
+    onClose();
+  };
+
+  // previews array에서 posA, posB 인덱스에 있는 데이터를 바꿈
+  const swap = (posA: number, posB: number): void => {
+    const _previews = [...previews];
+    [_previews[posA], _previews[posB]] = [_previews[posB], _previews[posA]];
+    setPreviews(_previews);
+  };
+
+  // 이미지 크롭 영역 state
+  const [crop, setCrop] = useState<Partial<Crop>>({
+    unit: '%',
+    width: 100,
+    aspect: 1,
+  });
+
+  const canvasRef = useRef<HTMLCanvasElement|null>(null);
+  useEffect(() => {
+    if (document) {
+      // 마운트 된 후 (document 존재할 때) 1회만 진행
+      canvasRef.current = document.createElement('canvas');
+    }
+    
+  },[]);
+
+  const imageRef = useRef<HTMLImageElement | null>(null);
+  // 이미지파일 불러왔을때 핸들러
+  const onImageLoadedHandler = (imgElem: HTMLImageElement): void => {
+    imageRef.current = imgElem;
+   
+  };
+
+  // 크롭영역 선택 핸들러 -> 크롭된 이미지 state에 저장
+  const onCropComplete = (_crop: Crop): void => {
+    if (imageRef.current && canvasRef.current && _crop.width && _crop.height) {
+      setCrop((crop) => ({ ...crop, height: _crop.height, width: _crop.width }));
+      
+      // 캔버스 요소에 크롭된 영역 이미지를 저장
+      drawImageOnCanvas({ canvas: canvasRef.current, image: imageRef.current, _crop });
+
+      // 크롭된 이미지를 dataURL형태로 저장
+      const url = canvasRef.current.toDataURL();
+      setCroppedImageBase64Url(url);
+    };
+  };
+
+  const saveCroppedCurrentPreview = (): void => {
+    if (!currentPreview || !croppedImageBase64Url || !canvasRef.current) return;
+
+    // 크롭된 영역 이미지를 파일로 저장하기 위해 blob으로 변경
+    canvasRef.current.toBlob((blob) => {
+      if (!blob) {
+        console.error('canvas empty'); 
+        return;
+      }
+      setPreviews((list) => {
+        return list.map((item) => (
+          item.id === currentPreview.id 
+            ? {
+              ...item, 
+              url: croppedImageBase64Url, 
+              file: new File(
+                [blob], 
+                item.filename, 
+                { lastModified: new Date().getTime(), type: blob.type }
+                ) // s3에 저장할때는 잘린 이미지의 파일이 필요
+            } 
+            : item
+        ));
+      });
+    });
+  };
+
+  const revertCurrentPreview = (): void => {
+    if (!currentPreview || !croppedImageBase64Url)
+      return;
+    setPreviews((list) => {
+      return list.map((item) => {
+        if (item.id === currentPreview.id) {
+          return { ...item, url: currentPreview.url };
+        }
+        return item;
+      });
+    });
+  };
+
+  const onImageClick = (preview: Preview): void => {
+    setCurrentPreview(preview);
+    setCrop({ unit: '%', width: 100, aspect: 1, x: 0, y: 0});
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} size="6xl">
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>등록할 상품 사진을 선택해주세요</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Stack>
+            <Stack direction="row">
+              <ImageInput
+                multiple
+                handleSuccess={handleSuccess}
+                handleError={handleError}
+                variant="chakra" />
+            </Stack>
+
+            <Divider />
+
+
+            <Stack direction="row">
+              {/* 이미지 미리보기 목록 */}
+              <Stack spacing={2} minW="140px">
+                <Text>등록할 상품 사진 미리보기</Text>
+                {previews.length !== 0 &&
+                  previews.map((preview, index) => {
+                    const { id, filename, url } = preview;
+                    return (
+                      <GoodsPreviewItem
+                        key={id}
+                        id={id}
+                        filename={filename}
+                        url={(url as string) || ''}
+                        {...PREVIEW_SIZE}
+                        width={80}
+                        height={80}
+                        onDelete={() => deletePreview(id)}
+                        onImageClick={() => onImageClick(preview)}
+                        selected={currentPreview === preview}
+                        actionButtons={<>
+                          <IconButton
+                            icon={<ChevronUpIcon />}
+                            size="sm"
+                            disabled={index === 0}
+                            onClick={() => {
+                              swap(index - 1, index);
+                            }}
+                            aria-label="위" />
+                          <IconButton
+                            icon={<ChevronDownIcon />}
+                            size="sm"
+                            disabled={index >= previews.length - 1}
+                            onClick={() => {
+                              swap(index + 1, index);
+                            }}
+                            aria-label="아래" />
+                        </>} />
+                    );
+                  })}
+              </Stack>
+              {/* 크롭 */}
+              <Box flexGrow={0}>
+                <Text textAlign="center">크롭영역</Text>
+                {currentPreview && (
+                  <Stack>
+                    <ReactCrop
+                      src={currentPreview.url as string}
+                      crop={crop}
+                      onChange={(newCrop) => setCrop(newCrop)}
+                      onImageLoaded={onImageLoadedHandler}
+                      onComplete={onCropComplete} 
+                    />
+                    <Stack direction="row">
+                      <Button
+                        disabled={!croppedImageBase64Url}
+                        onClick={saveCroppedCurrentPreview}
+                      >
+                        적용하기
+                      </Button>
+                      <Button onClick={revertCurrentPreview}>원래 이미지로 되돌리기</Button>
+                    </Stack>
+
+                  </Stack>
+                )}
+              </Box>
+            </Stack>
+          </Stack>
+        </ModalBody>
+        <ModalFooter>
+          <Button mr={3} onClick={() => onSave(previews, handleClose)} isLoading={isLoading}>
+            저장
+          </Button>
+          <Button onClick={handleClose}>취소</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/libs/components-seller/src/lib/GoodsRegistPictureDialog.tsx
+++ b/libs/components-seller/src/lib/GoodsRegistPictureDialog.tsx
@@ -192,7 +192,7 @@ export function GoodsRegistPictureDialog({
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={handleClose} size="6xl">
+    <Modal isOpen={isOpen} onClose={handleClose} size="4xl">
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>등록할 상품 사진을 선택해주세요</ModalHeader>

--- a/libs/components-seller/src/lib/GoodsRegistPictureDialog.tsx
+++ b/libs/components-seller/src/lib/GoodsRegistPictureDialog.tsx
@@ -245,7 +245,7 @@ export function GoodsRegistPictureDialog({
                           <>
                             <IconButton
                               icon={<ChevronLeftIcon />}
-                              size="sm"
+                              size="xs"
                               disabled={index === 0}
                               onClick={() => {
                                 swap(index - 1, index);
@@ -254,7 +254,7 @@ export function GoodsRegistPictureDialog({
                             />
                             <IconButton
                               icon={<ChevronRightIcon />}
-                              size="sm"
+                              size="xs"
                               disabled={index >= previews.length - 1}
                               onClick={() => {
                                 swap(index + 1, index);

--- a/libs/components-seller/src/lib/GoodsRegistPictureOrderChangeDialog.tsx
+++ b/libs/components-seller/src/lib/GoodsRegistPictureOrderChangeDialog.tsx
@@ -1,5 +1,6 @@
 import { ChevronDownIcon, ChevronUpIcon } from '@chakra-ui/icons';
 import {
+  Box,
   Button,
   IconButton,
   Modal,
@@ -87,13 +88,18 @@ export function GoodsRegistPictureOrderChangeDialog({
                 key={i.id}
                 position="relative"
                 data-image-index={index}
+                spacing={1}
               >
-                <ChakraNextImage
-                  layout="intrinsic"
-                  alt={i.image}
-                  src={i.image || ''}
-                  {...PREVIEW_SIZE}
-                />
+                <Text>{index + 1}</Text>
+                <Box>
+                  <ChakraNextImage
+                    layout="intrinsic"
+                    alt={i.image}
+                    src={i.image || ''}
+                    {...PREVIEW_SIZE}
+                  />
+                </Box>
+
                 <Stack justifyContent="center">
                   <IconButton
                     icon={<ChevronUpIcon />}

--- a/libs/components-seller/src/lib/GoodsRegistPictureOrderChangeDialog.tsx
+++ b/libs/components-seller/src/lib/GoodsRegistPictureOrderChangeDialog.tsx
@@ -1,6 +1,7 @@
+import { ChevronDownIcon, ChevronUpIcon } from '@chakra-ui/icons';
 import {
-  Text,
   Button,
+  IconButton,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -8,8 +9,8 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  Box,
   Stack,
+  Text,
   useToast,
 } from '@chakra-ui/react';
 import { ChakraNextImage } from '@project-lc/components-core/ChakraNextImage';
@@ -30,20 +31,12 @@ export function GoodsRegistPictureOrderChangeDialog({
   savedImages: GoodsImageDto[];
 }): JSX.Element {
   const toast = useToast();
-  const { setValue, getValues } = useFormContext<GoodsFormValues>();
-  const [draggingItem, setDraggingItem] = useState<null | HTMLElement>(null);
+  const { setValue } = useFormContext<GoodsFormValues>();
   const [imageListCopy, setImageListCopy] = useState<GoodsImageDto[]>([]);
 
   useEffect(() => {
     setImageListCopy([...savedImages]);
-  },[savedImages]);
-
-  const onDragStart = (event: React.DragEvent<HTMLDivElement>): void => {
-    const dragTarget = event.currentTarget;
-    const { imageIndex } = dragTarget.dataset;
-    setDraggingItem(dragTarget);
-    event.dataTransfer.setData('imageIndex', imageIndex || '');
-  };
+  }, [savedImages]);
 
   const moveDraggingItemFromTo = (
     draggingItemIndex: number,
@@ -56,30 +49,6 @@ export function GoodsRegistPictureOrderChangeDialog({
     setImageListCopy(
       _imageList.map((_image, index) => ({ ..._image, cut_number: index })),
     );
-  };
-
-  const onDrop = (event: React.DragEvent<HTMLDivElement>): void => {
-    event.preventDefault();
-    if (!draggingItem) return;
-    const dropTarget = event.currentTarget;
-
-    const dropTargetImageIndex = Number(dropTarget.dataset.imageIndex);
-    const dragTargetImageIndex = Number(event.dataTransfer.getData('imageIndex'));
-
-    if (dropTargetImageIndex === dragTargetImageIndex) {
-      return;
-    } // 동일 위치에 둔거면 종료
-
-    moveDraggingItemFromTo(dragTargetImageIndex, dropTargetImageIndex);
-  };
-
-  // This makes the third box become droppable
-  const onDragOver = (event: React.DragEvent<HTMLDivElement>): void => {
-    event.preventDefault();
-  };
-
-  const onDragEnd = (event: React.DragEvent<HTMLDivElement>): void => {
-    setDraggingItem(null);
   };
 
   const handleClose = (): void => {
@@ -113,15 +82,11 @@ export function GoodsRegistPictureOrderChangeDialog({
           <Text>이미지 순서를 변경해주세요</Text>
           <Stack>
             {imageListCopy.map((i, index) => (
-              <Box
+              <Stack
+                direction="row"
                 key={i.id}
                 position="relative"
-                draggable={!isLoading}
                 data-image-index={index}
-                onDragStart={onDragStart}
-                onDragOver={onDragOver}
-                onDrop={onDrop}
-                onDragEnd={onDragEnd}
               >
                 <ChakraNextImage
                   layout="intrinsic"
@@ -129,7 +94,27 @@ export function GoodsRegistPictureOrderChangeDialog({
                   src={i.image || ''}
                   {...PREVIEW_SIZE}
                 />
-              </Box>
+                <Stack justifyContent="center">
+                  <IconButton
+                    icon={<ChevronUpIcon />}
+                    size="xs"
+                    disabled={index === 0}
+                    onClick={() => {
+                      moveDraggingItemFromTo(index, index - 1);
+                    }}
+                    aria-label="위"
+                  />
+                  <IconButton
+                    icon={<ChevronDownIcon />}
+                    size="xs"
+                    disabled={index >= imageListCopy.length - 1}
+                    onClick={() => {
+                      moveDraggingItemFromTo(index, index + 1);
+                    }}
+                    aria-label="아래"
+                  />
+                </Stack>
+              </Stack>
             ))}
           </Stack>
         </ModalBody>

--- a/libs/components-seller/src/lib/GoodsRegistPictureOrderChangeDialog.tsx
+++ b/libs/components-seller/src/lib/GoodsRegistPictureOrderChangeDialog.tsx
@@ -1,0 +1,39 @@
+import {
+  Text,
+  Button,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+} from '@chakra-ui/react';
+
+export function GoodsRegistPictureOrderChangeDialog({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+}): JSX.Element {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>등록된 상품 사진 순서 변경</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Text>이미지 순서를 변경해주세요</Text>
+        </ModalBody>
+
+        <ModalFooter>
+          <Button colorScheme="blue" mr={3} onClick={onClose}>
+            Close
+          </Button>
+          <Button variant="ghost">Secondary Action</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/libs/components-seller/src/lib/GoodsRegistPictureOrderChangeDialog.tsx
+++ b/libs/components-seller/src/lib/GoodsRegistPictureOrderChangeDialog.tsx
@@ -15,7 +15,7 @@ import {
 import { ChakraNextImage } from '@project-lc/components-core/ChakraNextImage';
 import { useGoodsImageOrderMutation } from '@project-lc/hooks';
 import { GoodsImageDto } from '@project-lc/shared-types';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { GoodsFormValues } from './GoodsRegistForm';
 import { PREVIEW_SIZE } from './GoodsRegistPictures';
@@ -23,15 +23,20 @@ import { PREVIEW_SIZE } from './GoodsRegistPictures';
 export function GoodsRegistPictureOrderChangeDialog({
   isOpen,
   onClose,
+  savedImages,
 }: {
   isOpen: boolean;
   onClose: () => void;
+  savedImages: GoodsImageDto[];
 }): JSX.Element {
   const toast = useToast();
   const { setValue, getValues } = useFormContext<GoodsFormValues>();
-  const imageList = getValues('image');
   const [draggingItem, setDraggingItem] = useState<null | HTMLElement>(null);
-  const [imageListCopy, setImageListCopy] = useState<GoodsImageDto[]>(imageList);
+  const [imageListCopy, setImageListCopy] = useState<GoodsImageDto[]>([]);
+
+  useEffect(() => {
+    setImageListCopy([...savedImages]);
+  },[savedImages]);
 
   const onDragStart = (event: React.DragEvent<HTMLDivElement>): void => {
     const dragTarget = event.currentTarget;
@@ -83,7 +88,7 @@ export function GoodsRegistPictureOrderChangeDialog({
 
   const { mutateAsync, isLoading } = useGoodsImageOrderMutation();
   const saveChangedOrder = (): void => {
-    console.log(imageListCopy);
+    if (!imageListCopy.length) return;
     // 이미지 순서(cut_number) 변경 요청
     mutateAsync(imageListCopy)
       .then(() => {

--- a/libs/components-seller/src/lib/GoodsRegistPictureOrderChangeDialog.tsx
+++ b/libs/components-seller/src/lib/GoodsRegistPictureOrderChangeDialog.tsx
@@ -8,7 +8,15 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  Box,
+  Stack,
 } from '@chakra-ui/react';
+import { ChakraNextImage } from '@project-lc/components-core/ChakraNextImage';
+import { GoodsImageDto } from '@project-lc/shared-types';
+import { useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { GoodsFormValues } from './GoodsRegistForm';
+import { PREVIEW_SIZE } from './GoodsRegistPictures';
 
 export function GoodsRegistPictureOrderChangeDialog({
   isOpen,
@@ -17,6 +25,55 @@ export function GoodsRegistPictureOrderChangeDialog({
   isOpen: boolean;
   onClose: () => void;
 }): JSX.Element {
+  const { setValue, getValues } = useFormContext<GoodsFormValues>();
+  const imageList = getValues('image');
+  const [draggingItem, setDraggingItem] = useState<null | HTMLElement>(null);
+
+  const dragStartHandler = (event: React.DragEvent<HTMLDivElement>): void => {
+    const dragTarget = event.currentTarget;
+    const imageIndex = dragTarget.dataset.imageIndex;
+    console.log('drag start', {imageIndex});
+    setDraggingItem(dragTarget);
+    event.dataTransfer.setData('imageIndex', imageIndex || '');
+    event.dataTransfer.dropEffect = 'move';
+  }
+
+  // This function will be triggered when dropping
+  const dropHandler = (event: React.DragEvent<HTMLDivElement>): void => {
+    event.preventDefault();
+    if (!draggingItem) return;
+    const dropTarget = event.currentTarget;
+    const dropY = event.clientY; // 드롭할 y 포지션
+    const draggingItemY = draggingItem.getBoundingClientRect().y; // 드래그하고 있는 ㄴ아이템의 기존 y위치
+    console.log({dropY, draggingItemY}); 
+    const dropTargetImageIndex = dropTarget.dataset.imageIndex;
+    const dragTargetImageIndex = event.dataTransfer.getData('imageIndex');
+
+    if (dropY > draggingItemY) {
+
+    }
+    if (dropY < draggingItemY) {
+
+    }
+    // dropY < draggingItemY 이면 위로 드래그한거 -> 드래깅 아이템을 dropTargetIndex -1 으로 위치
+    // dropY > draggingItemY 이면 아래로 드래그한거 -> 드래깅 아이템을 dropTargetIndex + 1 으로 위치
+    // set
+    
+    console.log('drop', { dropTargetImageIndex, dragTargetImageIndex, draggingItemY, dropY });
+
+    // setContent(data);
+  };
+
+  // This makes the third box become droppable
+  const allowDrop = (event: React.DragEvent<HTMLDivElement>): void => {
+    event.preventDefault();
+  };
+
+  const dragEndHandler = (event: React.DragEvent<HTMLDivElement>): void => {
+    setDraggingItem(null);
+    console.log('drag end!!');
+  }
+
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
@@ -25,6 +82,27 @@ export function GoodsRegistPictureOrderChangeDialog({
         <ModalCloseButton />
         <ModalBody>
           <Text>이미지 순서를 변경해주세요</Text>
+          <Stack>
+            {imageList.map((i, index) => (
+              <Box
+                key={i.id}
+                position="relative"
+                draggable
+                data-image-index={index}
+                onDragStart={dragStartHandler}
+                onDragOver={allowDrop}
+                onDrop={dropHandler}
+                onDragEnd={dragEndHandler}
+              >
+                <ChakraNextImage
+                  layout="intrinsic"
+                  alt={i.image}
+                  src={i.image || ''}
+                  {...PREVIEW_SIZE}
+                />
+              </Box>
+            ))}
+          </Stack>
         </ModalBody>
 
         <ModalFooter>

--- a/libs/components-seller/src/lib/GoodsRegistPictureOrderChangeDialog.tsx
+++ b/libs/components-seller/src/lib/GoodsRegistPictureOrderChangeDialog.tsx
@@ -28,54 +28,57 @@ export function GoodsRegistPictureOrderChangeDialog({
   const { setValue, getValues } = useFormContext<GoodsFormValues>();
   const imageList = getValues('image');
   const [draggingItem, setDraggingItem] = useState<null | HTMLElement>(null);
+  const [imageListCopy, setImageListCopy] = useState<GoodsImageDto[]>(imageList);
 
-  const dragStartHandler = (event: React.DragEvent<HTMLDivElement>): void => {
+  const onDragStart = (event: React.DragEvent<HTMLDivElement>): void => {
     const dragTarget = event.currentTarget;
     const imageIndex = dragTarget.dataset.imageIndex;
-    console.log('drag start', {imageIndex});
     setDraggingItem(dragTarget);
     event.dataTransfer.setData('imageIndex', imageIndex || '');
     event.dataTransfer.dropEffect = 'move';
   }
 
-  // This function will be triggered when dropping
-  const dropHandler = (event: React.DragEvent<HTMLDivElement>): void => {
+  const moveDraggingItemFromTo = (draggingItemIndex: number, dropPositionIndex: number): void => {
+    const _imageList = [...imageListCopy];
+    const _moving = _imageList.splice(draggingItemIndex, 1)[0];
+    _imageList.splice(dropPositionIndex, 0, _moving);
+    setImageListCopy(_imageList);
+  }
+
+  const onDrop = (event: React.DragEvent<HTMLDivElement>): void => {
     event.preventDefault();
     if (!draggingItem) return;
     const dropTarget = event.currentTarget;
-    const dropY = event.clientY; // 드롭할 y 포지션
-    const draggingItemY = draggingItem.getBoundingClientRect().y; // 드래그하고 있는 ㄴ아이템의 기존 y위치
-    console.log({dropY, draggingItemY}); 
-    const dropTargetImageIndex = dropTarget.dataset.imageIndex;
-    const dragTargetImageIndex = event.dataTransfer.getData('imageIndex');
 
-    if (dropY > draggingItemY) {
+    const dropTargetImageIndex = Number(dropTarget.dataset.imageIndex);
+    const dragTargetImageIndex = Number(event.dataTransfer.getData('imageIndex'));
 
-    }
-    if (dropY < draggingItemY) {
+    if (dropTargetImageIndex === dragTargetImageIndex) {return;} // 동일 위치에 둔거면 종료
 
-    }
-    // dropY < draggingItemY 이면 위로 드래그한거 -> 드래깅 아이템을 dropTargetIndex -1 으로 위치
-    // dropY > draggingItemY 이면 아래로 드래그한거 -> 드래깅 아이템을 dropTargetIndex + 1 으로 위치
-    // set
-    
-    console.log('drop', { dropTargetImageIndex, dragTargetImageIndex, draggingItemY, dropY });
+    moveDraggingItemFromTo(dragTargetImageIndex, dropTargetImageIndex);
 
-    // setContent(data);
   };
 
   // This makes the third box become droppable
-  const allowDrop = (event: React.DragEvent<HTMLDivElement>): void => {
+  const onDragOver = (event: React.DragEvent<HTMLDivElement>): void => {
     event.preventDefault();
   };
 
-  const dragEndHandler = (event: React.DragEvent<HTMLDivElement>): void => {
+  const onDragEnd = (event: React.DragEvent<HTMLDivElement>): void => {
     setDraggingItem(null);
-    console.log('drag end!!');
+  }
+
+  const handleClose = (): void => {
+    onClose();
+  }
+
+  const saveChangedOrder = (): void => {
+
+    // 이미지 
   }
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal isOpen={isOpen} onClose={handleClose}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>등록된 상품 사진 순서 변경</ModalHeader>
@@ -83,33 +86,37 @@ export function GoodsRegistPictureOrderChangeDialog({
         <ModalBody>
           <Text>이미지 순서를 변경해주세요</Text>
           <Stack>
-            {imageList.map((i, index) => (
+            {imageListCopy.map((i, index) => (
               <Box
                 key={i.id}
                 position="relative"
                 draggable
                 data-image-index={index}
-                onDragStart={dragStartHandler}
-                onDragOver={allowDrop}
-                onDrop={dropHandler}
-                onDragEnd={dragEndHandler}
+                onDragStart={onDragStart}
+                onDragOver={onDragOver}
+                onDrop={onDrop}
+                onDragEnd={onDragEnd}
               >
+                <Text direction="row">
+                  {index}
+                </Text>
                 <ChakraNextImage
                   layout="intrinsic"
                   alt={i.image}
                   src={i.image || ''}
                   {...PREVIEW_SIZE}
                 />
+                
               </Box>
             ))}
           </Stack>
         </ModalBody>
 
         <ModalFooter>
-          <Button colorScheme="blue" mr={3} onClick={onClose}>
-            Close
+          <Button colorScheme="blue" mr={3} onClick={saveChangedOrder}>
+            변경하기
           </Button>
-          <Button variant="ghost">Secondary Action</Button>
+          <Button variant="ghost" onClick={handleClose}>닫기</Button>
         </ModalFooter>
       </ModalContent>
     </Modal>

--- a/libs/components-seller/src/lib/GoodsRegistPictures.tsx
+++ b/libs/components-seller/src/lib/GoodsRegistPictures.tsx
@@ -232,7 +232,14 @@ export function GoodsRegistPictures(): JSX.Element {
                     src={i.image || ''}
                     {...PREVIEW_SIZE}
                   />
-                  <Box bg="rgba(0,0,0,0.3)" width="100%" height={`${PREVIEW_SIZE.height / 3}px`} position="absolute" left={0} top={0}/>
+                  <Box
+                    bg="rgba(0,0,0,0.3)"
+                    width="100%"
+                    height={`${PREVIEW_SIZE.height / 3}px`}
+                    position="absolute"
+                    left={0}
+                    top={0}
+                  />
                   <IconButton
                     aria-label="등록된 이미지 삭제"
                     icon={<CloseIcon />}

--- a/libs/components-seller/src/lib/GoodsRegistPictures.tsx
+++ b/libs/components-seller/src/lib/GoodsRegistPictures.tsx
@@ -64,7 +64,7 @@ export function GoodsPreviewItem(
     actionButtons,
     selected,
     width,
-    height
+    height,
   } = props;
 
   return (
@@ -81,7 +81,13 @@ export function GoodsPreviewItem(
         minW={`${width}px`}
         minH={`${height}px`}
       >
-        <ChakraNextImage layout="intrinsic" alt={fileName} src={url} width={width} height={height} />
+        <ChakraNextImage
+          layout="intrinsic"
+          alt={fileName}
+          src={url}
+          width={width}
+          height={height}
+        />
       </Box>
 
       <Stack m={0}>

--- a/libs/components-seller/src/lib/GoodsRegistPictures.tsx
+++ b/libs/components-seller/src/lib/GoodsRegistPictures.tsx
@@ -71,7 +71,9 @@ export function GoodsPreviewItem(
     <Stack
       direction="row"
       alignItems="center"
-      borderWidth={selected ? '3px' : '1px'}
+      borderWidth="1px"
+      outline={selected ? 'auto' : undefined}
+      outlineColor={selected ? 'blue' : undefined}
       borderRadius="lg"
       p={1}
     >

--- a/libs/components-seller/src/lib/GoodsRegistPictures.tsx
+++ b/libs/components-seller/src/lib/GoodsRegistPictures.tsx
@@ -5,7 +5,7 @@ import {
   Stack,
   Text,
   useDisclosure,
-  useToast
+  useToast,
 } from '@chakra-ui/react';
 import { ChakraNextImage } from '@project-lc/components-core/ChakraNextImage';
 import { Preview } from '@project-lc/components-core/ImageInputDialog';
@@ -13,7 +13,7 @@ import SectionWithTitle from '@project-lc/components-layout/SectionWithTitle';
 import {
   useDeleteGoodsImageMutation,
   useGoodsImageMutation,
-  useProfile
+  useProfile,
 } from '@project-lc/hooks';
 import { GoodsImageDto } from '@project-lc/shared-types';
 import { useFormContext } from 'react-hook-form';
@@ -96,7 +96,10 @@ export function GoodsRegistPictures(): JSX.Element {
 
   /** 사진 등록 다이얼로그에서 저장 눌렀을때 - 이미지 저장하는 핸들러 */
   const registImage = useGoodsImageMutation();
-  const savePictures = async (previews: Preview[], onSuccess?: () => void): Promise<void> => {
+  const savePictures = async (
+    previews: Preview[],
+    onSuccess?: () => void,
+  ): Promise<void> => {
     if (!profileData) return;
 
     // 사진 개수 제한 - 저장된 이미지 + 등록할 이미지 개수가 8개 넘어가면 저장 안되도록
@@ -127,14 +130,11 @@ export function GoodsRegistPictures(): JSX.Element {
         })),
       );
 
-      console.log({result});
-
       // formState에 image에 저장
       setValue('image', prevImages ? [...prevImages, ...result] : [...result]);
 
       toast({ title: '이미지가 저장되었습니다', status: 'success' });
       if (onSuccess) onSuccess();
-
     } catch (error: any) {
       console.error(error);
       if (error?.response && error?.response?.status === 400) {
@@ -212,5 +212,3 @@ export function GoodsRegistPictures(): JSX.Element {
 }
 
 export default GoodsRegistPictures;
-
-

--- a/libs/components-seller/src/lib/GoodsRegistPictures.tsx
+++ b/libs/components-seller/src/lib/GoodsRegistPictures.tsx
@@ -261,6 +261,7 @@ export function GoodsRegistPictures(): JSX.Element {
       />
 
       <GoodsRegistPictureOrderChangeDialog
+        savedImages={savedImages}
         isOpen={imageOrderChangeDialog.isOpen}
         onClose={imageOrderChangeDialog.onClose}
       />
@@ -271,7 +272,7 @@ export function GoodsRegistPictures(): JSX.Element {
         title="이미지 삭제"
         onConfirm={deletePicture}
       >
-        <Text>{deleteImageId} 해당 이미지를 삭제하시겠습니까?</Text>
+        <Text>해당 이미지를 삭제하시겠습니까?</Text>
       </ConfirmDialog>
     </SectionWithTitle>
   );

--- a/libs/components-seller/src/lib/GoodsRegistPictures.tsx
+++ b/libs/components-seller/src/lib/GoodsRegistPictures.tsx
@@ -232,13 +232,14 @@ export function GoodsRegistPictures(): JSX.Element {
                     src={i.image || ''}
                     {...PREVIEW_SIZE}
                   />
+                  <Box bg="rgba(0,0,0,0.3)" width="100%" height={`${PREVIEW_SIZE.height / 3}px`} position="absolute" left={0} top={0}/>
                   <IconButton
                     aria-label="등록된 이미지 삭제"
                     icon={<CloseIcon />}
                     size="xs"
                     position="absolute"
-                    right={1}
-                    top={1}
+                    right={0}
+                    top={0}
                     onClick={() => {
                       setDeleteImageId(i.id || null);
                       imageDeleteConfirmDialog.onOpen();

--- a/libs/components-seller/src/lib/GoodsRegistPictures.tsx
+++ b/libs/components-seller/src/lib/GoodsRegistPictures.tsx
@@ -63,7 +63,8 @@ export function GoodsPreviewItem(
     onImageClick,
     actionButtons,
     selected,
-    ...rest
+    width,
+    height
   } = props;
 
   return (
@@ -77,10 +78,10 @@ export function GoodsPreviewItem(
       <Box
         onClick={onImageClick}
         cursor={onImageClick ? 'pointer' : undefined}
-        minW="80px"
-        minH="80px"
+        minW={`${width}px`}
+        minH={`${height}px`}
       >
-        <ChakraNextImage layout="intrinsic" alt={fileName} src={url} {...rest} />
+        <ChakraNextImage layout="intrinsic" alt={fileName} src={url} width={width} height={height} />
       </Box>
 
       <Stack m={0}>

--- a/libs/components-shared/src/lib/AvatarChangeButton.tsx
+++ b/libs/components-shared/src/lib/AvatarChangeButton.tsx
@@ -223,6 +223,7 @@ export function AvatarChangeButton(): JSX.Element {
                         imageRef.current = image;
                       }}
                       onComplete={onCropComplete}
+                      circularCrop
                     />
                   </Box>
                 )}

--- a/libs/components-shared/src/lib/AvatarChangeButton.tsx
+++ b/libs/components-shared/src/lib/AvatarChangeButton.tsx
@@ -30,27 +30,29 @@ import ReactCrop, { Crop } from 'react-image-crop';
 import 'react-image-crop/dist/ReactCrop.css';
 import { boxStyle } from '@project-lc/components-constants/commonStyleProps';
 
-
 export type DrawImageOnCanvasProp = {
-  canvas: HTMLCanvasElement,
-  image: HTMLImageElement,
-  _crop: Crop,
-}
+  canvas: HTMLCanvasElement;
+  image: HTMLImageElement;
+  _crop: Crop;
+};
 // img 태그에 표시된 이미지를 canvas에 표시하고 crop 의 크기만큼 잘라냄
 // 이미지 그린 캔버스 리턴
-export const drawImageOnCanvas = ({canvas, image, _crop}:DrawImageOnCanvasProp): HTMLCanvasElement => {
-  
+export const drawImageOnCanvas = ({
+  canvas,
+  image,
+  _crop,
+}: DrawImageOnCanvasProp): HTMLCanvasElement => {
+  const _canvas = canvas;
   const pixelRatio = window.devicePixelRatio;
   const scaleX = image.naturalWidth / image.width;
   const scaleY = image.naturalHeight / image.height;
-  const ctx = canvas.getContext('2d');
+  const ctx = _canvas.getContext('2d');
 
-  canvas.width = _crop.width * pixelRatio * scaleX;
-  canvas.height = _crop.height * pixelRatio * scaleY;
+  _canvas.width = _crop.width * pixelRatio * scaleX;
+  _canvas.height = _crop.height * pixelRatio * scaleY;
 
- 
   if (!ctx) {
-    throw new Error('No 2d context')
+    throw new Error('No 2d context');
   }
 
   ctx.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
@@ -68,8 +70,8 @@ export const drawImageOnCanvas = ({canvas, image, _crop}:DrawImageOnCanvasProp):
     _crop.height * scaleY,
   );
 
-  return canvas;
-}
+  return _canvas;
+};
 
 /**
  * 이미지 잘라내어 "blob"으로 변환하는 함수
@@ -84,7 +86,7 @@ export const getCroppedImage = (
   blobCallback: BlobCallback,
 ): void => {
   const canvas = document.createElement('canvas');
-  drawImageOnCanvas({canvas, image,_crop}).toBlob(blobCallback, 'image/jpeg', 1);
+  drawImageOnCanvas({ canvas, image, _crop }).toBlob(blobCallback, 'image/jpeg', 1);
 };
 
 export function AvatarChangeButton(): JSX.Element {

--- a/libs/components-shared/src/lib/AvatarChangeButton.tsx
+++ b/libs/components-shared/src/lib/AvatarChangeButton.tsx
@@ -30,19 +30,16 @@ import ReactCrop, { Crop } from 'react-image-crop';
 import 'react-image-crop/dist/ReactCrop.css';
 import { boxStyle } from '@project-lc/components-constants/commonStyleProps';
 
-/**
- * 이미지 잘라내어 blob으로 변환하는 함수
- * img 태그에 표시된 이미지를 canvas에 표시 -> crop 의 크기만큼 잘라 blob으로 변환 -> blobcallback 적용
- * @param image HTMLImageElement 잘라낼 이미지
- * @param _crop x,y,height,width 값 가지고 있다
- * @param blobCallback 클롭된 이미지 처리할 함수, blob으로 변환된 이미지를 받아 원하는 작업을 하는 콜백함수
- */
-export const getCroppedImage = (
+
+export type DrawImageOnCanvasProp = {
+  canvas: HTMLCanvasElement,
   image: HTMLImageElement,
   _crop: Crop,
-  blobCallback: BlobCallback,
-): void => {
-  const canvas = document.createElement('canvas');
+}
+// img 태그에 표시된 이미지를 canvas에 표시하고 crop 의 크기만큼 잘라냄
+// 이미지 그린 캔버스 리턴
+export const drawImageOnCanvas = ({canvas, image, _crop}:DrawImageOnCanvasProp): HTMLCanvasElement => {
+  
   const pixelRatio = window.devicePixelRatio;
   const scaleX = image.naturalWidth / image.width;
   const scaleY = image.naturalHeight / image.height;
@@ -51,7 +48,10 @@ export const getCroppedImage = (
   canvas.width = _crop.width * pixelRatio * scaleX;
   canvas.height = _crop.height * pixelRatio * scaleY;
 
-  if (!ctx) return;
+ 
+  if (!ctx) {
+    throw new Error('No 2d context')
+  }
 
   ctx.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
   ctx.imageSmoothingQuality = 'high';
@@ -68,7 +68,23 @@ export const getCroppedImage = (
     _crop.height * scaleY,
   );
 
-  canvas.toBlob(blobCallback, 'image/jpeg', 1);
+  return canvas;
+}
+
+/**
+ * 이미지 잘라내어 "blob"으로 변환하는 함수
+ * img 태그에 표시된 이미지를 blob으로 변환 -> blobcallback 적용
+ * @param image HTMLImageElement 잘라낼 이미지
+ * @param _crop x,y,height,width 값 가지고 있다
+ * @param blobCallback 클롭된 이미지 처리할 함수, blob으로 변환된 이미지를 받아 원하는 작업을 하는 콜백함수
+ */
+export const getCroppedImage = (
+  image: HTMLImageElement,
+  _crop: Crop,
+  blobCallback: BlobCallback,
+): void => {
+  const canvas = document.createElement('canvas');
+  drawImageOnCanvas({canvas, image,_crop}).toBlob(blobCallback, 'image/jpeg', 1);
 };
 
 export function AvatarChangeButton(): JSX.Element {

--- a/libs/hooks/src/lib/mutation/useGoodsImageMutation.tsx
+++ b/libs/hooks/src/lib/mutation/useGoodsImageMutation.tsx
@@ -23,3 +23,13 @@ export const useDeleteGoodsImageMutation = (): UseMutationResult<
     axios.delete<boolean>('/goods/image', { data: { imageId } }).then((res) => res.data),
   );
 };
+
+export const useGoodsImageOrderMutation = (): UseMutationResult<
+  boolean,
+  AxiosError,
+  GoodsImageDto[]
+> => {
+  return useMutation<boolean, AxiosError, GoodsImageDto[]>((dto: GoodsImageDto[]) =>
+    axios.patch<boolean>('/goods/image', dto).then((res) => res.data),
+  );
+};

--- a/libs/hooks/src/lib/queries/useAdminLiveShoppingList.tsx
+++ b/libs/hooks/src/lib/queries/useAdminLiveShoppingList.tsx
@@ -7,7 +7,7 @@ export const getAdminLiveShoppingList = async (
   dto: LiveShoppingParamsDto,
 ): Promise<LiveShoppingWithGoods[]> => {
   return axios
-    .get<LiveShoppingWithGoods[]>('/live-shoppings', {
+    .get<LiveShoppingWithGoods[]>('admin/live-shoppings', {
       params: {
         liveShoppingId: dto.id,
         goodsIds: dto.goodsIds,

--- a/libs/nest-modules-goods/src/goods/goods.controller.ts
+++ b/libs/nest-modules-goods/src/goods/goods.controller.ts
@@ -48,6 +48,12 @@ export class GoodsController {
     return this.goodsService.deleteGoodsImage(imageId);
   }
 
+  /** 여러 상품 이미지 데이터 수정 */
+  @Patch('/image')
+  updateGoodsImages(@Body(ValidationPipe) dto: GoodsImageDto[]): Promise<boolean> {
+    return this.goodsService.updateGoodsImages(dto);
+  }
+
   /** 상품 목록 조회 */
   @Get('/list')
   getGoodsList(

--- a/libs/nest-modules-goods/src/goods/goods.service.ts
+++ b/libs/nest-modules-goods/src/goods/goods.service.ts
@@ -528,17 +528,15 @@ export class GoodsService extends ServiceBaseWithCache {
     }
   }
 
-  /** 여러 상품 이미지 데이터 수정 */
+  /** 여러 상품 이미지 데이터 순서 수정 */
   public async updateGoodsImages(dto: GoodsImageDto[]): Promise<boolean> {
-    console.log('update images', dto);
-    await Promise.all(
-      dto.map((image) => {
-        const { id, ...data } = image;
-        return this.prisma.goodsImages.update({
-          where: { id },
-          data,
-        });
-      }),
+    await this.prisma.$transaction(
+      dto.map((image) =>
+        this.prisma.goodsImages.update({
+          where: { id: image.id },
+          data: { cut_number: image.cut_number },
+        }),
+      ),
     );
     return true;
   }

--- a/libs/nest-modules-goods/src/goods/goods.service.ts
+++ b/libs/nest-modules-goods/src/goods/goods.service.ts
@@ -421,7 +421,7 @@ export class GoodsService extends ServiceBaseWithCache {
           },
         },
         confirmation: true,
-        image: true,
+        image: { orderBy: { cut_number: 'asc' } },
         GoodsInfo: true,
         LiveShopping: true,
       },
@@ -526,6 +526,21 @@ export class GoodsService extends ServiceBaseWithCache {
       console.error(e);
       throw new InternalServerErrorException(e);
     }
+  }
+
+  /** 여러 상품 이미지 데이터 수정 */
+  public async updateGoodsImages(dto: GoodsImageDto[]): Promise<boolean> {
+    console.log('update images', dto);
+    await Promise.all(
+      dto.map((image) => {
+        const { id, ...data } = image;
+        return this.prisma.goodsImages.update({
+          where: { id },
+          data,
+        });
+      }),
+    );
+    return true;
   }
 
   /** 상품 수정시 상품 옵션 데이터 구분하는 함수(삭제, 수정, 생성) 


### PR DESCRIPTION
- 사진 등록 다이얼로그에 이미지를 1:1 비율로 잘라낼 수 있는 기능 추가
- 등록된 이미지 순서 변경 다이얼로그 추가
- 기타 수정사항
  - 관리자페이지 라이브쇼핑목록 조회요청 live-shopping => /admin/live-shopping 으로 수정


- 사진 등록하기 다이얼로그
    - [ ]  사진 업로드 후 미리보기 이미지를 클릭하면 이미지를 1:1 비율로 잘라내는 화면이 표시된다
    - [ ]  이미지 자르는 영역을 드래그하여 선택한 후 적용하기를 누르면 미리보기에 반영된다
    - [ ]  모두 등록하기 버튼을 눌러 미리보기에 보이는 형태의 이미지를 저장할 수 있다
    - [ ]  저장된 이미지는 상품사진 등록된 이미지 목록에 표시된다
- 상품사진 - 등록된 이미지 목록
    - [ ]  x 버튼을 눌러 등록된 이미지를 삭제할 수 있다
    - [ ]  순서변경하기 버튼을 눌러 순서변경 다이얼로그를 열 수 있다
- 상품 사진 순서 변경 다이얼로그
    - [ ]  이미지 순서 변경 후 변경하기 버튼을 눌르면 변경된 순서가 등록된 이미지 목록에 반영된다
