### PR TITLE
[판매자] 마이페이지 홈 현황 (project-lc)

### DIFF
--- a/libs/components-seller/src/lib/MypageOrderStats.tsx
+++ b/libs/components-seller/src/lib/MypageOrderStats.tsx
@@ -8,11 +8,12 @@ import {
   StatNumber,
   Text,
 } from '@chakra-ui/react';
-import { useFmOrdersStats } from '@project-lc/hooks';
+import { useProfile, useSellerOrderStats } from '@project-lc/hooks';
 import { orderKeys, OrderStatsKeyType } from '@project-lc/shared-types';
 
 export function MypageOrderStats(): JSX.Element {
-  const { data } = useFmOrdersStats();
+  const { data: profileData } = useProfile();
+  const { data } = useSellerOrderStats(profileData?.id);
 
   return (
     <Grid templateColumns={`repeat(${orderKeys.length}, 1fr)`}>

--- a/libs/components-seller/src/lib/MypageSalesStats.tsx
+++ b/libs/components-seller/src/lib/MypageSalesStats.tsx
@@ -9,11 +9,12 @@ import {
   StatNumber,
   Text,
 } from '@chakra-ui/react';
-import { useFmOrdersStats } from '@project-lc/hooks';
+import { useProfile, useSellerOrderStats } from '@project-lc/hooks';
 import { AiFillInteraction, AiFillShopping } from 'react-icons/ai';
 
 export function MypageSalesStats(): JSX.Element {
-  const { data } = useFmOrdersStats();
+  const { data: profileData } = useProfile();
+  const { data } = useSellerOrderStats(profileData?.id);
 
   return (
     <Grid templateColumns="1fr 1fr">

--- a/libs/hooks/src/index.ts
+++ b/libs/hooks/src/index.ts
@@ -149,6 +149,7 @@ export * from './lib/queries/useReviews';
 export * from './lib/queries/useSellCommission';
 export * from './lib/queries/useSellerGoodsList';
 export * from './lib/queries/useSellerOrderCancelRequest';
+export * from './lib/queries/useSellerOrderStats';
 export * from './lib/queries/useSellerSettlementHistory';
 export * from './lib/queries/useSettlementHistory';
 export * from './lib/queries/useSettlementHistoryCalender';

--- a/libs/hooks/src/lib/queries/useSellerOrderStats.tsx
+++ b/libs/hooks/src/lib/queries/useSellerOrderStats.tsx
@@ -1,0 +1,22 @@
+import { OrderStatsRes } from '@project-lc/shared-types';
+import { AxiosError } from 'axios';
+import { useQuery, UseQueryResult } from 'react-query';
+import axios from '../../axios';
+
+export const getSellerOrderStats = async (sellerId?: number): Promise<OrderStatsRes> => {
+  return axios
+    .get<OrderStatsRes>('/order/stats', { params: { sellerId } })
+    .then((res) => res.data);
+};
+
+export const useSellerOrderStats = (
+  sellerId?: number,
+): UseQueryResult<OrderStatsRes, AxiosError> => {
+  return useQuery<OrderStatsRes, AxiosError>(
+    ['SellerOrderStats', { sellerId }],
+    () => getSellerOrderStats(sellerId),
+    {
+      enabled: !!sellerId,
+    },
+  );
+};

--- a/libs/nest-modules-order/src/lib/order.controller.ts
+++ b/libs/nest-modules-order/src/lib/order.controller.ts
@@ -20,6 +20,7 @@ import {
   OrderDetailRes,
   OrderListRes,
   OrderPurchaseConfirmationDto,
+  OrderStatsRes,
   UpdateOrderDto,
 } from '@project-lc/shared-types';
 import { OrderService } from './order.service';
@@ -42,6 +43,14 @@ export class OrderController {
   @Post()
   createOrder(@Body(ValidationPipe) dto: CreateOrderDto): Promise<Order> {
     return this.orderService.createOrder(dto);
+  }
+
+  /** 판매자 주문현황 조회 */
+  @Get('stats')
+  async getOrdersStats(
+    @Query('sellerId', ParseIntPipe) sellerId: number,
+  ): Promise<OrderStatsRes> {
+    return this.orderService.getOrderStats(sellerId);
   }
 
   /** 비회원 주문 상세조회 - 가드 적용하지 않아야 함 */

--- a/libs/nest-modules-order/src/lib/order.service.ts
+++ b/libs/nest-modules-order/src/lib/order.service.ts
@@ -5,16 +5,21 @@ import { BroadcasterService } from '@project-lc/nest-modules-broadcaster';
 import { PrismaService } from '@project-lc/prisma-orm';
 import {
   CreateOrderDto,
+  FmOrderStatusNumString,
   GetNonMemberOrderDetailDto,
   GetOrderListDto,
   OrderDetailRes,
   OrderListRes,
+  orderProcessStepDict,
   OrderPurchaseConfirmationDto,
+  OrderStatsRes,
   UpdateOrderDto,
 } from '@project-lc/shared-types';
 import { nanoid } from 'nanoid';
 import dayjs = require('dayjs');
+import isToday = require('dayjs/plugin/isToday');
 
+dayjs.extend(isToday);
 @Injectable()
 export class OrderService {
   constructor(
@@ -470,5 +475,154 @@ export class OrderService {
     }
 
     return true;
+  }
+
+  /**
+   * 판매자 본인의 상품에 의거한 실제 주문 상태를 조회합니다.
+   * 이는 여러 판매자의 상품이 하나의 주문에 포함될 수 있는 상황에 대한 처리 용도입니다.
+   */
+  private getOrderRealStep(
+    orderStep: OrderProcessStep,
+    orderItemOtions: { step: OrderProcessStep }[],
+  ): OrderProcessStep {
+    if (orderItemOtions.length === 0) return orderStep;
+    const isPartialStep = [
+      'partialExportReady',
+      'partialExportDone',
+      'partialShipping',
+      'partialShippingDone',
+    ].includes(orderStep);
+
+    // 주문의 상태가 "부분0000"일 때,
+    if (isPartialStep) {
+      // "부분" 상태를 제거한 상태
+      const nonPartialStepString = orderStep.replace('partial', '');
+      const nonPartialStep = (nonPartialStepString[0].toLocaleLowerCase() +
+        nonPartialStepString.slice(1)) as OrderProcessStep;
+      // 옵션들 모두가 "부분" 상태를 제거한 상태만 있는 지 확인, 그렇다면 "부분" 상태를 제거한 상태를 반환
+      if (orderItemOtions.every((o) => o.step === nonPartialStep)) {
+        console.log('non partial step', nonPartialStep, { orderStep });
+        return nonPartialStep;
+      }
+    }
+
+    // 옵션들 모두가 주문상태보다 작은지 확인, 그렇다면 옵션들 중 가장 높은 상태를 반환
+    if (
+      orderItemOtions.every(
+        (o) =>
+          Number(orderProcessStepDict[o.step]) < Number(orderProcessStepDict[orderStep]),
+      )
+    ) {
+      return orderItemOtions.reduce((acc, curr) => {
+        if (!acc) return curr.step;
+        if (Number(orderProcessStepDict[acc]) < Number(orderProcessStepDict[curr.step]))
+          return curr.step;
+        return acc;
+      }, orderItemOtions[0].step);
+    }
+
+    return orderStep;
+  }
+
+  /** 판매자센터 마이페이지 홈 오늘매출현황, 주문현황조회 */
+  public async getOrderStats(sellerId: number): Promise<any> {
+    // Promise<OrderStatsRes>
+    // * 판매자의 주문조회 1개월 내(판매자의 상품이 주문상품으로 포함된 주문)
+    const sellerOrders = await this.prisma.order.findMany({
+      where: {
+        orderItems: { some: { goods: { sellerId } } },
+        createDate: { gte: dayjs().subtract(1, 'month').toDate() },
+      },
+      include: {
+        orderItems: { include: { options: true, goods: { select: { sellerId: true } } } },
+      },
+    });
+    // 주문상품 중 판매자의 상품&상품옵션만 추려내기
+    const ordersWithFilteredItems = sellerOrders.map((order) => {
+      const { orderItems, ...orderData } = order;
+
+      const sellerGoodsOrderItems = orderItems.filter((oi) => {
+        return oi.goods.sellerId === sellerId;
+      });
+      return { ...orderData, orderItems: sellerGoodsOrderItems };
+    });
+    // 판매자 상품인 주문상품옵션의 상태에 기반한 주문상태 표시
+    const ordersWithRealStep = ordersWithFilteredItems.map((order) => {
+      const { orderItems, step, ...orderData } = order;
+      const newStep = this.getOrderRealStep(
+        step,
+        orderItems.flatMap((item) => item.options),
+      );
+      return {
+        ...orderData,
+        step: newStep,
+        orderItems,
+      };
+    });
+    // 주문상태별 개수 카운트
+    const orderStats = {
+      shippingReady: 0, // 상품준비 + 부분출고준비 + 출고준비 + 부분출고완료 + 출고완료
+      shipping: 0, // 부분배송중 + 배송중 + 부분배송완료
+      shippingDone: 0, //  배송완료
+    };
+    ordersWithRealStep.forEach((order) => {
+      if (
+        [
+          'goodsReady',
+          'partialExportReady',
+          'exportReady',
+          'partialExportDone',
+          'exportDone',
+        ].includes(order.step)
+      ) {
+        orderStats.shippingReady += 1;
+      }
+      if (['partialShipping', 'shipping', 'partialShippingDone'].includes(order.step)) {
+        orderStats.shipping += 1;
+      }
+      if (['shippingDone'].includes(order.step)) {
+        orderStats.shippingDone += 1;
+      }
+    });
+
+    // * 판매자의 오늘매출현황 -> 1달치 조회했던 주문데이터 활용
+    // 1달치 조회한 주문 중 오늘 생성된 주문 && 주문상태가 결제확인 단계 이상인 주문 필터링
+    const sellerOrdersToday = ordersWithRealStep.filter((order) => {
+      return (
+        dayjs(order.createDate).isToday() &&
+        ![
+          'orderReceived',
+          'paymentCanceled',
+          'orderInvalidated',
+          'paymentFailed',
+        ].includes(order.step)
+      );
+    });
+
+    // 추려낸 주문상품의 배송비 + 주문상품옵션가격
+    const sellerOrderItemsToday = sellerOrdersToday.flatMap((order) => order.orderItems);
+    const orderItemOptionsToday = sellerOrderItemsToday.flatMap((orderItem) => {
+      const { options, shippingCost } = orderItem;
+      return { ...options, shippingCost };
+    });
+    // 판매자의 오늘환불현황
+    // 환불상품에 판매자 상품이 포함된 환불조회하고
+    // 환불 상품에서 판매자 상품만 추려냄
+    // const sellerRefund = await this.prisma.refund.findMany({
+    //   where: {
+    //     items: { some: { orderItem: { goods: { sellerId } } } },
+    //   },
+    // });
+
+    // return {
+    //   orders: { 배송완료: orderStats.shippingDone, 배송준비중: orderStats.shippingReady, 배송중: orderStats.shipping },
+    //   sales: { 주문: { count: sellerOrdersToday.length, sum: 0 }, 환불: { count: 0, sum: 0 } },
+    // };
+    return {
+      sellerOrdersCount: ordersWithRealStep.length,
+      ordersWithRealStep,
+      // sellerOrdersTodayCount: sellerOrdersToday.length,
+      // orderStats,
+    };
   }
 }

--- a/libs/shared-types/src/lib/constants/orderProcessStepDict.ts
+++ b/libs/shared-types/src/lib/constants/orderProcessStepDict.ts
@@ -56,3 +56,16 @@ export const inquireDisableSteps = [
   'orderInvalidated',
   'paymentFailed',
 ];
+
+// 판매자센터 마이페이지 주문현황
+export const sellerOrderSteps = {
+  shippingReady: [
+    'goodsReady',
+    'partialExportReady',
+    'exportReady',
+    'partialExportDone',
+    'exportDone',
+  ],
+  shipping: ['partialShipping', 'shipping', 'partialShippingDone'],
+  shippingDone: ['shippingDone'],
+};


### PR DESCRIPTION
GET order/stats 생성 => fm-order/stats와 동일한 형태의 데이터 리턴

주문과 환불 연결된 판매자의 상품을 기준으로 오늘 주문금액, 오늘 환불금액 표시

**테스트케이스**

사전작업
1. testseller 외에 아무 판매자나 만들고 다른 판매자에 테스트상품 2를 연결, 기존의 testseller는 상품1과 연결된 상태에서 testseller로 로그인하여 확인
2. 주문의 날짜를 다르게 지정

- 주문현황 (최근 1개월 기준 = createDate가 한달 내인 주문)
    - [ ]  상품준비 + 부분출고준비 + 출고준비 + 부분출고완료 + 출고완료 상태인 주문은 배송준비중에 집계된다
    - [ ]  부분배송중 + 배송중 + 부분배송완료 상태인 주문은 배송중에 집계된다
    - [ ]  배송완료 상태인 주문은 배송완료에 집계된다
    
    (각 기준은 기존 fm-order에서 사용하던 주문현황조회 서비스함수 getOrdersStats 참고함)
    
- 오늘 매출 현황
    - 주문
        - [ ]  주문 생성날짜가 오늘 & 판매자의 상품이 포함된 주문 & 판매자의 상품만 필터링 & 해당 주문상품 옵션에 기반한 새 주문상태가 주문접수, 결제취소, 주문무효, 결제실패 상태가 아닌 주문의 개수 표시
        - [ ]  주문의 paymentAmount가 아닌 (판매자의 상품인 주문상품옵션의 가격 합 + 판매자 주문상품의 배송비) 표시
    - 환불
        - [ ]  환불 생성날짜가 오늘 & 환불상품에 판매자의 상품이 포함된 환불정보의 개수 표시
        - [ ]  환불처리된 판매자의주문상품의 가격합을 표시