### PR TITLE
[관리자] fmGoodsSeq 입력제거 처리

### DIFF
--- a/apps/admin/pages/live-shopping/[liveShoppingId].tsx
+++ b/apps/admin/pages/live-shopping/[liveShoppingId].tsx
@@ -92,7 +92,6 @@ export function LiveShoppingDetail(): JSX.Element {
       sellEndDate: '',
       rejectionReason: '',
       videoUrl: '',
-      fmGoodsSeq: null,
     },
   });
   const toast = useToast();
@@ -121,7 +120,6 @@ export function LiveShoppingDetail(): JSX.Element {
       sellEndDate: '',
       rejectionReason: '',
       videoUrl: '',
-      fmGoodsSeq: null,
     });
     toast({ title: '변경 완료', status: 'success' });
   };
@@ -199,40 +197,6 @@ export function LiveShoppingDetail(): JSX.Element {
               {liveShopping[0].progress === LIVE_SHOPPING_PROGRESS.취소됨 ? (
                 <Text>사유 : {liveShopping[0].rejectionReason}</Text>
               ) : null}
-            </Stack>
-
-            <Stack>
-              <Stack direction="row" alignItems="center">
-                <Text>퍼스트몰 상품 번호: </Text>
-                <Text
-                  as="span"
-                  fontWeight="bold"
-                  textDecoration={liveShopping[0].fmGoodsSeq ? 'underline' : 'unset'}
-                  color={liveShopping[0].fmGoodsSeq ? 'blue' : 'unset'}
-                  cursor={liveShopping[0].fmGoodsSeq ? 'pointer' : 'default'}
-                  onClick={() => {
-                    window.open(
-                      `http://whiletrue.firstmall.kr/goods/view?no=${liveShopping[0].fmGoodsSeq}`,
-                    );
-                  }}
-                >
-                  {liveShopping[0].fmGoodsSeq || '미입력'}
-                </Text>
-              </Stack>
-              {liveShopping[0].progress === 'confirmed' && !liveShopping[0].fmGoodsSeq && (
-                <Alert status="error">
-                  <Stack>
-                    <AlertIcon />
-                    <AlertTitle>퍼스트몰 상품 번호가 입력되지 않았습니다.</AlertTitle>
-                    <AlertDescription>
-                      진행상태가 확정됨이지만 퍼스트몰 상품 번호가 입력되지 않았습니다.
-                      <br />
-                      라이브 쇼핑 진행시 사용하는 퍼스트몰 상품 번호가 입력되지 않으면
-                      방송인 수익금이 올바르게 처리되지 않습니다.
-                    </AlertDescription>
-                  </Stack>
-                </Alert>
-              )}
             </Stack>
 
             <Divider />
@@ -415,24 +379,6 @@ export function LiveShoppingDetail(): JSX.Element {
                 />
               </Stack>
               <Divider />
-
-              <Stack maxW="300px">
-                <FormControl>
-                  <FormLabel>퍼스트몰 상품 번호</FormLabel>
-                  <FormLabel color="gray.500" fontSize="xs">
-                    해당 라이브를 위해 퍼스트몰에서 생성한 새 상품의 상품 번호를
-                    입력하세요.
-                  </FormLabel>
-                  <FormHelperText fontSize="xs">
-                    <Text fontSize="xs" color="red.500" as="span">
-                      (주의){' '}
-                    </Text>
-                    방송인,방송시각등이 확정되었음에도 입력하지 않는 경우, 방송인에게
-                    수익금으로 반영되지 않습니다.
-                  </FormHelperText>
-                  <Input mt={2} type="number" {...register('fmGoodsSeq')} />
-                </FormControl>
-              </Stack>
 
               <Button onClick={openConfirmModal} colorScheme="blue">
                 변경

--- a/libs/components-admin/src/lib/AdminBroadcasterProductPromotionSection.tsx
+++ b/libs/components-admin/src/lib/AdminBroadcasterProductPromotionSection.tsx
@@ -27,7 +27,6 @@ import { boxStyle } from '@project-lc/components-constants/commonStyleProps';
 import { ChakraAutoComplete } from '@project-lc/components-core/ChakraAutoComplete';
 import { ConfirmDialog } from '@project-lc/components-core/ConfirmDialog';
 import {
-  getAdminDuplicateFmGoodsSeqFlagForProductPromotion,
   useAdminAllConfirmedLcGoodsList,
   useAdminProductPromotion,
   useAdminProductPromotionCreateMutation,
@@ -86,7 +85,6 @@ const commissionRateMinMax = {
 type ProductPromotionCreateFormData = {
   promotionPageId: number;
   goodsId: number | null;
-  fmGoodsSeq: number | null;
   broadcasterCommissionRate?: number;
   whiletrueCommissionRate?: number;
 };
@@ -174,34 +172,6 @@ export function AdminProductPromotionForm({
         </FormErrorMessage>
       </FormControl>
 
-      <FormControl isInvalid={!!errors.fmGoodsSeq}>
-        <Stack direction="row">
-          <FormLabel htmlFor="fmGoodsSeq" width="70%">
-            퍼스트몰 상품 고유번호
-          </FormLabel>
-          <Input
-            id="fmGoodsSeq"
-            autoComplete="off"
-            type="number"
-            {...register('fmGoodsSeq', {
-              required: '퍼스트몰 상품 고유번호를 입력해주세요.',
-              valueAsNumber: true,
-              validate: async (_fmGoodsSeq) => {
-                if (!_fmGoodsSeq) return '상품 고유번호는 숫자여야 합니다';
-                const isDuplicateFmGoodsSeq =
-                  await getAdminDuplicateFmGoodsSeqFlagForProductPromotion(_fmGoodsSeq);
-                return (
-                  !isDuplicateFmGoodsSeq ||
-                  '입력하신 퍼스트몰 고유번호는 다른 상품과 연결되어 있습니다. 상품홍보용 제품의 퍼스트몰 고유 번호는 다른 제품의 고유번호와 중복될 수 없습니다. 고유번호를 다시 확인해주세요.'
-                );
-              },
-            })}
-          />
-        </Stack>
-        <FormErrorMessage>
-          {errors.fmGoodsSeq && errors.fmGoodsSeq.message}
-        </FormErrorMessage>
-      </FormControl>
       <Button type="submit">생성</Button>
     </Stack>
   );
@@ -223,24 +193,18 @@ export function AdminProductPromotionCreateModal({
 
   const createProductPromotion = useAdminProductPromotionCreateMutation();
   const onSubmit: SubmitHandler<ProductPromotionCreateFormData> = async (data) => {
-    const {
-      goodsId,
-      fmGoodsSeq,
-      promotionPageId: broadcasterPromotionPageId,
-      ...rest
-    } = data;
-    if (!goodsId || !fmGoodsSeq) return;
+    const { goodsId, promotionPageId: broadcasterPromotionPageId, ...rest } = data;
+    if (!goodsId) return;
 
     const createDto: CreateProductPromotionDto = {
       broadcasterPromotionPageId,
       goodsId,
-      fmGoodsSeq,
       broadcasterId,
       ...rest,
     };
     createProductPromotion
       .mutateAsync(createDto)
-      .then((res) => {
+      .then(() => {
         toast({ title: '생성 성공', status: 'success' });
         onClose();
       })
@@ -260,7 +224,6 @@ export function AdminProductPromotionCreateModal({
             defaultValues={{
               promotionPageId,
               goodsId: null,
-              fmGoodsSeq: null,
               broadcasterCommissionRate: 5,
               whiletrueCommissionRate: 5,
             }}
@@ -287,12 +250,9 @@ export function ProductPromotionItemBox({
         promotionId: item.id,
         broadcasterPromotionPageId: item.broadcasterPromotionPageId,
       })
-      .then((res) => {
+      .then(() => {
         deleteDialog.onClose();
-        toast({
-          title: '해당 상품 홍보를 삭제하였습니다',
-          status: 'success',
-        });
+        toast({ title: '해당 상품 홍보를 삭제하였습니다', status: 'success' });
       });
   }, [deleteDialog, deleteRequest, item, toast]);
   return (
@@ -347,12 +307,7 @@ export function ProductPromotionItemBox({
           onClose={updateDialog.onClose}
           item={item}
         />
-        <Link href={`https://k-kmarket.com/goods/view?no=${item.fmGoodsSeq}`} isExternal>
-          퍼스트몰 상품 고유 번호 :
-          <Text as="span" color="blue.500">
-            {item.fmGoodsSeq}
-          </Text>
-        </Link>
+
         <Text>와일트루 수수료 : {item.whiletrueCommissionRate} %</Text>
         <Text>방송인 수수료 : {item.broadcasterCommissionRate} %</Text>
       </Stack>
@@ -376,12 +331,10 @@ export function AdminProductPromotionUpdateModal({
     register,
     handleSubmit,
     formState: { errors },
-    watch,
   } = useForm<UpdateProductPromotionDto>({
     defaultValues: {
       id: item.id,
       broadcasterPromotionPageId: item.broadcasterPromotionPageId,
-      fmGoodsSeq: item.fmGoodsSeq || undefined,
       goodsId: item.goodsId || undefined,
       broadcasterCommissionRate: Number(item.broadcasterCommissionRate),
       whiletrueCommissionRate: Number(item.whiletrueCommissionRate),
@@ -391,17 +344,10 @@ export function AdminProductPromotionUpdateModal({
   const updateRequest = useAdminProductPromotionUpdateMutation();
   const onSubmit: SubmitHandler<UpdateProductPromotionDto> = (data) => {
     if (!data.id || !data.broadcasterPromotionPageId) return;
-
-    const { fmGoodsSeq, ...rest } = data;
-    let dto: UpdateProductPromotionDto = {
-      ...rest,
-    };
-    if (fmGoodsSeq !== item.fmGoodsSeq) {
-      dto = { ...dto, fmGoodsSeq };
-    }
+    const dto: UpdateProductPromotionDto = data;
     updateRequest
       .mutateAsync(dto)
-      .then((res) => {
+      .then(() => {
         toast({ title: '홍보 상품 정보를 수정하였습니다', status: 'success' });
         onClose();
       })
@@ -467,41 +413,6 @@ export function AdminProductPromotionUpdateModal({
               </FormErrorMessage>
             </FormControl>
 
-            <FormControl isInvalid={!!errors.fmGoodsSeq}>
-              <Stack direction="row">
-                <FormLabel htmlFor="fmGoodsSeq" width="70%">
-                  퍼스트몰 상품 고유번호
-                </FormLabel>
-                <Input
-                  id="fmGoodsSeq"
-                  autoComplete="off"
-                  type="number"
-                  {...register('fmGoodsSeq', {
-                    required: '퍼스트몰 상품 고유번호를 입력해주세요.',
-                    valueAsNumber: true,
-                    validate: async (_fmGoodsSeq) => {
-                      if (!_fmGoodsSeq) return '상품 고유번호는 숫자여야 합니다';
-                      // 이전 퍼스트몰 고유번호와 동일한경우 중복검사 하지 않고 updateRequest의 dto에서 제외한다
-                      if (watch('fmGoodsSeq') === _fmGoodsSeq) {
-                        return true;
-                      }
-                      // 이전 입력한 퍼스트몰 고유번호화 다른 경우 중복검사
-                      const isDuplicateFmGoodsSeq =
-                        await getAdminDuplicateFmGoodsSeqFlagForProductPromotion(
-                          _fmGoodsSeq,
-                        );
-                      return (
-                        !isDuplicateFmGoodsSeq ||
-                        '입력하신 퍼스트몰 고유번호는 다른 상품과 연결되어 있습니다. 상품홍보용 제품의 퍼스트몰 고유 번호는 다른 제품의 고유번호와 중복될 수 없습니다. 고유번호를 다시 확인해주세요.'
-                      );
-                    },
-                  })}
-                />
-              </Stack>
-              <FormErrorMessage>
-                {errors.fmGoodsSeq && errors.fmGoodsSeq.message}
-              </FormErrorMessage>
-            </FormControl>
             <Stack direction="row">
               <Button type="submit" colorScheme="blue">
                 수정

--- a/libs/components-admin/src/lib/AdminLiveShoppingList.tsx
+++ b/libs/components-admin/src/lib/AdminLiveShoppingList.tsx
@@ -6,6 +6,7 @@ import { LiveShoppingProgressBadge } from '@project-lc/components-shared/LiveSho
 import { useAdminLiveShoppingList, useProfile } from '@project-lc/hooks';
 import { getLiveShoppingProgress, LiveShoppingWithGoods } from '@project-lc/shared-types';
 import dayjs from 'dayjs';
+import { getCustomerWebHost } from '@project-lc/utils';
 
 export function AdminLiveShoppingList({
   onRowClick,
@@ -13,7 +14,6 @@ export function AdminLiveShoppingList({
   onRowClick: (liveShoppingId: number) => void;
 }): JSX.Element {
   const { data: profileData } = useProfile();
-
   const { data, isLoading } = useAdminLiveShoppingList(
     {},
     { enabled: !!profileData?.id },
@@ -45,27 +45,19 @@ export function AdminLiveShoppingList({
       valueFormatter: ({ row }) => dayjs(row.createDate).format('YYYY/MM/DD HH:mm'),
     },
     {
-      field: 'fmGoodsSeq',
+      field: 'goodsName',
       headerName: '상품명',
       minWidth: 350,
       renderCell: ({ row }) =>
-        new Date(row.sellEndDate) > new Date() && row.fmGoodsSeq ? (
+        new Date(row.sellEndDate) > new Date() ? (
           <Tooltip label="상품페이지로 이동">
-            <Link
-              href={`http://whiletrue.firstmall.kr/goods/view?no=${row.fmGoodsSeq}`}
-              isExternal
-            >
+            <Link href={`${getCustomerWebHost()}/goods/${row.goodsId}`} isExternal>
               {row.goods.goods_name} <ExternalLinkIcon mx="2px" />
             </Link>
           </Tooltip>
         ) : (
           <Text>{row.goods.goods_name}</Text>
         ),
-    },
-    {
-      field: 'fmGoodSeq',
-      headerName: '퍼스트몰 상품ID',
-      valueFormatter: ({ row }) => (row.fmGoodsSeq ? row.fmGoodsSeq || '미입력' : '미정'),
     },
     {
       field: 'progress',

--- a/libs/components-admin/src/lib/AdminLiveShoppingUpdateConfirmModal.tsx
+++ b/libs/components-admin/src/lib/AdminLiveShoppingUpdateConfirmModal.tsx
@@ -73,9 +73,6 @@ export function AdminLiveShoppingUpdateConfirmModal(
             <Text>거절사유 : {watch('rejectionReason')}</Text>
           ) : null}
           {watch('videoUrl') ? <Text>영상 URL : {watch('videoUrl')}</Text> : null}
-          {watch('fmGoodsSeq') ? (
-            <Text>퍼스트몰 상품 번호 : {watch('fmGoodsSeq')}</Text>
-          ) : null}
         </Box>
       </Box>
     </ConfirmDialog>

--- a/libs/components-admin/src/lib/kkshow-main/AdminKkshowMainCarouselItemView.tsx
+++ b/libs/components-admin/src/lib/kkshow-main/AdminKkshowMainCarouselItemView.tsx
@@ -17,9 +17,7 @@ import {
   Text,
   useDisclosure,
 } from '@chakra-ui/react';
-import ImageInputDialog, {
-  ImageInputFileReadData,
-} from '@project-lc/components-core/ImageInputDialog';
+import { ImageInputFileReadData } from '@project-lc/components-core/ImageInputDialog';
 import { useAdminLiveShoppingImageMutation } from '@project-lc/hooks';
 import {
   KkshowMainResData,
@@ -31,7 +29,7 @@ import {
   SimpleBannerItem,
   UpcomingLiveItem,
 } from '@project-lc/shared-types';
-import { getAdminHost } from '@project-lc/utils';
+import { getAdminHost, getCustomerWebHost } from '@project-lc/utils';
 import { s3 } from '@project-lc/utils-s3';
 import path from 'path';
 import { useMemo, useRef, useState } from 'react';
@@ -401,7 +399,7 @@ export function CarouselItemProductAndBroadcasterInfo(
     setValue(`carousel.${index}.liveShoppingName`, data.liveShoppingName || '');
     setValue(
       `carousel.${index}.productLinkUrl`,
-      data.fmGoodsSeq ? `https://k-kmarket.com/goods/view?no=${data.fmGoodsSeq}` : '',
+      `${getCustomerWebHost()}/goods/${data.goodsId}`,
     );
     setValue(`carousel.${index}.normalPrice`, Number(data.goods.options[0].price));
     setValue(

--- a/libs/components-admin/src/lib/kkshow-main/AdminKkshowMainPreviewSection.tsx
+++ b/libs/components-admin/src/lib/kkshow-main/AdminKkshowMainPreviewSection.tsx
@@ -15,6 +15,7 @@ import ImageInputDialog, {
 } from '@project-lc/components-core/ImageInputDialog';
 import { useAdminLiveShoppingImageMutation } from '@project-lc/hooks';
 import { LiveShoppingWithGoods } from '@project-lc/shared-types';
+import { getCustomerWebHost } from '@project-lc/utils';
 import { s3 } from '@project-lc/utils-s3';
 import dayjs from 'dayjs';
 import path from 'path';
@@ -61,7 +62,6 @@ export function AdminKkshowMainPreviewSection(): JSX.Element {
     const {
       broadcastStartDate: _broadcastStartDate,
       broadcaster,
-      fmGoodsSeq,
       liveShoppingName,
       goods,
       id,
@@ -77,15 +77,8 @@ export function AdminKkshowMainPreviewSection(): JSX.Element {
     } else {
       setValue('trailer.imageUrl', '', { shouldDirty: true });
     }
-
     setValue('trailer.liveShoppingId', id, { shouldDirty: true });
-
-    if (fmGoodsSeq) {
-      setValue(
-        'trailer.productLinkUrl',
-        `https://k-kmarket.com/goods/view?no=${fmGoodsSeq}`,
-      );
-    }
+    setValue('trailer.productLinkUrl', `${getCustomerWebHost()}/goods/${item.goodsId}`);
     setValue('trailer.broadcastStartDate', _broadcastStartDate);
     if (_broadcastStartDate && dateRef.current) {
       dateRef.current.value = '';

--- a/libs/components-seller/src/lib/LiveShoppingList.tsx
+++ b/libs/components-seller/src/lib/LiveShoppingList.tsx
@@ -114,7 +114,7 @@ export function LiveShoppingList(): JSX.Element {
         row.liveShoppingName || '(라이브 쇼핑명은 라이브 쇼핑 확정 후, 등록됩니다.)',
     },
     {
-      field: 'fmGoodsSeq',
+      field: 'goods_name',
       headerName: '상품명',
       minWidth: 350,
       flex: 1,

--- a/libs/components-web-bc/src/lib/BroadcasterLiveShoppingList.tsx
+++ b/libs/components-web-bc/src/lib/BroadcasterLiveShoppingList.tsx
@@ -113,7 +113,7 @@ export function BroadcasterLiveShoppingList({
           row.liveShoppingName || '라이브 쇼핑명은 라이브 쇼핑 확정 후, 등록됩니다.',
       },
       {
-        field: 'fmGoodsSeq',
+        field: 'goods_name',
         headerName: '상품명',
         minWidth: 350,
         renderCell: ({ row }) =>

--- a/libs/firstmall-db/src/lib/fm-orders/fm-orders.controller.ts
+++ b/libs/firstmall-db/src/lib/fm-orders/fm-orders.controller.ts
@@ -105,53 +105,55 @@ export class FmOrdersController {
     return this.fmOrdersService.getOrdersStats(ids);
   }
 
-  @Get('/per-live-shopping')
-  async findSalesPerLiveShopping(
-    @SellerInfo() seller: UserPayload,
-  ): Promise<{ id: number; sales: string }[]> {
-    let liveShoppingList = await this.liveShoppingService
-      .findLiveShoppings({ sellerId: seller.id })
-      .then((result) => {
-        return result.map((val) => {
-          if (val.sellStartDate && val.sellEndDate) {
-            return {
-              id: val.id,
-              fmGoodsSeq: val.fmGoodsSeq,
-              sellStartDate: dayjs(val.sellStartDate).toString(),
-              sellEndDate: dayjs(val.sellEndDate).toString(),
-            };
-          }
-          return null;
-        });
-      });
+  // @deprecated
+  // @Get('/per-live-shopping')
+  // async findSalesPerLiveShopping(
+  //   @SellerInfo() seller: UserPayload,
+  // ): Promise<{ id: number; sales: string }[]> {
+  //   let liveShoppingList = await this.liveShoppingService
+  //     .findLiveShoppings({ sellerId: seller.id })
+  //     .then((result) => {
+  //       return result.map((val) => {
+  //         if (val.sellStartDate && val.sellEndDate) {
+  //           return {
+  //             id: val.id,
+  //             fmGoodsSeq: val.fmGoodsSeq,
+  //             sellStartDate: dayjs(val.sellStartDate).toString(),
+  //             sellEndDate: dayjs(val.sellEndDate).toString(),
+  //           };
+  //         }
+  //         return null;
+  //       });
+  //     });
 
-    liveShoppingList = liveShoppingList?.filter((n) => n);
-    return this.fmOrdersService.getOrdersStatsDuringLiveShoppingSales(liveShoppingList);
-  }
+  //   liveShoppingList = liveShoppingList?.filter((n) => n);
+  //   return this.fmOrdersService.getOrdersStatsDuringLiveShoppingSales(liveShoppingList);
+  // }
 
-  @Get('/broadcaster/per-live-shopping')
-  async broadcasterFindSalesPerLiveShopping(
-    @Query('broadcasterId') broadcasterId: number,
-  ): Promise<{ id: number; sales: string }[]> {
-    let liveShoppingList = await this.liveShoppingService
-      .findLiveShoppings({ broadcasterId })
-      .then((result) => {
-        return result.map((val) => {
-          if (val.sellStartDate && val.sellEndDate) {
-            return {
-              id: val.id,
-              fmGoodsSeq: val.fmGoodsSeq,
-              sellStartDate: dayjs(val.sellStartDate).toString(),
-              sellEndDate: dayjs(val.sellEndDate).toString(),
-            };
-          }
-          return null;
-        });
-      });
+  // @deprecated
+  // @Get('/broadcaster/per-live-shopping')
+  // async broadcasterFindSalesPerLiveShopping(
+  //   @Query('broadcasterId') broadcasterId: number,
+  // ): Promise<{ id: number; sales: string }[]> {
+  //   let liveShoppingList = await this.liveShoppingService
+  //     .findLiveShoppings({ broadcasterId })
+  //     .then((result) => {
+  //       return result.map((val) => {
+  //         if (val.sellStartDate && val.sellEndDate) {
+  //           return {
+  //             id: val.id,
+  //             fmGoodsSeq: val.fmGoodsSeq,
+  //             sellStartDate: dayjs(val.sellStartDate).toString(),
+  //             sellEndDate: dayjs(val.sellEndDate).toString(),
+  //           };
+  //         }
+  //         return null;
+  //       });
+  //     });
 
-    liveShoppingList = liveShoppingList?.filter((n) => n);
-    return this.fmOrdersService.getOrdersStatsDuringLiveShoppingSales(liveShoppingList);
-  }
+  //   liveShoppingList = liveShoppingList?.filter((n) => n);
+  //   return this.fmOrdersService.getOrdersStatsDuringLiveShoppingSales(liveShoppingList);
+  // }
 
   @Get('detail')
   async findOrderDetails(

--- a/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.ts
+++ b/libs/firstmall-db/src/lib/fm-orders/fm-orders.service.ts
@@ -34,6 +34,7 @@ import { ProductPromotionService } from '@project-lc/nest-modules-product-promot
 import { FirstmallDbService } from '../firstmall-db.service';
 import { StatCounter } from './utills/statCounter';
 
+/** @deprecated */
 @Injectable()
 export class FmOrdersService {
   constructor(
@@ -886,39 +887,39 @@ export class FmOrdersService {
     return true;
   }
 
-  public async getOrdersStatsDuringLiveShoppingSales(
-    dto: LiveShoppingWithSales[],
-  ): Promise<{ id: number; sales: string }[]> {
-    const salesPrice = [];
+  // public async getOrdersStatsDuringLiveShoppingSales(
+  //   dto: LiveShoppingWithSales[],
+  // ): Promise<{ id: number; sales: string }[]> {
+  //   const salesPrice = [];
 
-    const sql = `
-    SELECT
-      SUM(fm_order.payment_price) as sales
-    FROM fm_order
-    JOIN fm_order_item USING(order_seq)
-    WHERE fm_order_item.goods_seq IN (?)
-    AND fm_order.step != 85 AND fm_order.step != 0
-    AND
-    regist_date BETWEEN ? AND ?;
-    `;
-    await Promise.all(
-      dto.map(async (val) => {
-        const sellStartDate = dayjs(val.sellStartDate).format('YYYY-MM-DD HH:mm:ss');
-        const sellEndDate = dayjs(val.sellEndDate).format('YYYY-MM-DD HH:mm:ss');
-        const salesSum = await this.db.query(sql, [
-          val.fmGoodsSeq,
-          sellStartDate,
-          sellEndDate,
-        ]);
-        salesPrice.push({
-          id: val.id,
-          sales: salesSum[0].sales ? Number(salesSum[0].sales).toFixed() : null,
-        });
-      }),
-    );
+  //   const sql = `
+  //   SELECT
+  //     SUM(fm_order.payment_price) as sales
+  //   FROM fm_order
+  //   JOIN fm_order_item USING(order_seq)
+  //   WHERE fm_order_item.goods_seq IN (?)
+  //   AND fm_order.step != 85 AND fm_order.step != 0
+  //   AND
+  //   regist_date BETWEEN ? AND ?;
+  //   `;
+  //   await Promise.all(
+  //     dto.map(async (val) => {
+  //       const sellStartDate = dayjs(val.sellStartDate).format('YYYY-MM-DD HH:mm:ss');
+  //       const sellEndDate = dayjs(val.sellEndDate).format('YYYY-MM-DD HH:mm:ss');
+  //       const salesSum = await this.db.query(sql, [
+  //         val.fmGoodsSeq,
+  //         sellStartDate,
+  //         sellEndDate,
+  //       ]);
+  //       salesPrice.push({
+  //         id: val.id,
+  //         sales: salesSum[0].sales ? Number(salesSum[0].sales).toFixed() : null,
+  //       });
+  //     }),
+  //   );
 
-    return salesPrice;
-  }
+  //   return salesPrice;
+  // }
 
   /** 주문의 선물하기 여부 조회 */
   private async findOneOrderGiftFlag(

--- a/libs/firstmall-db/src/lib/fm-settlements/fm-settlements.service.ts
+++ b/libs/firstmall-db/src/lib/fm-settlements/fm-settlements.service.ts
@@ -11,6 +11,7 @@ import {
 import { FirstmallDbService } from '../firstmall-db.service';
 import { FmExportsService } from '../fm-exports/fm-exports.service';
 
+/** @deprecated */
 @Injectable()
 export class FmSettlementService {
   constructor(

--- a/libs/hooks/src/lib/queries/useAdminDuplicatePromotionPageFlag.tsx
+++ b/libs/hooks/src/lib/queries/useAdminDuplicatePromotionPageFlag.tsx
@@ -22,22 +22,3 @@ export const useAdminDuplicatePromotionPageFlag = (
     { enabled: !!url },
   );
 };
-
-/** 상품홍보에 등록할 fmGoodsSeq이 중복인지 확인 */
-export const getAdminDuplicateFmGoodsSeqFlagForProductPromotion = async (
-  fmGoodsSeq: number,
-): Promise<DuplicateFlag> => {
-  return axios
-    .get<DuplicateFlag>('/admin/product-promotion/duplicate', { params: { fmGoodsSeq } })
-    .then((res) => res.data);
-};
-
-export const useAdminDuplicateFmGoodsSeqFlagForProductPromotion = (
-  fmGoodsSeq: number,
-): UseQueryResult<DuplicateFlag, AxiosError> => {
-  return useQuery<DuplicateFlag, AxiosError>(
-    'AdminDuplicatePromotionPage',
-    () => getAdminDuplicateFmGoodsSeqFlagForProductPromotion(fmGoodsSeq),
-    { enabled: !!fmGoodsSeq },
-  );
-};

--- a/libs/nest-modules-admin/src/admin/admin-product-promotion.controller.ts
+++ b/libs/nest-modules-admin/src/admin/admin-product-promotion.controller.ts
@@ -39,14 +39,6 @@ export class AdminProductPromotionController {
     return this.productPromotionService.createProductPromotion(dto);
   }
 
-  /** 상품홍보에 입력할 fmGoodsSeq가 다른 상품에 연결된 fmGoodsSeq와 중복인지 확인 */
-  @Get('duplicate')
-  async checkHasDuplicateFmGoodsSeq(
-    @Query('fmGoodsSeq', ParseIntPipe) fmGoodsSeq: number,
-  ): Promise<boolean> {
-    return this.adminService.checkHasDuplicateFmGoodsSeq(fmGoodsSeq);
-  }
-
   /** 상품홍보 수정 */
   @Patch()
   async updateProductPromotion(

--- a/libs/nest-modules-admin/src/admin/admin.service.ts
+++ b/libs/nest-modules-admin/src/admin/admin.service.ts
@@ -268,14 +268,6 @@ export class AdminService {
     dto: LiveShoppingDTO,
     videoId?: number | null,
   ): Promise<boolean> {
-    if (dto.fmGoodsSeq) {
-      const isDuplicated = await this.checkDupFMGoodsConnectionId(Number(dto.fmGoodsSeq));
-      if (isDuplicated)
-        throw new BadRequestException(
-          `이미 다른 상품or라이브쇼핑or상품홍보에 연결된 퍼스트몰 상품번호입니다.
-          퍼스트몰 상품 고유번호를 다시 확인해주세요.`,
-        );
-    }
     const liveShoppingUpdate = await this.prisma.liveShopping.update({
       where: { id: Number(dto.id) },
       data: {
@@ -293,7 +285,6 @@ export class AdminService {
         videoId: videoId || undefined,
         whiletrueCommissionRate: dto.whiletrueCommissionRate || 0,
         broadcasterCommissionRate: dto.broadcasterCommissionRate || 0,
-        fmGoodsSeq: dto.fmGoodsSeq ? Number(dto.fmGoodsSeq) : undefined,
         liveShoppingName: dto.liveShoppingName || undefined,
       },
     });
@@ -388,7 +379,9 @@ export class AdminService {
     return false;
   }
 
-  /** 상품홍보 fmGoodsSeq 등록전 다른 곳에 등록된 fmGoodsSeq(goodsConfirmation, liveShopping) 과 중복되는지 확인
+  /**
+   * @deprecated
+   * 상품홍보 fmGoodsSeq 등록전 다른 곳에 등록된 fmGoodsSeq(goodsConfirmation, liveShopping) 과 중복되는지 확인
    * @return 중복되는 경우 true, 아니면 false
    */
   public async checkHasDuplicateFmGoodsSeq(goodsSeq: number): Promise<boolean> {

--- a/libs/nest-modules-broadcaster/src/broadcaster/broadcaster-promotion-page.service.ts
+++ b/libs/nest-modules-broadcaster/src/broadcaster/broadcaster-promotion-page.service.ts
@@ -12,6 +12,7 @@ import {
 export class BroadcasterPromotionPageService {
   constructor(private readonly prisma: PrismaService) {}
 
+  /** @deprecated */
   public async getFmGoodsSeqsLinkedToProductPromotions(
     id: Broadcaster['id'],
   ): Promise<broadcasterProductPromotionDto[]> {

--- a/libs/nest-modules-goods/src/goods/goods.service.ts
+++ b/libs/nest-modules-goods/src/goods/goods.service.ts
@@ -59,10 +59,12 @@ export class GoodsService {
         },
         LiveShopping: {
           select: {
+            // @deprecated
             fmGoodsSeq: true,
           },
         },
         productPromotion: {
+          // @deprecated
           select: { fmGoodsSeq: true },
         },
       },

--- a/libs/nest-modules-product-promotion/src/lib/product-promotion.service.ts
+++ b/libs/nest-modules-product-promotion/src/lib/product-promotion.service.ts
@@ -88,6 +88,7 @@ export class ProductPromotionService {
     return data;
   }
 
+  /** @deprecated */
   public async checkIsPromotionProductFmGoodsSeq(fmGoodsSeq: number): Promise<boolean> {
     const productPromotionFmGoodsSeq = await this.prisma.productPromotion.findFirst({
       where: {
@@ -99,6 +100,7 @@ export class ProductPromotionService {
   }
 
   /**
+   * @deprecated
    * 전달받은 fmGoodsSeq 배열에 해당하는 '상품홍보' 목록 조회
    * @param fmGoodsSeqs 퍼스트몰 상품 고유번호 fmGoodsSeq 배열 (productPromotion.fmGoodsSeq)
    */

--- a/libs/shared-types/src/lib/dto/broadcasterProductPromotion.dto.ts
+++ b/libs/shared-types/src/lib/dto/broadcasterProductPromotion.dto.ts
@@ -1,6 +1,8 @@
 import { IsInt, IsNumber, IsOptional } from 'class-validator';
 
+/** @deprecated */
 export class broadcasterProductPromotionDto {
+  /** @deprecated */
   @IsInt() fmGoodsSeq: number;
 }
 
@@ -19,15 +21,6 @@ export class CreateProductPromotionDto {
   @IsNumber()
   goodsId: number;
 
-  /** 퍼스트몰 상품 고유번호
-   * => ProductPromotion.fmGoodsSeq 는
-   * GoodsConfirmation.firstmallGoodsConnectionId 와
-   * LiveShopping.fmGoodsSeq 와 중복되면 안됨
-   * */
-  @IsNumber()
-  @IsOptional()
-  fmGoodsSeq?: number;
-
   @IsNumber()
   @IsOptional()
   broadcasterCommissionRate?: number;
@@ -42,11 +35,6 @@ export class UpdateProductPromotionDto {
   /** 방송홍보 id */
   @IsNumber()
   id: number;
-
-  /** 퍼스트몰 상품 id */
-  @IsNumber()
-  @IsOptional()
-  fmGoodsSeq?: number;
 
   /** 연결할 상품id (projectLcGoods) */
   @IsNumber()

--- a/libs/shared-types/src/lib/dto/liveShopping.dto.ts
+++ b/libs/shared-types/src/lib/dto/liveShopping.dto.ts
@@ -11,7 +11,6 @@ import {
   IsArray,
   IsDate,
   IsEnum,
-  IsInt,
   IsNotEmpty,
   IsNumber,
   IsOptional,
@@ -82,8 +81,6 @@ export class LiveShoppingDTO {
   @IsNotEmpty()
   broadcasterCommissionRate?: string;
 
-  @IsOptional() @IsInt() fmGoodsSeq?: LiveShopping['fmGoodsSeq'];
-
   @IsOptional() @IsString() liveShoppingName?: LiveShopping['liveShoppingName'];
 
   @IsOptional()
@@ -99,7 +96,7 @@ export type LiveShoppingRegistDTO = Pick<
 
 export type LiveShoppingWithSales = Pick<
   LiveShoppingDTO,
-  'id' | 'sellStartDate' | 'sellEndDate' | 'fmGoodsSeq'
+  'id' | 'sellStartDate' | 'sellEndDate'
 >;
 export class FindLiveShoppingDto {
   @Type(() => Number) @IsOptional() @IsNumber() id?: LiveShopping['id'];
@@ -125,7 +122,7 @@ export type LiveShoppingsWithBroadcasterAndGoodsName = Pick<
     goods_name: string;
   };
 };
-
+/** @deprecated */
 export type LiveShoppingFmGoodsSeq = Pick<LiveShopping, 'fmGoodsSeq'>;
 
 export type LiveShoppingId = Pick<LiveShopping, 'id'>;


### PR DESCRIPTION
## 할일

- (스키마)기존 연결된 fmGoodsReq를 제거하지는 않는다 (이번 배포에서)
- fmGoodsReq 연결하는 작업을 모두 제거한다
- fmGoodsReq 와 관련된 모든 사용하지 않는 작업을 deprecate 처리한다

### 처리목록

- 관리자 - 라이브쇼핑 등록/수정
- 관리자 - 상품홍보 페이지 관리
- 관리자 - 크크쇼메인화면 관리 → 퍼스트몰 링크 → 크크쇼 goods 링크

### 작업 진행 로그

- 220614 15:00 ~ 18:00 (3)

### 테스트케이스

- [ ]  관리자 - 라이브쇼핑 등록이 올바르게 된다
- [ ]  관리자 - 라이브쇼핑 수정이 올바르게 된다
- [ ]  관리자 - 상품홍보페이지 등록이 올바르게 된다
- [ ]  관리자 - 상품홍보 페이지 수정이 올바르게 된다
- [ ]  관리자 - 크크쇼 메인 관리시 링크처리가 올바르게 된다
    - [ ]  크크쇼 - 링크가 올바르게 이동된다