### PR TITLE
[크크쇼]검색결과페이지(다시 올림)

### DIFF
--- a/apps/web-kkshow/pages/index.tsx
+++ b/apps/web-kkshow/pages/index.tsx
@@ -37,7 +37,7 @@ export const getStaticProps: GetStaticProps<KkshowIndexProps> = async () => {
 
 export default function Index(): JSX.Element {
   return (
-    <Box overflow="hidden">
+    <Box overflow="hidden" position="relative">
       <Box
         display={{ base: 'none', md: 'block' }}
         pos="absolute"

--- a/apps/web-kkshow/pages/search/broadcaster.tsx
+++ b/apps/web-kkshow/pages/search/broadcaster.tsx
@@ -1,0 +1,27 @@
+import { Spinner } from '@chakra-ui/react';
+import SearchKeywordSection from '@project-lc/components-web-kkshow/search/SearchKeywordSection';
+import SearchPageLayout, {
+  useSearchPageState,
+} from '@project-lc/components-web-kkshow/search/SearchPageLayout';
+import SeeMoreBroadcasters from '@project-lc/components-web-kkshow/search/SeeMoreBroadcasters';
+
+export function Broadcaster(): JSX.Element {
+  const { data, isLoading, searchKeyword } = useSearchPageState();
+  const resultCount = data ? data.broadcasters.length : 0;
+
+  if (isLoading) {
+    return (
+      <SearchPageLayout>
+        <Spinner />
+      </SearchPageLayout>
+    );
+  }
+  return (
+    <SearchPageLayout>
+      <SearchKeywordSection keyword={searchKeyword} resultCount={resultCount} />
+      <SeeMoreBroadcasters data={data.broadcasters} />
+    </SearchPageLayout>
+  );
+}
+
+export default Broadcaster;

--- a/apps/web-kkshow/pages/search/goods.tsx
+++ b/apps/web-kkshow/pages/search/goods.tsx
@@ -1,0 +1,28 @@
+import { Spinner } from '@chakra-ui/react';
+import SearchKeywordSection from '@project-lc/components-web-kkshow/search/SearchKeywordSection';
+import SearchPageLayout, {
+  useSearchPageState,
+} from '@project-lc/components-web-kkshow/search/SearchPageLayout';
+import SeeMoreGoods from '@project-lc/components-web-kkshow/search/SeeMoreGoods';
+
+export function Goods(): JSX.Element {
+  const { data, isLoading, searchKeyword } = useSearchPageState();
+  const resultCount = data ? data.goods.length : 0;
+
+  if (isLoading) {
+    return (
+      <SearchPageLayout>
+        <Spinner />
+      </SearchPageLayout>
+    );
+  }
+
+  return (
+    <SearchPageLayout>
+      <SearchKeywordSection keyword={searchKeyword} resultCount={resultCount} />
+      <SeeMoreGoods data={data.goods} />
+    </SearchPageLayout>
+  );
+}
+
+export default Goods;

--- a/apps/web-kkshow/pages/search/index.tsx
+++ b/apps/web-kkshow/pages/search/index.tsx
@@ -1,0 +1,37 @@
+import { Divider, Spinner } from '@chakra-ui/react';
+import SearchKeywordSection from '@project-lc/components-web-kkshow/search/SearchKeywordSection';
+import SearchPageLayout, {
+  useSearchPageState,
+} from '@project-lc/components-web-kkshow/search/SearchPageLayout';
+import SearchResultBroadcasterSection from '@project-lc/components-web-kkshow/search/SearchResultBroadcasterSection';
+import SearchResultGoodsSection from '@project-lc/components-web-kkshow/search/SearchResultGoodsSection';
+import SearchResultLiveContentsSection from '@project-lc/components-web-kkshow/search/SearchResultLiveContentsSection';
+
+export function Search(): JSX.Element {
+  const { data, isLoading, searchKeyword } = useSearchPageState();
+  const resultCount = data
+    ? data.broadcasters.length + data.goods.length + data.liveContents.length
+    : 0;
+
+  if (isLoading) {
+    return (
+      <SearchPageLayout>
+        <Spinner />
+      </SearchPageLayout>
+    );
+  }
+
+  return (
+    <SearchPageLayout>
+      <SearchKeywordSection keyword={searchKeyword} resultCount={resultCount} />
+      <Divider />
+      <SearchResultGoodsSection keyword={searchKeyword} data={data.goods} />
+      <Divider />
+      <SearchResultLiveContentsSection keyword={searchKeyword} data={data.liveContents} />
+      <Divider />
+      <SearchResultBroadcasterSection keyword={searchKeyword} data={data.broadcasters} />
+    </SearchPageLayout>
+  );
+}
+
+export default Search;

--- a/apps/web-kkshow/pages/search/live-contents.tsx
+++ b/apps/web-kkshow/pages/search/live-contents.tsx
@@ -1,0 +1,27 @@
+import { Spinner } from '@chakra-ui/react';
+import SearchKeywordSection from '@project-lc/components-web-kkshow/search/SearchKeywordSection';
+import SearchPageLayout, {
+  useSearchPageState,
+} from '@project-lc/components-web-kkshow/search/SearchPageLayout';
+import SeeMoreLiveContents from '@project-lc/components-web-kkshow/search/SeeMoreLiveContents';
+
+export function LiveContents(): JSX.Element {
+  const { data, isLoading, searchKeyword } = useSearchPageState();
+  const resultCount = data ? data.liveContents.length : 0;
+
+  if (isLoading) {
+    return (
+      <SearchPageLayout>
+        <Spinner />
+      </SearchPageLayout>
+    );
+  }
+  return (
+    <SearchPageLayout>
+      <SearchKeywordSection keyword={searchKeyword} resultCount={resultCount} />
+      <SeeMoreLiveContents data={data.liveContents} />
+    </SearchPageLayout>
+  );
+}
+
+export default LiveContents;

--- a/libs/components-shared/src/lib/KksLogo.tsx
+++ b/libs/components-shared/src/lib/KksLogo.tsx
@@ -17,9 +17,10 @@ export const sellerDarkLogo = 'kkshow-seller-darkmode.png';
 export const broadcasterLogo = 'kkshow-broadcaster-lightmode.png';
 export const broadcasterDarkLogo = 'kkshow-broadcaster-darkmode.png';
 
+export type KkshowLogoVariant = 'white' | 'dark' | 'light';
 export interface KksLogoProps extends ImageProps {
   appType?: UserType;
-  variant?: 'white' | 'dark';
+  variant?: KkshowLogoVariant;
 }
 
 interface GetCorrectLogoOption {
@@ -33,6 +34,7 @@ function getCorrectLogoInfo({
   variant,
 }: GetCorrectLogoOption): string {
   if (variant === 'white') return LOGO_S3_PREFIX + whiteLogo;
+  if (variant === 'light') return LOGO_S3_PREFIX + lightLogo;
   if (variant === 'dark') return LOGO_S3_PREFIX + darkLogo;
   switch (appType) {
     case 'broadcaster':

--- a/libs/components-web-kkshow/src/lib/KkshowNavbar.tsx
+++ b/libs/components-web-kkshow/src/lib/KkshowNavbar.tsx
@@ -1,16 +1,38 @@
-import { Box, Flex, Link, Stack } from '@chakra-ui/react';
+import { Box, Flex, Link, Stack, useColorModeValue } from '@chakra-ui/react';
 import { kkshowNavLinks, NavItem } from '@project-lc/components-constants/navigation';
 import { ColorModeSwitcher } from '@project-lc/components-core/ColorModeSwitcher';
-import { KksLogo } from '@project-lc/components-shared/KksLogo';
+import { KkshowLogoVariant, KksLogo } from '@project-lc/components-shared/KksLogo';
 import NextLink from 'next/link';
+import GlobalSearcher from './GlobalSearcher';
 
-export function KkshowNavbar(): JSX.Element {
+type KkshowNavbarVariant = 'blue' | 'white';
+interface KkshowNavbar {
+  variant?: KkshowNavbarVariant;
+}
+/**
+ * @param variant 'blue'인 경우 배경색 파랑, 글자색 흰색 고정인 네비바(메인페이지나 쇼핑탭)
+ *                'white'인 경우 라이트모드에서는 배경색 흰색, 글자색 검정
+ *                             다크모드에서는 배경 검정, 글자 흰색인 네비바(검색페이지)
+ */
+export function KkshowNavbar({ variant = 'blue' }: KkshowNavbar): JSX.Element {
   const navHeight = 120;
+
+  const palette = {
+    bg: useColorModeValue('white', 'gray.800'),
+    color: useColorModeValue('gray.700', 'whiteAlpha.900'),
+    logoVariant: useColorModeValue('light', 'dark'),
+  };
+
+  if (variant === 'blue') {
+    palette.bg = 'blue.500';
+    palette.color = 'whiteAlpha.900';
+    palette.logoVariant = 'white';
+  }
 
   return (
     <Box
-      bg="blue.500"
-      color="whiteAlpha.900"
+      bg={palette.bg}
+      color={palette.color}
       pt={{ base: 0, md: 6 }}
       minH={navHeight}
       w="100%"
@@ -28,7 +50,10 @@ export function KkshowNavbar(): JSX.Element {
         <Box>
           <NextLink href="/" passHref>
             <Link>
-              <KksLogo variant="white" h={{ base: 30, md: 45 }} />
+              <KksLogo
+                variant={palette.logoVariant as KkshowLogoVariant}
+                h={{ base: 30, md: 45 }}
+              />
             </Link>
           </NextLink>
         </Box>
@@ -43,8 +68,7 @@ export function KkshowNavbar(): JSX.Element {
         {/* 우측 */}
         <Flex alignItems="center">
           <ColorModeSwitcher _hover={{}} />
-          {/* // TODO: 검색 기능 추가 이후 주석 해제 */}
-          {/* <GlobalSearcher /> */}
+          <GlobalSearcher />
         </Flex>
       </Flex>
 

--- a/libs/components-web-kkshow/src/lib/main/KkshowMainBestBroadcaster.tsx
+++ b/libs/components-web-kkshow/src/lib/main/KkshowMainBestBroadcaster.tsx
@@ -59,7 +59,7 @@ interface BestBroadcasterItemProps {
   avatarUrl: string;
   href: string;
 }
-function BestBroadcasterItem(props: BestBroadcasterItemProps): JSX.Element {
+export function BestBroadcasterItem(props: BestBroadcasterItemProps): JSX.Element {
   return (
     <LinkBox>
       <Stack
@@ -84,13 +84,19 @@ function BestBroadcasterItem(props: BestBroadcasterItemProps): JSX.Element {
           }}
         />
 
-        <NextLink passHref href={props.href || '#'}>
-          <LinkOverlay isExternal={props.href.includes('http')}>
-            <Heading noOfLines={2} fontSize="xl">
-              {props.broadcasterName}
-            </Heading>
-          </LinkOverlay>
-        </NextLink>
+        {props.href ? (
+          <NextLink passHref href={props.href || '#'}>
+            <LinkOverlay isExternal={props.href.includes('http')}>
+              <Heading noOfLines={2} fontSize="xl">
+                {props.broadcasterName}
+              </Heading>
+            </LinkOverlay>
+          </NextLink>
+        ) : (
+          <Heading noOfLines={2} fontSize="xl">
+            {props.broadcasterName}
+          </Heading>
+        )}
       </Stack>
     </LinkBox>
   );

--- a/libs/components-web-kkshow/src/lib/search/GoodsCard.tsx
+++ b/libs/components-web-kkshow/src/lib/search/GoodsCard.tsx
@@ -1,0 +1,52 @@
+import { ArrowForwardIcon, Icon } from '@chakra-ui/icons';
+import { AspectRatio, Box, LinkBox, LinkOverlay, Stack, Text } from '@chakra-ui/react';
+import MotionBox from '@project-lc/components-core/MotionBox';
+import { SearchResultItem } from '@project-lc/shared-types';
+import { motion } from 'framer-motion';
+import NextLink from 'next/link';
+
+const variants = {
+  hover: { scale: 1.1 },
+  normal: { scale: 1.0, minHeight: '132px', minWidth: '132px' },
+};
+
+/** 검색결과 - 상품아이템 => 쇼핑탭에서 작성한 상품컴포넌트와 비슷할듯하다 => 확인 후 수정필요
+ */
+export function GoodsCard({ item }: { item: SearchResultItem }): JSX.Element {
+  return (
+    <MotionBox initial="normal" whileHover="hover">
+      <LinkBox>
+        <NextLink href={item.linkUrl} passHref>
+          <LinkOverlay isExternal={item.linkUrl.includes('http')}>
+            <Stack>
+              <Box rounded="xl" overflow="hidden" position="relative">
+                <AspectRatio ratio={1}>
+                  <motion.img
+                    src={item.imageUrl}
+                    variants={variants}
+                    style={{ objectFit: 'cover' }}
+                  />
+                </AspectRatio>
+
+                <Icon
+                  as={ArrowForwardIcon}
+                  position="absolute"
+                  right={2}
+                  bottom={2}
+                  color="white"
+                  rounded="full"
+                  bg="rgba(0,0,0,0.4)"
+                  p={1}
+                  boxSize="2em"
+                />
+              </Box>
+              <Text fontFamily="Gmarket Sans" textAlign="center">
+                {item.title}
+              </Text>
+            </Stack>
+          </LinkOverlay>
+        </NextLink>
+      </LinkBox>
+    </MotionBox>
+  );
+}

--- a/libs/components-web-kkshow/src/lib/search/LiveContentCard.tsx
+++ b/libs/components-web-kkshow/src/lib/search/LiveContentCard.tsx
@@ -1,0 +1,71 @@
+import {
+  AspectRatio,
+  Box,
+  Icon,
+  Image,
+  LinkBox,
+  LinkOverlay,
+  Stack,
+  Text,
+} from '@chakra-ui/react';
+import MotionBox from '@project-lc/components-core/MotionBox';
+import { SearchResultItem } from '@project-lc/shared-types';
+import NextLink from 'next/link';
+import { FaPlayCircle } from 'react-icons/fa';
+
+const overlay = {
+  normal: {
+    display: 'none',
+    opacity: 0,
+    transition: {
+      duration: 0.2,
+      ease: 'easeIn',
+    },
+  },
+  hover: {
+    display: 'flex',
+    opacity: 1,
+    transition: {
+      duration: 0.2,
+      ease: 'easeIn',
+    },
+  },
+};
+export function LiveContentCard({ item }: { item: SearchResultItem }): JSX.Element {
+  return (
+    <MotionBox initial="normal" whileHover="hover">
+      <LinkBox>
+        <NextLink href={item.linkUrl} passHref>
+          <LinkOverlay isExternal={item.linkUrl.includes('http')}>
+            <Stack>
+              <Box rounded="xl" overflow="hidden" position="relative">
+                <AspectRatio ratio={16 / 9}>
+                  <Image src={item.imageUrl} objectFit="cover" />
+                </AspectRatio>
+
+                <MotionBox
+                  variants={overlay}
+                  position="absolute"
+                  left="0"
+                  right="0"
+                  bottom="0"
+                  top="0"
+                  bg="rgba(0,0,0,0.3)"
+                  justifyContent="center"
+                  alignItems="center"
+                >
+                  <Icon as={FaPlayCircle} color="white" fontSize="6xl" />
+                </MotionBox>
+              </Box>
+              <Text fontFamily="Gmarket Sans" fontWeight="bold">
+                {item.title}
+              </Text>
+            </Stack>
+          </LinkOverlay>
+        </NextLink>
+      </LinkBox>
+    </MotionBox>
+  );
+}
+
+export default LiveContentCard;

--- a/libs/components-web-kkshow/src/lib/search/SearchKeywordSection.tsx
+++ b/libs/components-web-kkshow/src/lib/search/SearchKeywordSection.tsx
@@ -1,0 +1,47 @@
+import { Box, Center, Container, Heading, Stack, Text } from '@chakra-ui/react';
+import React from 'react';
+
+function SearchKeywordSectionContainer({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <Box bg="blue.500" color="whiteAlpha.900">
+      <Container maxW="6xl">
+        <Center py={8}>{children}</Center>
+      </Container>
+    </Box>
+  );
+}
+
+export interface SearchKeywordSectionProps {
+  keyword?: string;
+  resultCount?: number;
+}
+export function SearchKeywordSection({
+  keyword,
+  resultCount,
+}: SearchKeywordSectionProps): JSX.Element {
+  if (!keyword || !resultCount) {
+    return (
+      <SearchKeywordSectionContainer>
+        <Stack fontSize="lg" fontWeight="bold" textAlign="center">
+          {keyword && <Heading fontSize="4xl">{`‘${keyword}’`}</Heading>}
+          <Text>검색 결과가 없습니다.</Text>
+          <Text>{keyword && '다른 '}제품이나 방송인을 검색해보세요.</Text>
+        </Stack>
+      </SearchKeywordSectionContainer>
+    );
+  }
+  return (
+    <SearchKeywordSectionContainer>
+      <Stack textAlign="center" fontWeight="bold">
+        <Heading fontSize="4xl">{`‘${keyword}’`}</Heading>
+        <Text>{resultCount} 개의 결과</Text>
+      </Stack>
+    </SearchKeywordSectionContainer>
+  );
+}
+
+export default SearchKeywordSection;

--- a/libs/components-web-kkshow/src/lib/search/SearchPageLayout.tsx
+++ b/libs/components-web-kkshow/src/lib/search/SearchPageLayout.tsx
@@ -1,0 +1,57 @@
+import { Box, Flex } from '@chakra-ui/react';
+import BottomQuickMenu from '@project-lc/components-shared/BottomQuickMenu';
+import { CommonFooter } from '@project-lc/components-layout/CommonFooter';
+import { kkshowFooterLinkList } from '@project-lc/components-constants/footerLinks';
+import { useKkshowSearchResult } from '@project-lc/hooks';
+import { useRouter } from 'next/router';
+import { useState, useEffect } from 'react';
+import { SearchResult } from '@project-lc/shared-types';
+import KkshowNavbar from '../KkshowNavbar';
+import KKshowMainExternLinks from '../main/KKshowMainExternLinks';
+
+export interface SearchPageLayoutProps {
+  children?: React.ReactNode;
+}
+/** search 페이지 기본 레이아웃(네비바, 하단 퀵메뉴, 푸터) */
+export function SearchPageLayout({ children }: SearchPageLayoutProps): JSX.Element {
+  return (
+    <Flex direction="column" overflow="hidden" minHeight="100vh">
+      {/* 검색페이지 네비바는 라이트모드에서 흰색배경이라 variant="white" 적용함 */}
+      <KkshowNavbar variant="white" />
+      <Box flexGrow={1}>{children}</Box>
+
+      <BottomQuickMenu />
+
+      <KKshowMainExternLinks mb={-4} bgColor="blue.900" color="whiteAlpha.900" />
+      <CommonFooter footerLinkList={kkshowFooterLinkList} />
+    </Flex>
+  );
+}
+
+export default SearchPageLayout;
+
+/** search 페이지에서 사용하는 keyword, 검색 결과 데이터 state */
+export function useSearchPageState(): {
+  data?: SearchResult;
+  isLoading: boolean;
+  searchKeyword?: string;
+} {
+  const router = useRouter();
+  const { keyword } = router.query;
+
+  const searchKeyword = keyword ? (keyword as string) : undefined;
+
+  const [query, setQuery] = useState<string | undefined>(searchKeyword);
+
+  const { data, isLoading } = useKkshowSearchResult(query);
+
+  useEffect(() => {
+    setQuery(keyword ? (keyword as string) : undefined);
+  }, [keyword]);
+
+  return {
+    data,
+    isLoading,
+    searchKeyword,
+  };
+}

--- a/libs/components-web-kkshow/src/lib/search/SearchResultBroadcasterSection.tsx
+++ b/libs/components-web-kkshow/src/lib/search/SearchResultBroadcasterSection.tsx
@@ -1,0 +1,92 @@
+import { useBreakpointValue, Box } from '@chakra-ui/react';
+import { SearchResultItem } from '@project-lc/shared-types';
+import { useRouter } from 'next/router';
+import { Grid as SwiperGrid, Pagination, Scrollbar } from 'swiper';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { BestBroadcasterItem } from '../main/KkshowMainBestBroadcaster';
+import {
+  SearchResultEmptyText,
+  SearchResultSectionContainerLayout,
+  SeeMoreButton,
+} from './SearchResultSectionContainerLayout';
+
+export interface SearchResultBroadcasterSectionProps {
+  data: SearchResultItem[];
+  keyword?: string;
+}
+export function SearchResultBroadcasterSection({
+  data,
+  keyword,
+}: SearchResultBroadcasterSectionProps): JSX.Element {
+  const router = useRouter();
+  // 모바일에서는 4개, 데스트탑에서는 최대 6개 표시 -> 나머지는 더보기 눌러서 별도 페이지에서 확인하도록
+  const displayItemCountOnSearchResultPage = useBreakpointValue({ base: 4, md: 6 });
+  const dataToDisplay = data.slice(0, displayItemCountOnSearchResultPage);
+  return (
+    <SearchResultSectionContainerLayout
+      title="방송인"
+      resultCount={data.length}
+      actionButton={
+        keyword ? (
+          <SeeMoreButton
+            onClick={() => {
+              router.push(`/search/broadcaster?keyword=${keyword}`);
+            }}
+          />
+        ) : undefined
+      }
+    >
+      {data.length > 0 ? (
+        <>
+          {/* (breakpoint: md 이상 기준) */}
+          <Box display={{ base: 'none', md: 'block' }}>
+            <Swiper
+              style={{ paddingTop: 16, paddingBottom: 16, width: '100%' }}
+              modules={[Pagination, Scrollbar]}
+              slidesPerView="auto"
+            >
+              {dataToDisplay.map((item, index) => {
+                const key = `${item.title}_${index}`;
+                return (
+                  <SwiperSlide key={key} style={{ width: '18%', paddingBottom: '32px' }}>
+                    <BestBroadcasterItem
+                      avatarUrl={item.imageUrl}
+                      broadcasterName={item.title}
+                      href={item.linkUrl}
+                    />
+                  </SwiperSlide>
+                );
+              })}
+            </Swiper>
+          </Box>
+          {/* (breakpoint: md 미만 기준) - 그리드 */}
+          <Box display={{ base: 'block', md: 'none' }}>
+            <Swiper
+              style={{ paddingTop: 16, paddingBottom: 16, width: '100%' }}
+              modules={[SwiperGrid]}
+              slidesPerView={2}
+              grid={{ rows: 2, fill: 'row' }}
+            >
+              {dataToDisplay.map((item, index) => {
+                const key = `${item.title}_${index}`;
+                return (
+                  <SwiperSlide key={key} style={{ width: '50%', paddingBottom: '32px' }}>
+                    <BestBroadcasterItem
+                      avatarUrl={item.imageUrl}
+                      broadcasterName={item.title}
+                      href={item.linkUrl}
+                    />
+                  </SwiperSlide>
+                );
+              })}
+            </Swiper>
+          </Box>
+        </>
+      ) : (
+        <SearchResultEmptyText />
+      )}
+    </SearchResultSectionContainerLayout>
+  );
+}
+
+export default SearchResultBroadcasterSection;

--- a/libs/components-web-kkshow/src/lib/search/SearchResultGoodsSection.tsx
+++ b/libs/components-web-kkshow/src/lib/search/SearchResultGoodsSection.tsx
@@ -1,0 +1,84 @@
+import { Box, useBreakpointValue } from '@chakra-ui/react';
+import { SearchResultItem } from '@project-lc/shared-types';
+import { useRouter } from 'next/router';
+import { Grid as SwiperGrid, Pagination, Scrollbar } from 'swiper';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { GoodsCard } from './GoodsCard';
+import {
+  SearchResultEmptyText,
+  SearchResultSectionContainerLayout,
+  SeeMoreButton,
+} from './SearchResultSectionContainerLayout';
+
+export interface SearchResultGoodsSectionProps {
+  data: SearchResultItem[];
+  keyword?: string;
+}
+export function SearchResultGoodsSection({
+  data,
+  keyword,
+}: SearchResultGoodsSectionProps): JSX.Element {
+  const router = useRouter();
+  // 모바일에서는 4개, 데스트탑에서는 최대 6개 표시 -> 나머지는 더보기 눌러서 별도 페이지에서 확인하도록
+  const displayItemCountOnSearchResultPage = useBreakpointValue({ base: 4, md: 6 });
+  const dataToDisplay = data.slice(0, displayItemCountOnSearchResultPage);
+  return (
+    <SearchResultSectionContainerLayout
+      title="상품"
+      resultCount={data.length}
+      actionButton={
+        keyword ? (
+          <SeeMoreButton
+            onClick={() => {
+              router.push(`/search/goods?keyword=${keyword}`);
+            }}
+          />
+        ) : undefined
+      }
+    >
+      {data.length > 0 ? (
+        <>
+          {/* (breakpoint: md 이상 기준) */}
+          <Box display={{ base: 'none', md: 'block' }}>
+            <Swiper
+              modules={[Pagination, Scrollbar]}
+              slidesPerView="auto"
+              spaceBetween={30}
+            >
+              {dataToDisplay.map((item, index) => {
+                const key = `${item.title}_${index}`;
+                return (
+                  <SwiperSlide key={key} style={{ width: '20%', paddingBottom: '32px' }}>
+                    <GoodsCard item={item} />
+                  </SwiperSlide>
+                );
+              })}
+            </Swiper>
+          </Box>
+          {/* (breakpoint: md 미만 기준) - 그리드 */}
+          <Box display={{ base: 'block', md: 'none' }}>
+            <Swiper
+              modules={[SwiperGrid]}
+              slidesPerView={2}
+              grid={{ rows: 2, fill: 'row' }}
+              spaceBetween={30}
+            >
+              {dataToDisplay.map((item, index) => {
+                const key = `${item.title}_${index}`;
+                return (
+                  <SwiperSlide key={key} style={{ width: '50%' }}>
+                    <GoodsCard item={item} />
+                  </SwiperSlide>
+                );
+              })}
+            </Swiper>
+          </Box>
+        </>
+      ) : (
+        <SearchResultEmptyText />
+      )}
+    </SearchResultSectionContainerLayout>
+  );
+}
+
+export default SearchResultGoodsSection;

--- a/libs/components-web-kkshow/src/lib/search/SearchResultLiveContentsSection.tsx
+++ b/libs/components-web-kkshow/src/lib/search/SearchResultLiveContentsSection.tsx
@@ -1,0 +1,83 @@
+import { Box, useBreakpointValue } from '@chakra-ui/react';
+import { SearchResultItem } from '@project-lc/shared-types';
+import { useRouter } from 'next/router';
+import { Grid as SwiperGrid, Pagination, Scrollbar } from 'swiper';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import LiveContentCard from './LiveContentCard';
+import {
+  SearchResultEmptyText,
+  SearchResultSectionContainerLayout,
+  SeeMoreButton,
+} from './SearchResultSectionContainerLayout';
+
+export interface SearchResultLiveContentsSectionProps {
+  data: SearchResultItem[];
+  keyword?: string;
+}
+export function SearchResultLiveContentsSection({
+  data,
+  keyword,
+}: SearchResultLiveContentsSectionProps): JSX.Element {
+  const router = useRouter();
+  const displayItemCountOnSearchResultPage = useBreakpointValue({ base: 2, md: 4 });
+  const dataToDisplay = data.slice(0, displayItemCountOnSearchResultPage);
+  return (
+    <SearchResultSectionContainerLayout
+      title="라이브 컨텐츠"
+      resultCount={data.length}
+      actionButton={
+        keyword ? (
+          <SeeMoreButton
+            onClick={() => {
+              router.push(`/search/live-contents?keyword=${keyword}`);
+            }}
+          />
+        ) : undefined
+      }
+    >
+      {data.length > 0 ? (
+        <>
+          {/* (breakpoint: md 이상 기준) */}
+          <Box display={{ base: 'none', md: 'block' }}>
+            <Swiper
+              modules={[Pagination, Scrollbar]}
+              slidesPerView="auto"
+              spaceBetween={30}
+            >
+              {dataToDisplay.map((item, index) => {
+                const key = `${item.title}_${index}`;
+                return (
+                  <SwiperSlide key={key} style={{ width: '40%', paddingBottom: '32px' }}>
+                    <LiveContentCard item={item} />
+                  </SwiperSlide>
+                );
+              })}
+            </Swiper>
+          </Box>
+          {/* (breakpoint: md 미만 기준) - 그리드 */}
+          <Box display={{ base: 'block', md: 'none' }}>
+            <Swiper
+              modules={[SwiperGrid]}
+              slidesPerView={1}
+              grid={{ rows: 2, fill: 'row' }}
+              spaceBetween={30}
+            >
+              {dataToDisplay.map((item, index) => {
+                const key = `${item.title}_${index}`;
+                return (
+                  <SwiperSlide key={key} style={{ width: '100%' }}>
+                    <LiveContentCard item={item} />
+                  </SwiperSlide>
+                );
+              })}
+            </Swiper>
+          </Box>
+        </>
+      ) : (
+        <SearchResultEmptyText />
+      )}
+    </SearchResultSectionContainerLayout>
+  );
+}
+
+export default SearchResultLiveContentsSection;

--- a/libs/components-web-kkshow/src/lib/search/SearchResultSectionContainerLayout.tsx
+++ b/libs/components-web-kkshow/src/lib/search/SearchResultSectionContainerLayout.tsx
@@ -1,0 +1,47 @@
+import { Box, Button, Container, Heading, Stack, Text } from '@chakra-ui/react';
+
+export interface SearchResultSectionContainerProps {
+  title: string;
+  resultCount?: number;
+  children: React.ReactNode;
+  actionButton?: React.ReactNode;
+}
+/** 상품, 라이브컨텐츠, 크리에이터 영역 레이아웃 컴포넌트 */
+export function SearchResultSectionContainerLayout({
+  title,
+  resultCount,
+  children,
+  actionButton,
+}: SearchResultSectionContainerProps): JSX.Element {
+  return (
+    <Box>
+      <Container maxW="6xl" px={6}>
+        <Stack py={12} spacing={8}>
+          <Stack direction="row" justify="space-between" fontWeight="bold" width="100%">
+            <Stack direction="row" alignItems="flex-end">
+              <Heading color="blue.500" fontSize={{ base: '2xl', md: '3xl' }}>
+                {title}
+              </Heading>
+              {resultCount && <Text>{resultCount}개의 검색결과</Text>}
+            </Stack>
+
+            {actionButton && <Box alignSelf="flex-end">{actionButton}</Box>}
+          </Stack>
+          <Box>{children}</Box>
+        </Stack>
+      </Container>
+    </Box>
+  );
+}
+
+export function SearchResultEmptyText(): JSX.Element {
+  return <Text>검색 결과가 없습니다</Text>;
+}
+
+export function SeeMoreButton({ onClick }: { onClick: () => void }): JSX.Element {
+  return (
+    <Button variant="link" colorScheme="blue" onClick={onClick}>
+      더보기
+    </Button>
+  );
+}

--- a/libs/components-web-kkshow/src/lib/search/SeeMoreBroadcasters.tsx
+++ b/libs/components-web-kkshow/src/lib/search/SeeMoreBroadcasters.tsx
@@ -1,0 +1,51 @@
+import { Grid, GridItem, useBreakpointValue } from '@chakra-ui/react';
+import { SearchResultItem } from '@project-lc/shared-types';
+import { BestBroadcasterItem } from '../main/KkshowMainBestBroadcaster';
+import { SearchResultEmptyText } from './SearchResultSectionContainerLayout';
+import SeeMorePageLayout, { useSeeMorePageState } from './SeeMorePageLayout';
+
+export interface SeeMoreBroadcastersProps {
+  data: SearchResultItem[];
+}
+export function SeeMoreBroadcasters({ data }: SeeMoreBroadcastersProps): JSX.Element {
+  const { dataToDisplay, handleLoadMore } = useSeeMorePageState({
+    data,
+    itemPerPage: 15,
+  });
+  const itemPerRow = {
+    base: 2, // 모바일화면에서 한줄에 2개씩 표시
+    md: 5, // md이상 화면에서 한줄에 5개씩 표시
+  };
+  const templateColumns = useBreakpointValue({
+    base: `repeat(${itemPerRow.base}, 1fr)`,
+    md: `repeat(${itemPerRow.md}, 1fr)`,
+  });
+  return (
+    <SeeMorePageLayout
+      title="방송인"
+      resultCount={data.length}
+      handleLoadMore={handleLoadMore}
+    >
+      <Grid templateColumns={templateColumns} gap={6} mb={8}>
+        {dataToDisplay.length > 0 ? (
+          dataToDisplay.map((item, index) => {
+            const key = `${item.title}_${index}`;
+            return (
+              <GridItem w="100%" h="100%" key={key} py={8}>
+                <BestBroadcasterItem
+                  avatarUrl={item.imageUrl}
+                  broadcasterName={item.title}
+                  href={item.linkUrl}
+                />
+              </GridItem>
+            );
+          })
+        ) : (
+          <SearchResultEmptyText />
+        )}
+      </Grid>
+    </SeeMorePageLayout>
+  );
+}
+
+export default SeeMoreBroadcasters;

--- a/libs/components-web-kkshow/src/lib/search/SeeMoreGoods.tsx
+++ b/libs/components-web-kkshow/src/lib/search/SeeMoreGoods.tsx
@@ -1,0 +1,47 @@
+import { Grid, GridItem, useBreakpointValue } from '@chakra-ui/react';
+import { SearchResultItem } from '@project-lc/shared-types';
+import { GoodsCard } from './GoodsCard';
+import { SearchResultEmptyText } from './SearchResultSectionContainerLayout';
+import SeeMorePageLayout, { useSeeMorePageState } from './SeeMorePageLayout';
+
+export interface SeeMoreGoodsProps {
+  data: SearchResultItem[];
+}
+export function SeeMoreGoods({ data }: SeeMoreGoodsProps): JSX.Element {
+  const { dataToDisplay, handleLoadMore } = useSeeMorePageState({
+    data,
+    itemPerPage: 12,
+  });
+  const itemPerRow = {
+    base: 2, // 모바일화면에서 한줄에 2개씩 표시
+    md: 4, // md이상 화면에서 한줄에 4개씩 표시
+  };
+  const templateColumns = useBreakpointValue({
+    base: `repeat(${itemPerRow.base}, 1fr)`,
+    md: `repeat(${itemPerRow.md}, 1fr)`,
+  });
+  return (
+    <SeeMorePageLayout
+      title="상품"
+      resultCount={data.length}
+      handleLoadMore={handleLoadMore}
+    >
+      <Grid templateColumns={templateColumns} gap={{ base: 6, md: 16 }} mb={8}>
+        {dataToDisplay.length > 0 ? (
+          dataToDisplay.map((item, index) => {
+            const key = `${item.title}_${index}`;
+            return (
+              <GridItem w="100%" h="100%" key={key}>
+                <GoodsCard item={item} />
+              </GridItem>
+            );
+          })
+        ) : (
+          <SearchResultEmptyText />
+        )}
+      </Grid>
+    </SeeMorePageLayout>
+  );
+}
+
+export default SeeMoreGoods;

--- a/libs/components-web-kkshow/src/lib/search/SeeMoreLiveContents.tsx
+++ b/libs/components-web-kkshow/src/lib/search/SeeMoreLiveContents.tsx
@@ -1,0 +1,49 @@
+import { Grid, GridItem, useBreakpointValue } from '@chakra-ui/react';
+import { SearchResultItem } from '@project-lc/shared-types';
+import LiveContentCard from './LiveContentCard';
+import { SearchResultEmptyText } from './SearchResultSectionContainerLayout';
+import SeeMorePageLayout, { useSeeMorePageState } from './SeeMorePageLayout';
+
+export interface SeeMoreLiveContentsProps {
+  data: SearchResultItem[];
+}
+export function SeeMoreLiveContents({ data }: SeeMoreLiveContentsProps): JSX.Element {
+  const { dataToDisplay, handleLoadMore } = useSeeMorePageState({
+    data,
+    itemPerPage: 9,
+  });
+
+  const itemPerRow = {
+    base: 1, // 모바일화면에서 한줄에 1개씩 표시
+    md: 3, // md이상 화면에서 한줄에 3개씩 표시
+  };
+  const templateColumns = useBreakpointValue({
+    base: `repeat(${itemPerRow.base}, 1fr)`,
+    md: `repeat(${itemPerRow.md}, 1fr)`,
+  });
+
+  return (
+    <SeeMorePageLayout
+      title="라이브 컨텐츠"
+      resultCount={data.length}
+      handleLoadMore={handleLoadMore}
+    >
+      <Grid templateColumns={templateColumns} gap={16} mb={8}>
+        {dataToDisplay.length > 0 ? (
+          dataToDisplay.map((item, index) => {
+            const key = `${item.title}_${index}`;
+            return (
+              <GridItem w="100%" h="100%" key={key}>
+                <LiveContentCard item={item} />
+              </GridItem>
+            );
+          })
+        ) : (
+          <SearchResultEmptyText />
+        )}
+      </Grid>
+    </SeeMorePageLayout>
+  );
+}
+
+export default SeeMoreLiveContents;

--- a/libs/components-web-kkshow/src/lib/search/SeeMorePageLayout.tsx
+++ b/libs/components-web-kkshow/src/lib/search/SeeMorePageLayout.tsx
@@ -1,0 +1,71 @@
+import { Button, Center, Stack } from '@chakra-ui/react';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+import {
+  SearchResultSectionContainerLayout,
+  SearchResultSectionContainerProps,
+} from './SearchResultSectionContainerLayout';
+
+/** 더보기 페이지에서 사용하는 페이지네이션 state */
+export function useSeeMorePageState<T>({
+  data,
+  itemPerPage,
+}: {
+  data: T[];
+  itemPerPage: number;
+}): {
+  page: number;
+  dataToDisplay: T[];
+  hasMore: boolean;
+  handleLoadMore?: () => void;
+} {
+  const [page, setPage] = useState<number>(1);
+  // 한 페이지에 몇개의 아이템 표시할것인지
+  const dataToDisplay = data.slice(0, page * itemPerPage);
+
+  const hasMore = data.length > page * itemPerPage;
+  const handleLoadMore = hasMore ? () => setPage((prev) => prev + 1) : undefined;
+
+  return {
+    page,
+    dataToDisplay,
+    hasMore,
+    handleLoadMore,
+  };
+}
+
+export interface SeeMorePageLayoutProps extends SearchResultSectionContainerProps {
+  children: React.ReactNode;
+  handleLoadMore?: () => void;
+}
+/** 통합검색페이지에서 영역별 '더보기' 눌렀을때 이동하는 더보기페이지 레이아웃 */
+export function SeeMorePageLayout({
+  title,
+  resultCount,
+  handleLoadMore,
+  children,
+}: SeeMorePageLayoutProps): JSX.Element {
+  const router = useRouter();
+  return (
+    <SearchResultSectionContainerLayout
+      title={title}
+      resultCount={resultCount || 0}
+      actionButton={
+        <Button variant="link" onClick={() => router.back()}>
+          돌아가기
+        </Button>
+      }
+    >
+      <Stack>
+        {children}
+        {handleLoadMore && (
+          <Center>
+            <Button onClick={handleLoadMore}>더보기</Button>
+          </Center>
+        )}
+      </Stack>
+    </SearchResultSectionContainerLayout>
+  );
+}
+
+export default SeeMorePageLayout;

--- a/libs/hooks/src/index.ts
+++ b/libs/hooks/src/index.ts
@@ -108,6 +108,7 @@ export * from './lib/queries/useGoodsCommonInfoList';
 export * from './lib/queries/useGoodsStock';
 export * from './lib/queries/useHealthCheck';
 export * from './lib/queries/useKkshowMain';
+export * from './lib/queries/useKkshowSearchResult';
 export * from './lib/queries/useLiveShoppingList';
 export * from './lib/queries/useNotice';
 export * from './lib/queries/useNotifications';

--- a/libs/hooks/src/lib/queries/useKkshowSearchResult.tsx
+++ b/libs/hooks/src/lib/queries/useKkshowSearchResult.tsx
@@ -1,0 +1,88 @@
+import { AxiosError } from 'axios';
+import { useQuery, UseQueryResult } from 'react-query';
+import { SearchResult, SearchResultItem } from '@project-lc/shared-types';
+import axios from '../../axios';
+
+export type KkshowSearchResult = SearchResult;
+
+const initialData: KkshowSearchResult = {
+  goods: [],
+  liveContents: [],
+  broadcasters: [],
+};
+
+const images = {
+  goods: [
+    'https://k-kmarket.com/data/goods/1/2022/02/_temp_16449180896963view.jpg',
+    'https://k-kmarket.com/data/goods/1/2022/02/_temp_16448938223899view.png',
+  ],
+  liveContents: [
+    'https://miricanvas.zendesk.com/hc/article_attachments/360049418472/__________._2.png',
+    'https://miricanvas.zendesk.com/hc/article_attachments/360049418472/__________._2.png',
+  ],
+  broadcasters: [
+    'https://static-cdn.jtvnw.net/jtv_user_pictures/2067380c-6c8f-4a4d-9f68-65c13572a59b-profile_image-150x150.png',
+    'https://static-cdn.jtvnw.net/jtv_user_pictures/d156ff24-5b64-4ffa-83a8-1ecf0d1e71d2-profile_image-150x150.png',
+  ],
+};
+
+function generateDummyList(
+  type: 'goods' | 'liveContents' | 'broadcasters',
+  num: number,
+): SearchResultItem[] {
+  const arr = new Array(num).fill({
+    imageUrl: '',
+    linkUrl: '',
+    title: '',
+  });
+  if (type === 'goods') {
+    return arr.map((_, index) => ({
+      imageUrl: images.goods[index % 2 === 0 ? 0 : 1],
+      linkUrl: 'https://k-kmarket.com/goods/view?no=179',
+      title: `더미데이터 ${index + 1}_백종원의 3대천왕 출연 속초 닭강정 (순한 맛)`,
+    }));
+  }
+  if (type === 'broadcasters') {
+    return arr.map((_, index) => ({
+      imageUrl: images.broadcasters[index % 2 === 0 ? 0 : 1],
+      linkUrl: 'https://k-kmarket.com/goods/catalog?code=00160001',
+      title: `더미 방송인${index + 1} `,
+    }));
+  }
+  if (type === 'liveContents') {
+    return arr.map((_, index) => ({
+      imageUrl: images.liveContents[index % 2 === 0 ? 0 : 1],
+      linkUrl: 'https://youtu.be/4Bkuhi7i7Mk',
+      title: `[더미데이터 x ${index + 1}] 라이브 커머스 방송`,
+    }));
+  }
+  return [];
+}
+
+// TODO: 백엔드 요청 연결 후 삭제 요망
+const dummyData: KkshowSearchResult = {
+  goods: generateDummyList('goods', 33),
+  liveContents: generateDummyList('liveContents', 12),
+  broadcasters: generateDummyList('broadcasters', 16),
+};
+
+export const getKkshowSearchResult = async (
+  keyword?: string,
+): Promise<KkshowSearchResult> => {
+  // TODO: 백엔드 요청 연결 후 수정 필요
+  if (keyword) return Promise.resolve(dummyData);
+  return Promise.resolve(initialData);
+  // return axios.get<KkshowSearchResult>('/').then((res) => res.data);
+};
+
+export const useKkshowSearchResult = (
+  keyword?: string,
+): UseQueryResult<KkshowSearchResult, AxiosError> => {
+  return useQuery<KkshowSearchResult, AxiosError>(
+    ['KkshowSearchResult', { keyword }],
+    () => getKkshowSearchResult(keyword),
+    {
+      initialData,
+    },
+  );
+};


### PR DESCRIPTION
- 이전 작업 브랜치에 썼던 더미이미지 url에 일부 credential 값이 포함되어 있어 해당 부분 삭제하여 다시 올렸습니다

프론트 검색결과 페이지 주소

- 검색결과페이지 /search?keyword={키워드}
- 검색결과 상품더보기 페이지 /search/goods?keyword={키워드}
- 검색결과 라이브컨텐츠 더보기 페이지 /search/live-contents?keyword={키워드}
- 검색결과 방송인 더보기 페이지 /search/broadcaster?keyword={키워드}

검색결과 페이지 테스트하기

- `http://localhost:4000/search?keyword=키워드` 입력 ⇒ 고정된 더미데이터가 결과페이지에 표시됨
- `http://localhost:4000/search` ⇒ 검색어 입력하지 않은 경우 화면 표시됨
- 더미데이터 개수, 데이터 수정 → useKkshowSearchResult.tsx 파일에서 dummyData 부분 수정


### 테스트케이스

- 검색어 || 검색결과가 없는경우
    - [ ]  검색결과 없음. 검색어 입력하라는 문구 출력
- 검색어 && 검색결과가 있는 경우
    - [ ]  통합검색페이지에 각 종류별(상품, 라이브컨텐츠, 방송인) 검색결과 총개수와 검색결과 일부가 표시된다
    - [ ]  각 종류별 더보기 버튼 누르면 해당 종류 검색결과 더보기 페이지로 이동한다(검색결과가 디자인 시안보다 많은 경우 처리에 대해 도리님과 이야기한 후 와챠피디아 검색결과 페이지 참고하여 만듦)
    - 상품 영역
        - [ ]  데스크탑 - 가로스크롤 최대 6개 상품 표시 → 나머지 데이터는 더보기 페이지에서 표시한다
        - [ ]  모바일 - 최대 4개 상품 격자형태로 표시 → 나머지 데이터는 더보기 페이지에서 표시한다
        - [ ]  데이터로 들어온 상품 이미지와 상품명이 표시된다
        - [ ]  클릭시 데이터로 들어온 상품 판매페이지로 이동한다
    - 라이브컨텐츠영역
        - [ ]  데스크탑 - 가로스크롤 최대 4개 컨텐츠 표시
        - [ ]  모바일 - 최대 2개컨텐츠 2행으로 표시
        - [ ]  데이터로 들어온 섬네일 이미지와 컨텐츠명이 표시된다
        - [ ]  클릭시 유튜브 페이지로 이동한다
    - 방송인영역
        - [ ]  데스크탑 - 가로스크롤 최대 6개 방송인 표시
        - [ ]  모바일 - 최대 4개 방송인 격자형태로 표시
        - [ ]  데이터로 들어온 방송인 이미지와 활동명이 표시된다
        - [ ]  클릭시 상품홍보페이지로 이동한다