### PR TITLE
feat: nrgram 마이그레이션 파일 생성

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - MYSQL_DATABASE=public
     ports:
       - "3306:3306"
-    command: --innodb_ft_min_token_size=1
+    command: --ngram-token-size=1
 
   
   ###############

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - MYSQL_DATABASE=public
     ports:
       - "3306:3306"
-    command: --ngram-token-size=1
+    command: --ngram_token_size=1
 
   
   ###############

--- a/libs/prisma-orm/prisma/migrations/20220404094900_version7/migration.sql
+++ b/libs/prisma-orm/prisma/migrations/20220404094900_version7/migration.sql
@@ -69,3 +69,4 @@ CREATE FULLTEXT INDEX `Broadcaster_userNickname_idx` ON `Broadcaster`(`userNickn
 
 -- CreateIndex
 CREATE FULLTEXT INDEX `Goods_goods_name_idx` ON `Goods`(`goods_name`);
+

--- a/libs/prisma-orm/prisma/migrations/20220406071635/migration.sql
+++ b/libs/prisma-orm/prisma/migrations/20220406071635/migration.sql
@@ -1,0 +1,9 @@
+-- DROP INDEX
+DROP INDEX `Broadcaster_userNickname_idx` ON `Broadcaster`;
+
+-- DROP INDEX
+DROP INDEX `Goods_goods_name_idx` ON `Goods`;
+
+ALTER TABLE `Broadcaster` ADD FULLTEXT INDEX `Broadcaster_userNickname_idx`(`userNickname`) WITH PARSER NGRAM;
+
+ALTER TABLE `Goods` ADD FULLTEXT INDEX `Goods_goods_name_idx`(`goods_name`) WITH PARSER NGRAM;


### PR DESCRIPTION
- nrgram 적용 마이그레이션 파일 생성
- ngram 적용시, innodb_ft_min_token_size 대신 ngram_token_size 사용
  - ngram_token_size 디폴트는 2
  - 우리는 1로 설정 (떡, 닭, 빵) -> db의 부하는 상승한다고 합니다