### PR TITLE
[fix] 방송인센터 IOS 모바일 접속안되는 현상 => BroadcastChannel 사용하는 훅 삭제

### DIFF
--- a/apps/web-broadcaster-center/pages/404.tsx
+++ b/apps/web-broadcaster-center/pages/404.tsx
@@ -1,5 +1,4 @@
 import { Button, Flex, Heading, Text, VStack } from '@chakra-ui/react';
-import { useCloseLiveShoppingStateBoardIfNotLoggedIn } from '@project-lc/hooks';
 import { NextSeo } from 'next-seo';
 import { useRouter } from 'next/router';
 
@@ -9,8 +8,6 @@ export function Custom404(): JSX.Element {
     router.push('/');
   };
 
-  // 로그인 상태가 아닌경우 방송인 현황판 닫기 이펙트
-  useCloseLiveShoppingStateBoardIfNotLoggedIn();
   return (
     <>
       <NextSeo title="페이지를 찾을 수 없습니다." description="" />

--- a/apps/web-broadcaster-center/pages/index.tsx
+++ b/apps/web-broadcaster-center/pages/index.tsx
@@ -9,18 +9,13 @@ import { BroadcasterMainHero } from '@project-lc/components-web-bc/main/Broadcas
 import { BroadcasterMainHowToUse } from '@project-lc/components-web-bc/main/BroadcasterMainHowToUse';
 import { BroadcasterMainIntroduce } from '@project-lc/components-web-bc/main/BroadcasterMainIntroduce';
 import { BroadcasterMainProcess } from '@project-lc/components-web-bc/main/BroadcasterMainProcess';
-import {
-  useCloseLiveShoppingStateBoardIfNotLoggedIn,
-  useIsLoggedIn,
-} from '@project-lc/hooks';
+import { useIsLoggedIn } from '@project-lc/hooks';
 import { useRouter } from 'next/router';
 
 export function Index(): JSX.Element {
   const router = useRouter();
   const inquiry = useDisclosure();
   const { isLoggedIn } = useIsLoggedIn();
-  // 로그인 상태가 아닌경우 방송인 현황판 닫기 이펙트
-  useCloseLiveShoppingStateBoardIfNotLoggedIn();
   return (
     <div>
       <Flex minH="100vh" justify="space-between" flexDirection="column">

--- a/libs/components-shared/src/lib/MypageLayout.tsx
+++ b/libs/components-shared/src/lib/MypageLayout.tsx
@@ -7,11 +7,7 @@ import {
 import LoginRequireAlertDialog from '@project-lc/components-core/LoginRequireAlertDialog';
 import FullscreenLoading from '@project-lc/components-layout/FullscreenLoading';
 import MypageFooter from '@project-lc/components-layout/MypageFooter';
-import {
-  useCloseLiveShoppingStateBoardIfNotLoggedIn,
-  useDisplaySize,
-  useIsLoggedIn,
-} from '@project-lc/hooks';
+import { useDisplaySize, useIsLoggedIn } from '@project-lc/hooks';
 import { UserType } from '@project-lc/shared-types';
 import { FloatingHelpButton } from './FloatingHelpButton';
 import MypageBreadcrumb from './MypageBreadCrumb';
@@ -34,9 +30,6 @@ export function MypageLayout({
 }: MypageLayoutProps): JSX.Element {
   const { status } = useIsLoggedIn();
   const { isMobileSize } = useDisplaySize();
-
-  // 로그인 상태가 아닌경우 방송인 현황판 닫기 이펙트
-  useCloseLiveShoppingStateBoardIfNotLoggedIn();
 
   return (
     <Flex

--- a/libs/hooks/src/lib/auth-hooks.tsx
+++ b/libs/hooks/src/lib/auth-hooks.tsx
@@ -61,38 +61,3 @@ export function useMoveToMainIfLoggedIn(): void {
     }
   }, [isLoggedIn, router]);
 }
-
-/**
- * 로그인 상태가 아닌 경우 방송인센터 라이브 방송 현황판 윈도우 닫기 이펙트
- BroadcastChannel : 동일 origin 에 있는 window, tab, iframe 사이에서 통신 할 수 있게 하는 api
- 방송인센터 탭 여러개 켜놓고 한곳에서 로그아웃 한 경우 
- 다른 탭에서 열린 현황판 window 종료하기 위해 사용
- */
-export function useCloseLiveShoppingStateBoardIfNotLoggedIn(): void {
-  const bcRef = useRef<BroadcastChannel | null>();
-  const { isLoggedIn, status } = useIsLoggedIn();
-  const { closeWindow } = liveShoppingStateBoardWindowStore();
-
-  // 마운트시 bc 객체 생성 & ev 메시지 핸들러 할당
-  useEffect(() => {
-    bcRef.current = new BroadcastChannel('LoginFlag');
-    bcRef.current.onmessage = (ev) => {
-      if (ev.data === 'not logged in') {
-        closeWindow();
-      }
-    };
-    return () => {
-      if (bcRef.current) {
-        bcRef.current = null;
-      }
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // 로그인 상태가 아닌경우 'not logged in' 메시지 발송
-  useEffect(() => {
-    if (!isLoggedIn || status === 'error') {
-      bcRef.current?.postMessage('not logged in');
-    }
-  }, [isLoggedIn, status]);
-}


### PR DESCRIPTION
방송인센터 IOS 모바일 접속안되는 현상
-> ios에서 사용하는 브라우저 버전이 BroadcastChannel api를 지원하지 않는듯 함

BroadcastChannel 적용했던 이유 : 
(방송인센터를 탭 여러개에서 열어서 로그인 한 상태를 가정)
탭a 에서 현황판을 켜고, 탭 b에서 로그아웃 한 경우 탭 a에서 열린 현황판을 닫고 싶었음. 
다른 탭에서 메세지 주고받을 api로  BroadcastChannel 사용하였음
[BroadcastChannel 브라우저 지원](https://developer.mozilla.org/ko/docs/Web/API/BroadcastChannel#browser_compatibility)

BroadcastChannel 채널 대체할 다른 api 찾는데 시간이 걸림
모바일 브라우저 테스트 익숙하지 않음
탭a에서 로그아웃 했을때 탭 b에서 열린 현황판 닫는 기능이 반드시 필요한것 같지 않음
=> BroadcastChannel 사용하는 훅을 삭제하였습니다


