### PR TITLE
fix: 방송인 닉네임 없는 경우, 라이브 쇼핑 등록시 방송인 구분 못하는 문제 수정

### DIFF
--- a/apps/admin/pages/live-shopping/[liveShoppingId].tsx
+++ b/apps/admin/pages/live-shopping/[liveShoppingId].tsx
@@ -33,7 +33,7 @@ import { GoodsDetailOptionsInfo } from '@project-lc/components-seller/goods-deta
 import { GoodsDetailPurchaseLimitInfo } from '@project-lc/components-seller/goods-detail/GoodsDetailPurchaseLimitInfo';
 import { GoodsDetailShippingInfo } from '@project-lc/components-seller/goods-detail/GoodsDetailShippingInfo';
 import { GoodsDetailSummary } from '@project-lc/components-seller/goods-detail/GoodsDetailSummary';
-import { BroadcasterName } from '@project-lc/components-shared/BroadcasterName';
+import { AdminLiveShoppingBroadcasterName } from '@project-lc/components-admin/AdminLiveShoppingBroadcasterName';
 import { LiveShoppingProgressBadge } from '@project-lc/components-shared/LiveShoppingProgressBadge';
 import {
   useAdminGoodsById,
@@ -196,7 +196,10 @@ export function LiveShoppingDetail(): JSX.Element {
             <Stack direction="row" alignItems="center">
               <Text as="span">방송인: </Text>
               {liveShopping[0].broadcaster ? (
-                <BroadcasterName data={liveShopping[0].broadcaster} color="blue" />
+                <AdminLiveShoppingBroadcasterName
+                  data={liveShopping[0].broadcaster}
+                  color="blue"
+                />
               ) : (
                 <Text fontWeight="bold">미정</Text>
               )}

--- a/libs/components-admin/src/lib/AdminLiveShoppingBroadcasterName.tsx
+++ b/libs/components-admin/src/lib/AdminLiveShoppingBroadcasterName.tsx
@@ -1,0 +1,22 @@
+import { Text } from '@chakra-ui/react';
+import { Broadcaster } from '@prisma/client';
+
+export function AdminLiveShoppingBroadcasterName(props: {
+  data: { userNickname: Broadcaster['userNickname']; email: Broadcaster['email'] };
+  color?: string;
+}): JSX.Element {
+  const { data, color } = props;
+
+  return (
+    <>
+      {data ? (
+        <Text color={color || 'unset'}>
+          {data ? `${data.userNickname} (${data.email})` : '미정'}
+        </Text>
+      ) : (
+        <Text>미정</Text>
+      )}
+    </>
+  );
+}
+export default AdminLiveShoppingBroadcasterName;

--- a/libs/components-admin/src/lib/BroadcasterAutocomplete.tsx
+++ b/libs/components-admin/src/lib/BroadcasterAutocomplete.tsx
@@ -13,11 +13,13 @@ export function BroadcasterAutocomplete(): JSX.Element {
       <Text as="span">방송인</Text>
       <ChakraAutoComplete
         options={data || []}
-        getOptionLabel={(option) => option?.userNickname || ''}
+        getOptionLabel={(option) =>
+          option ? `${option.userNickname} (${option.email})` : ''
+        }
         onChange={(newV) => {
           if (newV) {
             setValue('broadcasterId', newV.id);
-            handleBroadcasterSelect(newV.userNickname);
+            handleBroadcasterSelect(`${newV.userNickname} (${newV.email})`);
           } else {
             setValue('broadcasterId', null);
             handleBroadcasterSelect(null);


### PR DESCRIPTION
- [x] 닉네임과 이메일 동시에 표기하도록 변경