### PR TITLE
fix: 검색창 form-id 대신 onClick으로 변경

### DIFF
--- a/libs/components-web-kkshow/src/lib/search-input/FullPageSearchBox.tsx
+++ b/libs/components-web-kkshow/src/lib/search-input/FullPageSearchBox.tsx
@@ -17,9 +17,11 @@ import { SearchForm, SearchInputBox, SearchInputBoxProps } from './SearchInputBo
 
 interface FullPageSearchBoxProps {
   searchBoxInputRef?: SearchInputBoxProps['inputRef'];
+  onSubmit: () => void;
 }
 export function FullPageSearchBox({
   searchBoxInputRef,
+  onSubmit,
 }: FullPageSearchBoxProps): JSX.Element {
   const closeSearchDrawer = useKkshowSearchStore((s) => s.closeSearchDrawer);
   const { setValue } = useFormContext<SearchForm>();
@@ -39,7 +41,7 @@ export function FullPageSearchBox({
           variant="unstyle"
           icon={<ChevronLeftIcon w="30px" h="35px" />}
         />
-        <SearchInputBox inputRef={searchBoxInputRef} autoFocus />
+        <SearchInputBox inputRef={searchBoxInputRef} onSubmit={onSubmit} autoFocus />
       </Flex>
 
       {/* 최근검색어 */}
@@ -52,10 +54,12 @@ export function FullPageSearchBox({
 
 interface FullPageSearchDrawerProps extends FullPageSearchBoxProps {
   containerRef?: RefObject<HTMLElement | null>;
+  onSubmit: () => void;
 }
 export function FullPageSearchDrawer({
   containerRef,
   searchBoxInputRef,
+  onSubmit,
 }: FullPageSearchDrawerProps): JSX.Element {
   const { isSearchDrawerOpen, openSearchDrawer, closeSearchDrawer } =
     useKkshowSearchStore();
@@ -85,7 +89,10 @@ export function FullPageSearchDrawer({
         <DrawerOverlay display={{ base: 'flex', md: 'none' }} />
         <DrawerContent display={{ base: 'flex', md: 'none' }}>
           <DrawerBody p={0}>
-            <FullPageSearchBox searchBoxInputRef={searchBoxInputRef} />
+            <FullPageSearchBox
+              searchBoxInputRef={searchBoxInputRef}
+              onSubmit={onSubmit}
+            />
           </DrawerBody>
         </DrawerContent>
       </Drawer>

--- a/libs/components-web-kkshow/src/lib/search-input/FullPageSearchBox.tsx
+++ b/libs/components-web-kkshow/src/lib/search-input/FullPageSearchBox.tsx
@@ -28,6 +28,7 @@ export function FullPageSearchBox({
 
   const onKeywordClick = (item: string): void => {
     setValue('keyword', item);
+    onSubmit();
   };
 
   return (

--- a/libs/components-web-kkshow/src/lib/search-input/SearchInputBox.tsx
+++ b/libs/components-web-kkshow/src/lib/search-input/SearchInputBox.tsx
@@ -23,11 +23,13 @@ export interface SearchForm {
 export interface SearchInputBoxProps {
   inputRef?: RefObject<HTMLInputElement>;
   autoFocus?: boolean;
+  onSubmit: () => void;
 }
 
 export function SearchInputBox({
   inputRef,
   autoFocus,
+  onSubmit,
 }: SearchInputBoxProps): JSX.Element {
   const { isMobileSize } = useDisplaySize();
 
@@ -61,9 +63,11 @@ export function SearchInputBox({
           autoComplete="off"
           bgColor={useColorModeValue('white', 'gray.600')}
           color={useColorModeValue('blackAlpha.900', 'whiteAlpha.900')}
-          form={SEARCH_FORM_ID}
           onKeyDown={(e) => {
             if (e.code === 'Escape') closeSearchRecommendPopover();
+            if (e.key === 'Enter') {
+              onSubmit();
+            }
           }}
           onInput={() => {
             if (!isSearchPopoverOpen) openSearchRecommendPopover();
@@ -94,8 +98,7 @@ export function SearchInputBox({
           variant="fill"
           aria-label="search-button-icon"
           icon={<SearchIcon />}
-          form={SEARCH_FORM_ID}
-          type="submit"
+          onClick={onSubmit}
         />
       </Tooltip>
 

--- a/libs/components-web-kkshow/src/lib/search-input/SearchInputBox.tsx
+++ b/libs/components-web-kkshow/src/lib/search-input/SearchInputBox.tsx
@@ -106,6 +106,7 @@ export function SearchInputBox({
       <SearchHelpPopover
         onItemClick={(item) => {
           setValue('keyword', item);
+          onSubmit();
           closeSearchRecommendPopover();
         }}
       />

--- a/libs/components-web-kkshow/src/lib/search-input/Searcher.tsx
+++ b/libs/components-web-kkshow/src/lib/search-input/Searcher.tsx
@@ -48,17 +48,18 @@ export function Searcher(): JSX.Element {
 
   return (
     <FormProvider {...methods}>
-      <form id={SEARCH_FORM_ID} onSubmit={methods.handleSubmit(onSubmit)}>
-        {/* 데스크탑 검색 input */}
-        <Flex display={{ base: 'none', md: 'flex' }} w={360}>
-          <SearchInputBox inputRef={inputRef} />
-        </Flex>
+      {/* 데스크탑 검색 input */}
+      <Flex display={{ base: 'none', md: 'flex' }} w={360}>
+        <SearchInputBox inputRef={inputRef} onSubmit={methods.handleSubmit(onSubmit)} />
+      </Flex>
 
-        {/* 모바일 검색 full-page drawer */}
-        <Flex display={{ base: 'flex', md: 'none' }}>
-          <FullPageSearchDrawer searchBoxInputRef={inputRef} />
-        </Flex>
-      </form>
+      {/* 모바일 검색 full-page drawer */}
+      <Flex display={{ base: 'flex', md: 'none' }}>
+        <FullPageSearchDrawer
+          searchBoxInputRef={inputRef}
+          onSubmit={methods.handleSubmit(onSubmit)}
+        />
+      </Flex>
     </FormProvider>
   );
 }


### PR DESCRIPTION
- [x] 검색창 검색어 입력되지 않는 에러 수정
  - [x] form-id로 연결시 제출해도 formData.keyword가 비어있음
    - 관련 문서들 찾아봤는데, 되는 게 맞는 상황인 것으로 보이지만 안돼서 다른 추천 방법인 onClick으로 변경함
  - [x] onClick으로 변경 이후, onSubmit props로 넘겨주도록 변경
- [x] 최근검색어 클릭시 바로 검색되도록 변경