### PR TITLE
fix : 소비자 주문내역목록에서 선물하기 주문도 배송조회가 가능한 문제 수정

### DIFF
--- a/apps/web-kkshow/pages/mypage/shipping-tracking/[orderCode].tsx
+++ b/apps/web-kkshow/pages/mypage/shipping-tracking/[orderCode].tsx
@@ -1,12 +1,25 @@
-import { Box, Center, Text } from '@chakra-ui/react';
+import { Box, Center, Spinner, Text } from '@chakra-ui/react';
 import { DeliveryTrackingList } from '@project-lc/components-shared/delivery-tracking/DeliveryTracking';
 import CustomerMypageLayout from '@project-lc/components-web-kkshow/mypage/CustomerMypageLayout';
+import { OrderInfoGiftExportsItem } from '@project-lc/components-web-kkshow/mypage/order/OrderInfoExportsList';
+import { useOrderDetail } from '@project-lc/hooks';
 import { useRouter } from 'next/router';
 
 export function ShippingTrackingIndex(): JSX.Element {
   const router = useRouter();
   const orderCode = router.query.orderCode as string;
-  if (!orderCode)
+  const orderDetail = useOrderDetail({ orderCode });
+
+  if (orderDetail.isLoading) {
+    return (
+      <CustomerMypageLayout title="배송 조회">
+        <Center>
+          <Spinner />
+        </Center>
+      </CustomerMypageLayout>
+    );
+  }
+  if (!orderCode || !orderDetail.data)
     return (
       <CustomerMypageLayout title="배송 조회">
         <Box p={[2, 2, 4]}>
@@ -16,6 +29,23 @@ export function ShippingTrackingIndex(): JSX.Element {
         </Box>
       </CustomerMypageLayout>
     );
+
+  if (orderDetail.data.giftFlag) {
+    return (
+      <CustomerMypageLayout title="배송 조회">
+        <Box p={[2, 2, 4]}>
+          <Text fontSize="xl" fontWeight="bold">
+            배송 조회
+          </Text>
+          <OrderInfoGiftExportsItem
+            order={orderDetail.data}
+            exports={orderDetail.data.exports}
+          />
+        </Box>
+      </CustomerMypageLayout>
+    );
+  }
+
   return (
     <CustomerMypageLayout title="배송 조회">
       <Box p={[2, 2, 4]}>

--- a/libs/components-seller/src/lib/kkshow-order/OrderFilterConsole.tsx
+++ b/libs/components-seller/src/lib/kkshow-order/OrderFilterConsole.tsx
@@ -184,7 +184,7 @@ export function OrderFilterConsole(): JSX.Element {
                   <Checkbox
                     m={1}
                     aria-label={`order-status-${orderStatuses[orderStatus].name}`}
-                    key={orderStatus}
+                    key={orderStatuses[orderStatus].name}
                     colorScheme={orderStatuses[orderStatus].chakraColor}
                     isChecked={watch('searchStatuses')?.includes(orderProcessStep)}
                     onChange={(_) => {

--- a/libs/components-web-kkshow/src/lib/mypage/order/OrderInfoExportsList.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/order/OrderInfoExportsList.tsx
@@ -74,7 +74,7 @@ interface OrderInfoGiftExportsItemProps {
   order: OrderDetailRes;
   exports: ExportBaseData[];
 }
-function OrderInfoGiftExportsItem({
+export function OrderInfoGiftExportsItem({
   exports,
 }: OrderInfoGiftExportsItemProps): JSX.Element {
   const isNowShipping = useMemo(

--- a/libs/components-web-kkshow/src/lib/mypage/orderList/CustomerOrderItemActionButtons.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/orderList/CustomerOrderItemActionButtons.tsx
@@ -60,7 +60,7 @@ export function OrderItemActionButtons({
       onClick: () => {
         router.push(`/mypage/shipping-tracking/${order.orderCode}`);
       },
-      display: deliveryTrackingAbleSteps.includes(step), // 출고완료 이후 표시
+      display: !order.giftFlag && deliveryTrackingAbleSteps.includes(step), // 선물하기 주문이 아닌경우 && 출고완료 이후 표시
       disabled: false,
     },
     {
@@ -99,7 +99,7 @@ export function OrderItemActionButtons({
           );
         }
       },
-      display: exchangeReturnAbleSteps.includes(step), // 상품준비 이후 표시
+      display: !order.giftFlag && exchangeReturnAbleSteps.includes(step), // 선물하기 주문이 아닌경우 && 상품준비 이후 표시
       disabled: false,
     },
     {

--- a/libs/components-web-kkshow/src/lib/mypage/orderList/CustomerOrderList.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/orderList/CustomerOrderList.tsx
@@ -129,8 +129,15 @@ function OrderData({ order }: { order: OrderDataWithRelations }): JSX.Element {
   const giftBroadcaster = order.orderItems.find((oi) => !!oi.support)?.support
     ?.broadcaster;
   return (
-    <Stack borderWidth="1px" borderRadius="md" p={1} boxShadow="md" bg={orderDataBgColor}>
-      <Stack direction="row" justifyContent="space-between">
+    <Stack
+      borderWidth="1px"
+      borderRadius="md"
+      p={1}
+      boxShadow="md"
+      bg={orderDataBgColor}
+      spacing={1}
+    >
+      <Stack direction="row" justifyContent="space-between" alignItems="center">
         <Stack direction={{ base: 'column', sm: 'row' }}>
           <Text>주문번호 : {order.orderCode}</Text>
           <TextDotConnector display={{ base: 'none', sm: 'block' }} />
@@ -144,7 +151,7 @@ function OrderData({ order }: { order: OrderDataWithRelations }): JSX.Element {
       {order.giftFlag && giftBroadcaster && (
         <Stack direction="row" alignItems="center" px={1}>
           <Avatar size="xs" src={giftBroadcaster.avatar || ''} />
-          <Text>{giftBroadcaster.userNickname}</Text>
+          <Text fontWeight="bold">{giftBroadcaster.userNickname}</Text>
           <Text>님께 보낸 선물 🎁</Text>
         </Stack>
       )}

--- a/libs/components-web-kkshow/src/lib/mypage/orderList/CustomerOrderList.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/orderList/CustomerOrderList.tsx
@@ -1,4 +1,5 @@
 import {
+  Avatar,
   Button,
   Center,
   Spinner,
@@ -124,6 +125,9 @@ function OrderData({ order }: { order: OrderDataWithRelations }): JSX.Element {
   const handleDetailClick = (): void => {
     router.push(`/mypage/orders/${order.orderCode}`);
   };
+
+  const giftBroadcaster = order.orderItems.find((oi) => !!oi.support)?.support
+    ?.broadcaster;
   return (
     <Stack borderWidth="1px" borderRadius="md" p={1} boxShadow="md" bg={orderDataBgColor}>
       <Stack direction="row" justifyContent="space-between">
@@ -137,8 +141,15 @@ function OrderData({ order }: { order: OrderDataWithRelations }): JSX.Element {
           상세보기
         </Button>
       </Stack>
+      {order.giftFlag && giftBroadcaster && (
+        <Stack direction="row" alignItems="center" px={1}>
+          <Avatar size="xs" src={giftBroadcaster.avatar || ''} />
+          <Text>{giftBroadcaster.userNickname}</Text>
+          <Text>님께 보낸 선물 🎁</Text>
+        </Stack>
+      )}
 
-      <Stack p={1}>
+      <Stack px={1}>
         {order.orderItems.map((item) => (
           <OrderItem key={item.id} orderItem={item} order={order} />
         ))}

--- a/libs/components-web-kkshow/src/lib/nonmember/NonMemberOrderDetailDisplay.tsx
+++ b/libs/components-web-kkshow/src/lib/nonmember/NonMemberOrderDetailDisplay.tsx
@@ -19,6 +19,7 @@ import { VirtualAccountDetail } from '@project-lc/components-shared/payment/Virt
 import dayjs from 'dayjs';
 import { OrderItemOptionInfo } from '../mypage/orderList/OrderItemOptionInfo';
 import { SuccessDeliveryAddress } from '../payment/DeliveryAddress';
+import { OrderInfoGiftExportsItem } from '../mypage/order/OrderInfoExportsList';
 
 export interface NonMemberOrderDetailDisplayProps {
   orderData: NonMemberOrderDetailRes;
@@ -155,7 +156,9 @@ export function NonmemberExportInfo({ order }: { order: OrderDetailRes }): JSX.E
   if (!order.exports || order.exports.length === 0) {
     return <Text>아직 상품이 출고되지 않았습니다</Text>;
   }
-
+  if (order.giftFlag) {
+    return <OrderInfoGiftExportsItem order={order} exports={order.exports} />;
+  }
   return (
     <>
       {order.exports.map((_export) => {

--- a/libs/nest-modules-order/src/lib/order.service.ts
+++ b/libs/nest-modules-order/src/lib/order.service.ts
@@ -12,6 +12,8 @@ import {
 } from '@prisma/client';
 import { UserPwManager } from '@project-lc/nest-core';
 import { BroadcasterService } from '@project-lc/nest-modules-broadcaster';
+import { CustomerCouponService } from '@project-lc/nest-modules-coupon';
+import { MileageService } from '@project-lc/nest-modules-mileage';
 import { PrismaService } from '@project-lc/prisma-orm';
 import {
   CreateOrderDto,
@@ -22,6 +24,7 @@ import {
   GetOneOrderDetailDto,
   GetOrderListDto,
   getOrderProcessStepNameByStringNumber,
+  NonMemberOrderDetailRes,
   OrderDataWithRelations,
   OrderDetailRes,
   OrderListRes,
@@ -34,14 +37,11 @@ import {
   ShippingCheckItem,
   ShippingCostByShippingGroupId,
   UpdateOrderDto,
-  NonMemberOrderDetailRes,
 } from '@project-lc/shared-types';
 import { calculateShippingCost } from '@project-lc/utils';
 import { nanoid } from 'nanoid';
 import dayjs = require('dayjs');
 import isToday = require('dayjs/plugin/isToday');
-import { CustomerCouponService } from '@project-lc/nest-modules-coupon';
-import { MileageService } from '@project-lc/nest-modules-mileage';
 
 dayjs.extend(isToday);
 
@@ -121,6 +121,32 @@ export class OrderService {
       recipientAddress: '',
       recipientDetailAddress: '',
       recipientPostalCode: '',
+    };
+  }
+
+  /** 주문 상세조회(OrderDetailRes) 데이터에서
+   * 출고정보 중 택배사(deliveryCompany), 운송장번호(deliveryNumber) 삭제
+   *
+   * 주문 목록 조회는 출고데이터를 포함하지 않으므로 주문상세조회 응답값에만 해당 함수 적용함
+   * */
+  private removeDeliveryCompanyAndDeliveryNumber(order: OrderDetailRes): OrderDetailRes {
+    const { exports } = order;
+    // 출고정보가 없는경우 그대로 리턴
+    if (!exports || exports.length === 0) {
+      return order;
+    }
+    // 출고정보가 있는경우, 출고정보에서 deliveryCompany, deliveryNumber 삭제하고 리턴
+    const exportsDeliveryCompanyAndDeliveryNumberRemoved = exports.map((ex) => {
+      return {
+        ...ex,
+        deliveryCompany: '',
+        deliveryNumber: '',
+      };
+    });
+
+    return {
+      ...order,
+      exports: exportsDeliveryCompanyAndDeliveryNumberRemoved,
     };
   }
 
@@ -428,8 +454,8 @@ export class OrderService {
     // 소비자 주문목록 후처리
     const postProcessed = orders.map((order) => {
       let _o = { ...order };
-      //  선물하기 주문일 시 받는사람 정보 삭제
-      if (_o.giftFlag) {
+      //  선물하기 주문 && 소비자센터에서 요청한 경우 받는사람 정보 삭제
+      if (_o.giftFlag && dto.appType === 'customer') {
         _o = this.removeRecipientInfo(_o);
       }
       return _o;
@@ -626,7 +652,7 @@ export class OrderService {
   }
 
   /** 주문 상세 조회 */
-  async findOneOrderDetail(where: Prisma.OrderWhereInput): Promise<any> {
+  async findOneOrderDetail(where: Prisma.OrderWhereInput): Promise<OrderDetailRes> {
     // 주문이 있는지 확인
     await this.findOneOrder(where);
 
@@ -739,9 +765,14 @@ export class OrderService {
       };
     }
 
-    // 소비자센터에서 주문 조회 요청 && 선물주문인경우 => 받는사람 정보 삭제하고 리턴
+    /** 소비자센터에서 주문상세 조회 요청 && 선물주문인경우
+     * => 받는사람 정보 삭제  & 출고데이터에서 택배사, 운송장번호 정보 삭제하고 보낸다
+     */
     if (appType === 'customer' && result.giftFlag) {
+      // 받는사람 정보 삭제
       result = this.removeRecipientInfo(result);
+      // 출고데이터에서 택배사, 운송장번호 정보 삭제
+      result = this.removeDeliveryCompanyAndDeliveryNumber(result);
     }
 
     return result;
@@ -760,7 +791,7 @@ export class OrderService {
       nonMemberOrderFlag: true,
     });
 
-    return { order };
+    return { order: this.removeDeliveryCompanyAndDeliveryNumber(order) };
   }
 
   /** 주문수정 */

--- a/libs/nest-modules-order/src/lib/order.service.ts
+++ b/libs/nest-modules-order/src/lib/order.service.ts
@@ -783,7 +783,7 @@ export class OrderService {
     ordererPhone,
     ordererName,
   }: GetNonMemberOrderDetailDto): Promise<NonMemberOrderDetailRes> {
-    const order = await this.findOneOrderDetail({
+    let order = await this.findOneOrderDetail({
       ordererPhone,
       ordererName,
       customerId: null,
@@ -791,7 +791,14 @@ export class OrderService {
       nonMemberOrderFlag: true,
     });
 
-    return { order: this.removeDeliveryCompanyAndDeliveryNumber(order) };
+    if (order.giftFlag) {
+      // 선물주문인경우 받는사람 정보 삭제
+      order = this.removeRecipientInfo(order);
+      // 출고정보에서 운송장번호, 택배회사 정보 삭제
+      order = this.removeDeliveryCompanyAndDeliveryNumber(order);
+    }
+
+    return { order };
   }
 
   /** 주문수정 */


### PR DESCRIPTION
- 주문상세화면에서는 선물주문인경우 출고정보 표시되지 않았음
- 소비자 > 주문/배송목록에서 '배송조회' 버튼을 눌렀을때 이동하는 배송조회화면에서 배송지와 운송장번호가 표시됨

수정내용
- [x]  소비자>출고조회페이지에서 '선물주문'인 경우 출고정보 표시하지 않도록 수정
- [x]  소비자>비회원 주문조회시 '선물주문'인 경우 출고정보 표시하지 않도록 수정
- [x]  api>상세데이터를 조회하는 서비스 함수에서 (선물 주문인 경우 && 크크쇼 소비자센터에서 요청한 경우), 주문에 대한 출고정보 중 “택배사”, “운송장번호” 데이터 삭제하고 응답하도록 함
    - 주문목록데이터 응답타입에는 출고정보가 포함되지 않기때문에 주문상세 조회시 & appType=”customer” 소비자센터에서 요청한 경우에 한해서 적용