### PR TITLE
피드백반영 : 판매자 - 반품(환불) 처리, 소비자 - 주문취소

### DIFF
--- a/apps/web-seller/pages/mypage/orders/[orderCode].tsx
+++ b/apps/web-seller/pages/mypage/orders/[orderCode].tsx
@@ -189,7 +189,7 @@ export function OrderDetail(): JSX.Element {
           </SectionWithTitle>
         )}
 
-        {/* 반품 정보 */}
+        {/* 반품(환불) 정보 */}
         {order.data.returns.length > 0 && (
           <SectionWithTitle title={returnSectionTitle}>
             {order.data.returns.map((_ret) => (
@@ -199,7 +199,7 @@ export function OrderDetail(): JSX.Element {
             ))}
           </SectionWithTitle>
         )}
-        {/* 교환 정보 */}
+        {/* 교환(재배송) 정보 */}
         {order.data.exchanges.length > 0 && (
           <SectionWithTitle title={exchangeSectionTitle}>
             {order.data.exchanges.map((exchangeData) => (

--- a/apps/web-seller/pages/mypage/orders/[orderCode].tsx
+++ b/apps/web-seller/pages/mypage/orders/[orderCode].tsx
@@ -98,10 +98,8 @@ export function OrderDetail(): JSX.Element {
           <OrderDetailTitle order={order.data} />
         </Box>
 
-        {/* 환불(주문취소요청) , 반품, 교환 알림 문구 */}
-        {(order.data.returns.length > 0 ||
-          order.data.orderCancellations.length > 0 ||
-          order.data.exchanges.length > 0) && (
+        {/* 반품(환불), 교환(재배송) 요청 여부 알림 문구 */}
+        {(order.data.returns.length > 0 || order.data.exchanges.length > 0) && (
           <Stack as="section">
             {order.data.returns.length > 0 && (
               <OrderExchangeReturnCancelExistsAlert
@@ -113,12 +111,6 @@ export function OrderDetail(): JSX.Element {
               <OrderExchangeReturnCancelExistsAlert
                 alertTypeKey="exchange"
                 targetSectionTitle={exchangeSectionTitle}
-              />
-            )}
-            {order.data.orderCancellations.length > 0 && (
-              <OrderExchangeReturnCancelExistsAlert
-                alertTypeKey="cancel"
-                targetSectionTitle={orderCancelSectionTitle}
               />
             )}
           </Stack>

--- a/libs/components-seller/src/lib/kkshow-order/OrderReturnStatusDialog.tsx
+++ b/libs/components-seller/src/lib/kkshow-order/OrderReturnStatusDialog.tsx
@@ -192,18 +192,22 @@ export function OrderReturnStatusDialog({
 
             {/* 반품상태변경 */}
             <Stack spacing={1} my={2}>
-              {watch('status') === 'complete' && (
-                <Alert mb={2} status="warning">
+              {watch('status') === 'processing' && (
+                <Alert mb={2} status="info">
                   <List spacing={3}>
                     <ListItem>
-                      <ListIcon as={RiErrorWarningFill} color="orange.500" />
-                      {RETURN_TEXT}완료 선택시, 실제 환불이 진행되므로 반드시 물품 수령 및
-                      확인 후,
-                      {RETURN_TEXT}완료를 선택하세요.
+                      <ListIcon as={RiErrorWarningFill} />
+                      요청 승인 선택시, 크크쇼 관리자가 소비자에게 입금하는 실제
+                      환불과정이 진행됩니다.
+                    </ListItem>
+                    <ListItem>
+                      <ListIcon as={RiErrorWarningFill} />
+                      크크쇼 관리자의 입금 후 자동으로 {RETURN_TEXT}요청은 완료처리
+                      됩니다.
                     </ListItem>
                     <ListItem>
                       <ListIcon as={AiFillWarning} color="red.500" />
-                      {RETURN_TEXT} 완료 등록 후,{' '}
+                      {RETURN_TEXT} 완료 처리 후,{' '}
                       <Text as="span" color="red.500" fontWeight="bold">
                         이전 단계로의 변경은 불가
                       </Text>
@@ -225,8 +229,11 @@ export function OrderReturnStatusDialog({
                   isDisabled={data.status === 'complete'}
                 >
                   <option value="requested">요청됨(초기 상태, 담당자 확인전)</option>
-                  <option value="processing">처리진행중(담당자 확인 후 처리 중)</option>
-                  <option value="complete">처리완료</option>
+                  <option value="processing">
+                    요청승인(크크쇼 관리자가 소비자에게 입금 후 자동 처리완료됨)
+                  </option>
+                  {/* 반품(환불)의 경우 관리자가 소비자에게 입금후 완료처리됨, 판매자가 완료처리할 수 없음 */}
+                  {/* <option value="complete">처리완료</option> */}
                   <option value="canceled">취소(거절)</option>
                 </Select>
                 {errors.status && (

--- a/libs/components-web-kkshow/src/lib/mypage/orderList/CustomerOrderItemActionButtons.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/orderList/CustomerOrderItemActionButtons.tsx
@@ -68,7 +68,7 @@ export function OrderItemActionButtons({
       disabled: false,
     },
     {
-      label: '주문 취소 신청',
+      label: '주문 취소',
       onClick: () => {
         if (!cancelDataIncludingThisOrderItem) {
           orderCancelDialog.onOpen();

--- a/libs/hooks/src/index.ts
+++ b/libs/hooks/src/index.ts
@@ -70,6 +70,7 @@ export * from './lib/mutation/useNotificationMutation';
 export * from './lib/mutation/useOrderMutation';
 export * from './lib/mutation/useOrderPurchaseConfirmMutation';
 export * from './lib/mutation/usePaymentMutation';
+export * from './lib/mutation/useRefundMutation';
 export * from './lib/mutation/useRegistGoods';
 export * from './lib/mutation/useRestoreInactiveDataMutation';
 export * from './lib/mutation/useReviewCommentMutation';

--- a/libs/hooks/src/lib/mutation/useRefundMutation.tsx
+++ b/libs/hooks/src/lib/mutation/useRefundMutation.tsx
@@ -1,0 +1,24 @@
+import { CreateRefundRes, CreateRefundDto } from '@project-lc/shared-types';
+import { AxiosError } from 'axios';
+import { useQueryClient, useMutation, UseMutationResult } from 'react-query';
+import axios from '../../axios';
+
+export type useRefundMutationRes = CreateRefundRes;
+
+/** 환불데이터 생성 뮤테이션 */
+export const useCreateRefundMutation = (): UseMutationResult<
+  useRefundMutationRes,
+  AxiosError,
+  CreateRefundDto
+> => {
+  const queryClient = useQueryClient();
+  return useMutation<useRefundMutationRes, AxiosError, CreateRefundDto>(
+    (dto: CreateRefundDto) =>
+      axios.post<useRefundMutationRes>('/refund', dto).then((res) => res.data),
+    {
+      onSuccess: (data) => {
+        // queryClient.invalidateQueries('');
+      },
+    },
+  );
+};

--- a/libs/nest-modules-order/src/lib/order-cancellation/order-cancellation.controller.ts
+++ b/libs/nest-modules-order/src/lib/order-cancellation/order-cancellation.controller.ts
@@ -8,10 +8,12 @@ import {
   Patch,
   Post,
   Query,
+  UseGuards,
   UseInterceptors,
   ValidationPipe,
 } from '@nestjs/common';
 import { CacheClearKeys, HttpCacheInterceptor } from '@project-lc/nest-core';
+import { JwtAuthGuard } from '@project-lc/nest-modules-authguard';
 import {
   CreateOrderCancellationDto,
   CreateOrderCancellationRes,
@@ -25,6 +27,7 @@ import {
 } from '@project-lc/shared-types';
 import { OrderCancellationService } from './order-cancellation.service';
 
+@UseGuards(JwtAuthGuard)
 @UseInterceptors(HttpCacheInterceptor)
 @CacheClearKeys('order/cancellation')
 @Controller('order/cancellation')

--- a/libs/nest-modules-order/src/lib/order-cancellation/order-cancellation.service.ts
+++ b/libs/nest-modules-order/src/lib/order-cancellation/order-cancellation.service.ts
@@ -38,9 +38,9 @@ export class OrderCancellationService {
         `주문취소는 주문접수, 입금확인 단계에서만 신청 가능합니다.`,
       );
     }
-    // 취소요청한 주문이 주문접수상태이면(환불 필요없음) 주문취소, 주문취소상품 상태 바로 완료 처리
-    const status: ProcessStatus =
-      order.step === 'orderReceived' ? 'complete' : 'requested';
+
+    // 주문취소, 주문취소상품 상태 : 완료
+    const status: ProcessStatus = 'complete';
 
     // 주문취소코드 생성
     const cancelCode = nanoid();
@@ -52,7 +52,7 @@ export class OrderCancellationService {
         cancelCode,
         order: { connect: { id: orderId } },
         status,
-        completeDate: status === 'complete' ? new Date() : undefined,
+        completeDate: new Date(),
         items: {
           create: items.map((item) => ({
             orderItem: { connect: { id: item.orderItemId } },

--- a/libs/nest-modules-refund/src/lib/refund.controller.ts
+++ b/libs/nest-modules-refund/src/lib/refund.controller.ts
@@ -5,10 +5,12 @@ import {
   ParseIntPipe,
   Post,
   Query,
+  UseGuards,
   UseInterceptors,
   ValidationPipe,
 } from '@nestjs/common';
 import { CacheClearKeys, HttpCacheInterceptor } from '@project-lc/nest-core';
+import { JwtAuthGuard } from '@project-lc/nest-modules-authguard';
 import {
   CreateRefundDto,
   CreateRefundRes,
@@ -18,6 +20,7 @@ import {
 } from '@project-lc/shared-types';
 import { RefundService } from './refund.service';
 
+@UseGuards(JwtAuthGuard)
 @UseInterceptors(HttpCacheInterceptor)
 @CacheClearKeys('refund')
 @Controller('refund')


### PR DESCRIPTION
- 판매자센터 반품(환불)요청에 대해 완료처리는 진행할 수 없도록 수정(환불절차는 관리자가 진행함). 판매자는 승인까지만 진행하고, 이후 관리자가 환불 진행 후 반품완료처리됨
- 판매자센터 주문취소 요청에 대한 승인거절 과정 불필요하여 삭제(상품준비 상태 이후 주문은 반품요청 진행됨, 결제완료 단계에서는 상품이 준비되지 않았으므로 판매자 승인없이 환불처리 가능함)
  - 소비자센터 주문취소시 바로 주문취소완료 처리 & 환불처리 진행하도록 수정
  - 판매자센터 주문취소내역에 대한 알림표시 삭제