### PR TITLE
fix: 상품 필수정보 생성 혹은 수정 이후 상품상세 조회 오류 발생

### DIFF
--- a/libs/components-web-kkshow/src/lib/goods/GoodsViewPurchaseBox.tsx
+++ b/libs/components-web-kkshow/src/lib/goods/GoodsViewPurchaseBox.tsx
@@ -128,9 +128,16 @@ export function GoodsViewPurchaseBox({
               justify="space-between"
             >
               <Box>
-                <Text mb={2}>
-                  {opt.option_title} : {opt.option1}
-                </Text>
+                {/* 옵션이 기본옵션 하나밖에 없는 경우 - 옵션명, 옵션값이 없으므로 상품명 출력 */}
+                {isOnlyDefaultOption ? (
+                  <Text>{goods.goods_name}</Text>
+                ) : (
+                  <Text mb={2}>
+                    {/* 여러 옵션이 존재하는 경우 옵션명, 옵션값이 각각 존재하므로 옵션명:옵션값 형태로 출력 */}
+                    {opt.option_title} : {opt.option1}
+                  </Text>
+                )}
+
                 <OptionQuantity
                   quantity={opt.quantity}
                   handleDecrease={() => store.handleDecreaseOptQuantity(opt.id)}

--- a/libs/nest-modules-goods/src/goods/goods.service.ts
+++ b/libs/nest-modules-goods/src/goods/goods.service.ts
@@ -388,6 +388,7 @@ export class GoodsService {
     });
 
     if (!result) return null;
+
     return {
       ...result,
       informationNotice: result.informationNotice
@@ -453,7 +454,7 @@ export class GoodsService {
           confirmation: { create: { status: 'waiting' } },
           categories: { connect: { id: categoryId } },
           informationNotice: {
-            create: { contents: JSON.parse(informationNoticeContents) },
+            create: { contents: JSON.stringify(JSON.parse(informationNoticeContents)) },
           },
         },
       });
@@ -576,7 +577,6 @@ export class GoodsService {
 
   /** 상품 수정 */
   async updateOneGoods(id: number, dto: RegistGoodsDto): Promise<{ goodsId: number }> {
-    console.log('dto: ', dto);
     const {
       options: comingOptions,
       image,
@@ -627,7 +627,7 @@ export class GoodsService {
           GoodsInfo: goodsInfoId ? { connect: { id: goodsInfoId } } : undefined,
           informationNotice: {
             update: {
-              contents: JSON.parse(informationNoticeContents),
+              contents: JSON.stringify(JSON.parse(informationNoticeContents)),
             },
           },
           categories: { connect: { id: categoryId } },


### PR DESCRIPTION
- 판매자>상품등록 에서 상품 생성이후 ⇒ 해당 상품 상세보기 조회시 no data 표시됨, 크크쇼 상품페이지에서 해당 상품 조회시 상품 정보가 안뜸
    
    상품 상세조회시 `JSON.parse(result.informationNotice?.contents as string)` 부분에서 오류발생함
   
원인 : 상품 생성 혹은 수정시 입력한 informationNoticeContents가 string이 아닌 객체형태로 저장되어 있어서 오류가난거같음
수정방안 : 상품 생성 혹은 수정시 informationNoticeContents 값에 JSON.stringify 적용하여 저장
    
- [x]  상품생성 혹은 수정시 informationNoticeContents 값을 string 형태로 전달하도록 수정함
    
**기타 수정 사항**
 - [x]  크크쇼 상품상세페이지 단일옵션인경우 개수 선택하는 부분에 옵션명, 옵션값 존재하지 않아서 표시되지 않음 → 상품명 출력하도록 함
    
 