### PR TITLE
fix(web-kkshow): 모바일화면에서 키워드 모음 잘려보이는 현상 수정

### DIFF
--- a/libs/components-admin/src/lib/kkshow-main/AdminKkshowShoppingKeywords.tsx
+++ b/libs/components-admin/src/lib/kkshow-main/AdminKkshowShoppingKeywords.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/no-array-index-key */
-import { DeleteIcon } from '@chakra-ui/icons';
 import {
   Box,
   Button,
@@ -164,18 +163,12 @@ function AdminKkshowShoppingKeywordTable({
 
   return (
     <Box>
-      <Button onClick={() => append({ keyword: '', linkUrl: '' })}>키워드 추가</Button>
-      <Table w={600} size="sm">
+      <Button onClick={() => append({ keyword: '' })}>키워드 추가</Button>
+      <Table w={300} size="sm">
         <Thead>
           <Tr>
             <Th flex={1}>
               키워드명
-              <Text as="span" color="red">
-                *
-              </Text>
-            </Th>
-            <Th flex={2}>
-              키워드 링크
               <Text as="span" color="red">
                 *
               </Text>
@@ -197,15 +190,7 @@ function AdminKkshowShoppingKeywordTable({
                     })}
                   />
                 </Td>
-                <Td>
-                  <Input
-                    m={0}
-                    p={0}
-                    {...register(`keywords.${index}.keywords.${keywordIdx}.linkUrl`, {
-                      required: true,
-                    })}
-                  />
-                </Td>
+
                 <Td>
                   <PageManagerContainerButtonSet
                     variant="only-icon"

--- a/libs/components-web-kkshow/src/lib/shopping/ShoppingKeywords.tsx
+++ b/libs/components-web-kkshow/src/lib/shopping/ShoppingKeywords.tsx
@@ -59,7 +59,7 @@ export function ShoppingKeywords(): JSX.Element {
       </FadeUp>
 
       <Grid
-        gridTemplateColumns={{ base: '1fr 1fr 1fr', md: 'repeat(6, 1fr)' }}
+        gridTemplateColumns={{ base: '1fr 1fr', sm: '1fr 1fr 1fr', md: 'repeat(6, 1fr)' }}
         gap={[2, 4]}
         mt={4}
       >

--- a/libs/prisma-orm/prisma/seedData/kkshowShoppingTab.ts
+++ b/libs/prisma-orm/prisma/seedData/kkshowShoppingTab.ts
@@ -217,30 +217,12 @@ export const kkshowShoppingTabDummyData = {
       imageUrl:
         'https://lc-project.s3.ap-northeast-2.amazonaws.com/kkshow-shopping-keywords-theme-images/1648450101822_keyword.png',
       keywords: [
-        {
-          keyword: '순두부찌개',
-          linkUrl: 'https://k-kmarket.com/goods/view?no=179',
-        },
-        {
-          keyword: '짜장면',
-          linkUrl: 'https://k-kmarket.com/goods/view?no=178',
-        },
-        {
-          keyword: '돈가스',
-          linkUrl: 'https://k-kmarket.com/goods/view?no=178',
-        },
-        {
-          keyword: '밀키트',
-          linkUrl: 'https://k-kmarket.com/goods/view?no=178',
-        },
-        {
-          keyword: '이상해꽃',
-          linkUrl: 'https://namu.wiki/w/%EC%9D%B4%EC%83%81%ED%95%B4%EA%BD%83',
-        },
-        {
-          keyword: '파이리',
-          linkUrl: 'https://namu.wiki/w/%ED%8C%8C%EC%9D%B4%EB%A6%AC',
-        },
+        { keyword: '순두부찌개' },
+        { keyword: '짜장면' },
+        { keyword: '돈가스' },
+        { keyword: '밀키트' },
+        { keyword: '이상해꽃' },
+        { keyword: '파이리' },
       ],
     },
     {
@@ -248,30 +230,12 @@ export const kkshowShoppingTabDummyData = {
       imageUrl:
         'https://lc-project.s3.ap-northeast-2.amazonaws.com/kkshow-shopping-keywords-theme-images/1648450101822_keyword.png',
       keywords: [
-        {
-          keyword: '파스타',
-          linkUrl: 'https://k-kmarket.com/goods/view?no=178',
-        },
-        {
-          keyword: '곰',
-          linkUrl: 'https://k-kmarket.com/goods/view?no=179',
-        },
-        {
-          keyword: '\b호랑이',
-          linkUrl: 'https://k-kmarket.com/goods/view?no=178',
-        },
-        {
-          keyword: '이름대로',
-          linkUrl: 'https://k-kmarket.com/goods/view?no=179',
-        },
-        {
-          keyword: '김광석',
-          linkUrl: 'https://k-kmarket.com/goods/view?no=178',
-        },
-        {
-          keyword: '명예',
-          linkUrl: 'https://k-kmarket.com/goods/view?no=179',
-        },
+        { keyword: '파스타' },
+        { keyword: '곰' },
+        { keyword: '\b호랑이' },
+        { keyword: '이름대로' },
+        { keyword: '김광석' },
+        { keyword: '명예' },
       ],
     },
   ],

--- a/libs/shared-types/src/lib/res-types/kkshowShoppingTab.res.ts
+++ b/libs/shared-types/src/lib/res-types/kkshowShoppingTab.res.ts
@@ -27,7 +27,6 @@ export interface KkshowShoppingTabReviewData extends ImageCard {
 export type KkshowShopingTabTheme = string;
 export type KkshowShoppingTabKeyword = {
   keyword: string; // 키워드
-  linkUrl: string; // 링크주소
 };
 export interface KkshowShoppingTabThemeData {
   theme: KkshowShopingTabTheme; // 테마


### PR DESCRIPTION
<details>
<summary>이전</summary>
<img width="299" alt="스크린샷 2022-04-01 오후 12 00 14" src="https://user-images.githubusercontent.com/43170520/161186758-6c4a378b-f5c7-4110-8185-2664af4a7d9e.png">
</details>

<details>
<summary>이후</summary>
<img width="299" alt="스크린샷 2022-04-01 오후 12 00 24" src="https://user-images.githubusercontent.com/43170520/161186793-1bf8e43f-6a4a-4088-af44-802597015622.png"></details>


