### PR TITLE
[인프라] ISR SSG 상품상세페이지 빌드 환경 조성

### DIFF
--- a/libs/hooks/src/lib/queries/useGoodsById.tsx
+++ b/libs/hooks/src/lib/queries/useGoodsById.tsx
@@ -1,18 +1,20 @@
 import { GoodsByIdRes } from '@project-lc/shared-types';
-import { getApiHost } from '@project-lc/utils';
 import { AxiosError } from 'axios';
 import { useQuery, UseQueryResult } from 'react-query';
 import axios from '../../axios';
 
 export const generateGoodsByIdKey = (
-  goodsId: number | string,
-): [string, number | string] => ['GoodsById', goodsId];
-export const getGoodsById = async (goodsId: number | string): Promise<GoodsByIdRes> => {
+  goodsId: number | string | null,
+): [string, number | string | null] => ['GoodsById', goodsId];
+
+export const getGoodsById = async (
+  goodsId: number | string | null,
+): Promise<GoodsByIdRes> => {
   return axios.get<GoodsByIdRes>(`/goods/${goodsId}`).then((res) => res.data);
 };
 
 export const useGoodsById = (
-  goodsId: number | string,
+  goodsId: number | string | null,
   initialData?: GoodsByIdRes,
 ): UseQueryResult<GoodsByIdRes, AxiosError> => {
   return useQuery<GoodsByIdRes, AxiosError>(
@@ -20,4 +22,18 @@ export const useGoodsById = (
     () => getGoodsById(goodsId),
     { initialData, enabled: !!goodsId },
   );
+};
+
+export type AllGoodsIdsRes = number[];
+
+export const ALL_GOODS_IDS_KEY = 'AllGoodsIds';
+export const getAllGoodsIds = async (): Promise<AllGoodsIdsRes> => {
+  return axios
+    .get<AllGoodsIdsRes>('/goods/all-ids')
+    .then((res) => res.data)
+    .catch(() => []);
+};
+
+export const useAllGoodsIds = (): UseQueryResult<AllGoodsIdsRes, AxiosError> => {
+  return useQuery<AllGoodsIdsRes, AxiosError>(ALL_GOODS_IDS_KEY, getAllGoodsIds);
 };


### PR DESCRIPTION
- Nextjs에서 DB 직접 접근 제거
- API서버로 올바르게 요청할 수 있도록 구성

### 의도

GetStaticPaths와 GetStaticProps를 통해 SSG 방식으로 각 상품에 대한 상세페이지를 구성하고자 함

### 문제

1. GetStaticPaths 에서 API 요청이 안되는 현상
2. 1의 문제로 GetStaticPaths 에서 곧바로 prisma를 통해 DB에 접근하여 상품 번호 목록을 가져오도록 구성함.
3. 2의 처리는 빌드 환경과 로컬DB가 동시에 배포되고 있는 로컬환경에서는 별 문제없이 동작하나, Test/Prod 환경의 경우 빌드환경은 Vercel, 각 환경의 DB는 AWS상에서 배포되고 있음.
    1. Test/Prod 환경 DB는 보안을 위해 허용된 IP로부터의 요청만 처리함.
    2. Vercel은 IP가 가변적이며, 대역폭이 특정되어있지 않음. 따라서 DB에서 Vercel 빌드머신에 대한 접근 허용처리를 할 수 없음.
    3. 이로 인해 Vercel에서 빌드시, DB에 접근할 수 없음.

### 문제의 해결

1. Github Actions의 Migration 처리도 동일한 문제를 가졌지만, Github Actions의 경우 self-hosted 빌드 서버를 구성하는 기능을 제공하고 이를 통해 DB접근 허용된 IP주소를 가지는 빌드 서버를 따로 구성해 처리할 수 있었음.
    - Vercel에서도 self-hosted 빌드 서버를 구성할 수 있는가? 그렇다면 이 문제를 해결 가능
        
        → 구성할 수 없음
        
    - Vercel VPC Peering
        
        AWS Aurora를 사용하는 경우 public url을 제공하지 않으므로 VPC Peering 없이는 Nextjs API를 통해 접근하지 못한다고 함./
        
        → AWS VPC와 peering 연결하는 기능이 현재 Vercel 로드맵에 있으나 아직 제공되지는 않음.
       
2. GetStaticPaths 요청을 DB에 직접접근하지 않는 방식으로 구현할 수 있는가?
    - 환경에 따라 올바른 project-lc API 서버로의 요청을 통해 해결
        
        → nextjs 빌드시 NODE_ENV가 production으로 설정되어있어 호스트명을 찾지 못했던 것.
        
        → 이를 올바르게 참조하도록 수정하니 API 요청이 올바르게 작동함.
        
        → 또한 API서버를 찾지 못한 경우 빈 배열을 반환하도록 하여 오류 없이 일단 빌드되도록 처리함.
        
        → ISR을 통해 배포 이후 지속적으로 SSG를 실행하므로 이 처리는 큰 문제를 일으키지 않을 것.
        
        → 빌드 환경 (Vercel) 에서 API_HOST 에 대한 환경변수를 올바르게 추가하여야 함.
        
        → 로컬환경에서 web-kkshow 를 빌드하는 경우 API_HOST에 대한 환경변수값(`(http://localhost:3000)`)을  올바르게 추가해야함.