### PR TITLE
[스키마] amount 명칭 컬럼이 개수, 금액 두가지로 혼용되는 문제 수정

### DIFF
--- a/libs/components-admin/src/lib/BcSettlementTargetList.tsx
+++ b/libs/components-admin/src/lib/BcSettlementTargetList.tsx
@@ -311,7 +311,7 @@ function BcSettlementTargetDetail({
             <GridItem colSpan={{ base: 4, sm: 3 }}>
               <Text fontWeight="bold">{item.orderItem.goods.goods_name}</Text>
               {item.orderItemOption.name && item.orderItemOption.value && (
-                <Text fontSize="sm">{`${item.orderItemOption.name}: ${item.orderItemOption.value} ${item.amount}개`}</Text>
+                <Text fontSize="sm">{`${item.orderItemOption.name}: ${item.orderItemOption.value} ${item.quantity}개`}</Text>
               )}
               <Text fontSize="sm">
                 총{' '}

--- a/libs/components-admin/src/lib/order/returnRequest/AdminReturnRequestDetail.tsx
+++ b/libs/components-admin/src/lib/order/returnRequest/AdminReturnRequestDetail.tsx
@@ -114,8 +114,8 @@ export function AdminReturnRequestDetail({
       orderId: data.order.id,
       reason: '소비자 환불 요청',
       items: data.items.map((i: ReturnItemWithOriginOrderItemInfo) => {
-        const { orderItemId, orderItemOptionId, amount } = i;
-        return { orderItemId, orderItemOptionId, amount };
+        const { orderItemId, orderItemOptionId, quantity } = i;
+        return { orderItemId, orderItemOptionId, quantity };
       }),
       returnId: data.id, // 연결된 반품(환불)요청
       refundAmount: formData.refundAmount, // 환불금액

--- a/libs/components-seller/src/lib/ExportBundleDialog.tsx
+++ b/libs/components-seller/src/lib/ExportBundleDialog.tsx
@@ -91,7 +91,7 @@ export function ExportBundleDialog({
   const exportBundle = useCallback(
     async (dto: ExportManyDto) => {
       const isExportable = dto.exportOrders.every((o) =>
-        o.items.every((i) => !(Number(i.amount) === 0)),
+        o.items.every((i) => !(Number(i.quantity) === 0)),
       );
       if (!isExportable)
         return toast({
@@ -105,7 +105,7 @@ export function ExportBundleDialog({
         ...dto,
         exportOrders: dto.exportOrders.map((order) => ({
           ...order,
-          items: order.items.filter((x) => !!x.amount),
+          items: order.items.filter((x) => !!x.quantity),
         })),
       };
 

--- a/libs/components-seller/src/lib/ExportDialog.tsx
+++ b/libs/components-seller/src/lib/ExportDialog.tsx
@@ -77,9 +77,9 @@ export function ExportDialog({
       if (isValid) {
         formMethods.setValue(`${orderShippingIdx}.orderId`, orderId);
         const dto = formMethods.getValues(fieldID);
-        const realDto = { ...dto, items: dto.items.filter((x) => !!x.amount) };
+        const realDto = { ...dto, items: dto.items.filter((x) => !!x.quantity) };
         // 보낼 수량이 0개 인지 체크
-        if (realDto.items.every((o) => Number(o.amount) === 0)) {
+        if (realDto.items.every((o) => Number(o.quantity) === 0)) {
           toast({
             status: 'warning',
             description:

--- a/libs/components-seller/src/lib/ExportManyDialog.tsx
+++ b/libs/components-seller/src/lib/ExportManyDialog.tsx
@@ -86,10 +86,10 @@ export function ExportManyDialog({
         const realDto = {
           ...dto,
           items: dto.items.filter((v) => !!v),
-          exportOptions: dto.items.filter((x) => !!x.amount),
+          exportOptions: dto.items.filter((x) => !!x.quantity),
         };
 
-        if (dto.items.every((o) => Number(o.amount) === 0)) {
+        if (dto.items.every((o) => Number(o.quantity) === 0)) {
           toast({
             status: 'warning',
             description:
@@ -110,7 +110,7 @@ export function ExportManyDialog({
     const dto: CreateKkshowExportDto[] = [];
     selectedKeys.forEach((k) => {
       const data = formData[Number(k)];
-      const realData = { ...data, items: data.items.filter((x) => !!x.amount) };
+      const realData = { ...data, items: data.items.filter((x) => !!x.quantity) };
       dto.push(realData);
     });
 

--- a/libs/components-seller/src/lib/ExportOrderOptionList.tsx
+++ b/libs/components-seller/src/lib/ExportOrderOptionList.tsx
@@ -424,7 +424,7 @@ export function ExportOrderOptionItem({
     if (!orderExp) return 0; // 출고를 찾을 수 없는 경우
     const orderOptExp = orderExp.items.find((i) => i.orderItemOptionId === option.id);
     if (!orderOptExp) return 0; // 출고가 있으나 해당 옵션에 대한 출고는 없는 경우
-    return orderOptExp.amount;
+    return orderOptExp.quantity;
   }, [option.id, order.exports, order.id]);
 
   // 남은 수량
@@ -435,7 +435,7 @@ export function ExportOrderOptionItem({
     if (!orderExp) return option.quantity;
     const orderOptExp = orderExp.items.find((i) => i.orderItemOptionId === option.id);
     if (!orderOptExp) return option.quantity;
-    const _restEa = option.quantity - orderOptExp.amount;
+    const _restEa = option.quantity - orderOptExp.quantity;
     if (_restEa < 0) return 0;
     return _restEa;
   }, [option.id, option.quantity, order.exports, order.id]);
@@ -452,7 +452,7 @@ export function ExportOrderOptionItem({
       setValue(`${orderShippingIndex}.items.${realIndex}.orderItemId`, item.id);
       // 보낼 수량 기본값으로 남은 수량 만큼 설정되어 있도록 처리
       if (restEa > 0) {
-        setValue(`${orderShippingIndex}.items.${realIndex}.amount`, restEa);
+        setValue(`${orderShippingIndex}.items.${realIndex}.quantity`, restEa);
       }
     }
   }, [item.id, option.id, orderShippingIndex, realIndex, restEa, selected, setValue]);
@@ -477,13 +477,13 @@ export function ExportOrderOptionItem({
           isInvalid={
             !!(
               errors[orderShippingIndex]?.items &&
-              errors[orderShippingIndex]?.items?.[realIndex]?.amount
+              errors[orderShippingIndex]?.items?.[realIndex]?.quantity
             )
           }
         >
           <Input
             isDisabled={restEa === 0 || !selected}
-            {...register(`${orderShippingIndex}.items.${realIndex}.amount`, {
+            {...register(`${orderShippingIndex}.items.${realIndex}.quantity`, {
               required: {
                 message: '보낼 수량을 입력해주세요.',
                 value: !!selected && sendedEa !== option.quantity,
@@ -497,8 +497,8 @@ export function ExportOrderOptionItem({
           />
           <FormErrorMessage fontSize="xs">
             {errors[orderShippingIndex]?.items &&
-              errors[orderShippingIndex]?.items?.[realIndex]?.amount &&
-              errors[orderShippingIndex]?.items?.[realIndex]?.amount?.message}
+              errors[orderShippingIndex]?.items?.[realIndex]?.quantity &&
+              errors[orderShippingIndex]?.items?.[realIndex]?.quantity?.message}
           </FormErrorMessage>
         </FormControl>
       </Td>

--- a/libs/components-seller/src/lib/OrderDetailOptionList.tsx
+++ b/libs/components-seller/src/lib/OrderDetailOptionList.tsx
@@ -106,7 +106,7 @@ export function OrderDetailOptionDescription({
                     (ei) => ei.orderItemOptionId === opt.id,
                   );
                   const exportedCount = currentOptionExportItems
-                    .map((ei) => ei.amount)
+                    .map((ei) => ei.quantity)
                     .reduce((sum, cur) => sum + cur, 0);
                   return (
                     <Tr key={opt.id}>

--- a/libs/components-seller/src/lib/kkshow-order/OrderCancelStatusDialog.tsx
+++ b/libs/components-seller/src/lib/kkshow-order/OrderCancelStatusDialog.tsx
@@ -168,7 +168,7 @@ export function OrderCancelStatusDialog({
                   // 주문취소하려는 주문이 결제승인이 완료된 상태였다면 예상환불금액은 상품 전체 가격 합 표시, 아니면 0 원
                   cancelDetail.order?.payment?.depositDoneFlag
                     ? cancelDetail.items
-                        .map((item) => item.price * item.amount) // 취소상품 개수 * 가격
+                        .map((item) => item.price * item.quantity) // 취소상품 개수 * 가격
                         .reduce((sum, price) => sum + price, 0)
                     : 0
                 }

--- a/libs/components-seller/src/lib/kkshow-order/OrderDetailCancelInfo.tsx
+++ b/libs/components-seller/src/lib/kkshow-order/OrderDetailCancelInfo.tsx
@@ -24,7 +24,9 @@ export function OrderDetailCancelInfo({
         />
         <TextDotConnector />
         <Text isTruncated>
-          {cancelData.items.map((item) => item.amount).reduce((sum, cur) => sum + cur, 0)}
+          {cancelData.items
+            .map((item) => item.quantity)
+            .reduce((sum, cur) => sum + cur, 0)}
           개
         </Text>
       </Stack>

--- a/libs/components-seller/src/lib/kkshow-order/OrderDetailExchangeInfo.tsx
+++ b/libs/components-seller/src/lib/kkshow-order/OrderDetailExchangeInfo.tsx
@@ -32,7 +32,7 @@ export function OrderDetailExchangeInfo({
         <TextDotConnector />
         <Text isTruncated>
           {exchangeData.exchangeItems
-            .map((item) => item.amount)
+            .map((item) => item.quantity)
             .reduce((sum, cur) => sum + cur, 0)}{' '}
           개
         </Text>

--- a/libs/components-seller/src/lib/kkshow-order/OrderDetailExportInfo.tsx
+++ b/libs/components-seller/src/lib/kkshow-order/OrderDetailExportInfo.tsx
@@ -17,7 +17,7 @@ export function OrderDetailExportInfo({
 }): JSX.Element {
   const totalExportedEa = useMemo(() => {
     return exportData.items.reduce((prev, curr) => {
-      return prev + Number(curr.amount);
+      return prev + Number(curr.quantity);
     }, 0);
   }, [exportData.items]);
 

--- a/libs/components-seller/src/lib/kkshow-order/OrderDetailReturnInfo.tsx
+++ b/libs/components-seller/src/lib/kkshow-order/OrderDetailReturnInfo.tsx
@@ -26,7 +26,9 @@ export function OrderDetailReturnInfo({
         />
         <TextDotConnector />
         <Text isTruncated>
-          {returnData.items.map((item) => item.amount).reduce((sum, cur) => sum + cur, 0)}{' '}
+          {returnData.items
+            .map((item) => item.quantity)
+            .reduce((sum, cur) => sum + cur, 0)}{' '}
           개
         </Text>
       </Stack>

--- a/libs/components-seller/src/lib/kkshow-order/OrderReturnStatusDialog.tsx
+++ b/libs/components-seller/src/lib/kkshow-order/OrderReturnStatusDialog.tsx
@@ -185,7 +185,7 @@ export function OrderReturnStatusDialog({
               <RelatedRefundData
                 refund={returnDetail.refund}
                 estimatedRefundAmount={returnDetail.items
-                  .map((item) => item.price * item.amount) // 환불상품 가격 * 개수
+                  .map((item) => item.price * item.quantity) // 환불상품 가격 * 개수
                   .reduce((sum, price) => sum + price, 0)}
                 // 소비자가 환불요청시 환불요청계좌를 입력했다면, 환불예정계좌료 표시
                 refundAccount={returnDetail.refundAccount || undefined}

--- a/libs/components-seller/src/lib/kkshow-order/ReExportDialog.tsx
+++ b/libs/components-seller/src/lib/kkshow-order/ReExportDialog.tsx
@@ -66,7 +66,7 @@ export function ReExportDialog({
       items: exchangeData.exchangeItems.map((item) => ({
         orderItemId: item.orderItemId,
         orderItemOptionId: item.orderItemOptionId,
-        amount: item.amount,
+        quantity: item.quantity,
       })),
     },
   });
@@ -171,7 +171,7 @@ export function ReExportDialog({
                             </Text>
                           </Td>
                           <Td>
-                            <Text>{exchangeItem.amount} 개 </Text>
+                            <Text>{exchangeItem.quantity} 개 </Text>
                           </Td>
                         </Tr>
                       );

--- a/libs/components-shared/src/lib/delivery-tracking/DeliveryTracking.tsx
+++ b/libs/components-shared/src/lib/delivery-tracking/DeliveryTracking.tsx
@@ -78,7 +78,7 @@ export function DeliveryTracking({ exportData }: DeliveryTrackingProps): JSX.Ele
               <Flex gap={2} fontSize="sm">
                 <Text>{exportItem.title1}:</Text>
                 <Text>{exportItem.option1}</Text>
-                <Text>{exportItem.amount}개</Text>
+                <Text>{exportItem.quantity}개</Text>
               </Flex>
               <Text fontSize="sm">총 {getLocaleNumber(exportItem.price)}원</Text>
             </Box>

--- a/libs/components-shared/src/lib/order/ExchangeReturnCancelRequestGoodsData.tsx
+++ b/libs/components-shared/src/lib/order/ExchangeReturnCancelRequestGoodsData.tsx
@@ -5,13 +5,13 @@ import { getLocaleNumber } from '@project-lc/utils-frontend';
 
 interface ExchangeReturnCancelRequestGoodsDataProps
   extends ExchangeReturnCancelItemBaseData {
-  amount: number;
+  quantity: number;
 }
 /** 교환,환불,주문취소 상품 & 옵션 & 개수 표시 컴포넌트 */
 export function ExchangeReturnCancelRequestGoodsData(
   props: ExchangeReturnCancelRequestGoodsDataProps,
 ): JSX.Element {
-  const { goodsName, image, optionName, optionValue, amount, price } = props;
+  const { goodsName, image, optionName, optionValue, quantity, price } = props;
   return (
     <Stack direction="row">
       {/* 이미지 */}
@@ -29,9 +29,9 @@ export function ExchangeReturnCancelRequestGoodsData(
             </>
           )}
 
-          <Text>{amount} 개 </Text>
+          <Text>{quantity} 개 </Text>
           <TextDotConnector />
-          <Text>{getLocaleNumber(price * amount)}원</Text>
+          <Text>{getLocaleNumber(price * quantity)}원</Text>
         </Stack>
       </Stack>
     </Stack>

--- a/libs/components-web-kkshow/src/lib/mypage/exchange-return-cancel/ItemSelectSection.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/exchange-return-cancel/ItemSelectSection.tsx
@@ -6,7 +6,7 @@ import { OrderItemOptionInfo } from '../orderList/OrderItemOptionInfo';
 export type SelectedOrderItem = {
   orderItemId: number;
   orderItemOptionId: number;
-  amount: number;
+  quantity: number;
 };
 
 export interface ItemSelectSectionProps {
@@ -30,7 +30,7 @@ export function ItemSelectSection({
         item.options.map((opt) => ({
           orderItemId: item.id,
           orderItemOptionId: opt.id,
-          amount: opt.quantity,
+          quantity: opt.quantity,
         })),
       );
       setSelectedItems(all);
@@ -72,7 +72,7 @@ export function ItemSelectSection({
                     {
                       orderItemId: item.id,
                       orderItemOptionId: opt.id,
-                      amount: opt.quantity,
+                      quantity: opt.quantity,
                     },
                   ]);
                 }

--- a/libs/components-web-kkshow/src/lib/mypage/exchange-return-cancel/detailPage/CustomerOrderCancelDetail.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/exchange-return-cancel/detailPage/CustomerOrderCancelDetail.tsx
@@ -89,7 +89,7 @@ export function OrderCancelDetailData({
           // 주문취소하려는 주문이 결제승인이 완료된 상태였다면 예상환불금액은 상품 전체 가격 합 표시, 아니면 0 원
           data.order.payment?.depositDoneFlag
             ? data.items
-                .map((item) => item.price * item.amount)
+                .map((item) => item.price * item.quantity)
                 .reduce((sum, price) => sum + price, 0)
             : 0
         }

--- a/libs/components-web-kkshow/src/lib/mypage/exchange-return-cancel/detailPage/CustomerReturnDetail.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/exchange-return-cancel/detailPage/CustomerReturnDetail.tsx
@@ -120,7 +120,7 @@ export function ReturnDetailData({ data }: { data: ReturnDetailRes }): JSX.Eleme
       <RelatedRefundData
         refund={data.refund}
         estimatedRefundAmount={data.items
-          .map((item) => item.price * item.amount)
+          .map((item) => item.price * item.quantity)
           .reduce((sum, price) => sum + price, 0)}
         // 소비자가 환불요청시 환불요청계좌를 입력했다면, 환불예정계좌료 표시
         refundAccount={data.refundAccount || undefined}

--- a/libs/components-web-kkshow/src/lib/mypage/order/OrderInfoExportsList.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/order/OrderInfoExportsList.tsx
@@ -178,7 +178,7 @@ export function OrderInfoExportsItem({
             <Text>
               {orderItemOption.name}: {orderItemOption.value}
             </Text>
-            <Text>{exportItem.amount}개</Text>
+            <Text>{exportItem.quantity}개</Text>
           </HStack>
 
           <HStack>

--- a/libs/components-web-kkshow/src/lib/mypage/orderList/OrderCancelDialog.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/orderList/OrderCancelDialog.tsx
@@ -1,7 +1,6 @@
 import { Box, Center, Flex, Spinner, Stack, Text, useToast } from '@chakra-ui/react';
 import { OrderProcessStep } from '@prisma/client';
 import { ConfirmDialog } from '@project-lc/components-core/ConfirmDialog';
-import { OrderStatusBadge } from '@project-lc/components-shared/order/OrderStatusBadge';
 import { RefundAccountForm } from '@project-lc/components-shared/payment/RefundAccountForm';
 import {
   useCreateRefundMutation,
@@ -51,7 +50,7 @@ export function OrderCancelDialog({
         .map((opt) => ({
           orderItemId: item.id,
           orderItemOptionId: opt.id,
-          amount: opt.quantity,
+          quantity: opt.quantity,
           discountPrice: Number(opt.discountPrice), // CreateOrderCancellationDto와 무관. CreateRefundDto.refundAmount 계산용
           step: opt.step,
         })),
@@ -63,7 +62,7 @@ export function OrderCancelDialog({
     if (!orderDetailData) return 0;
     // 1. 취소할 상품들 옵션별 가격*개수 합
     const orderItemOptionsPrice = targetItemOptions
-      .map((opt) => opt.amount * opt.discountPrice)
+      .map((opt) => opt.quantity * opt.discountPrice)
       .reduce((sum, cur) => sum + cur, 0);
 
     // 주문취소상품에 적용된 배송비 정보 찾기
@@ -93,11 +92,11 @@ export function OrderCancelDialog({
     const dto: CreateOrderCancellationDto = {
       orderId: orderDetailData.id,
       items: targetItemOptions.map((opt) => {
-        const { orderItemId, orderItemOptionId, amount } = opt;
+        const { orderItemId, orderItemOptionId, quantity } = opt;
         return {
           orderItemId,
           orderItemOptionId,
-          amount,
+          quantity,
         };
       }),
     };

--- a/libs/nest-modules-exchange/src/lib/exchange.service.ts
+++ b/libs/nest-modules-exchange/src/lib/exchange.service.ts
@@ -12,7 +12,6 @@ import {
   GetExchangeListDto,
   UpdateExchangeDto,
 } from '@project-lc/shared-types';
-import { Cache } from 'cache-manager';
 import { nanoid } from 'nanoid';
 
 @Injectable()
@@ -38,7 +37,7 @@ export class ExchangeService {
           create: exchangeItems.map((item) => ({
             orderItem: { connect: { id: item.orderItemId } },
             orderItemOption: { connect: { id: item.orderItemOptionId } },
-            amount: item.amount,
+            quantity: item.quantity,
           })),
         },
         images: {
@@ -100,7 +99,7 @@ export class ExchangeService {
 
       const _items = exchangeItems.map((i) => ({
         id: i.id, // 교환 상품 고유번호
-        amount: i.amount, // 교환 상품 개수
+        quantity: i.quantity, // 교환 상품 개수
         status: i.status, // 교환 상품 처리상태
         goodsName: i.orderItem.goods.goods_name, // 원래 주문한 상품명
         image: i.orderItem.goods.image?.[0]?.image, // 주문 상품 이미지
@@ -156,7 +155,7 @@ export class ExchangeService {
 
     const _items = exchangeItems.map((i) => ({
       id: i.id, // 교환 상품 고유번호
-      amount: i.amount, // 교환 상품 개수
+      quantity: i.quantity, // 교환 상품 개수
       status: i.status, // 교환 상품 처리상태
       goodsName: i.orderItem.goods.goods_name, // 원래 주문한 상품명
       image: i.orderItem.goods.image?.[0]?.image, // 주문 상품 이미지

--- a/libs/nest-modules-order/src/lib/order-cancellation/order-cancellation.service.ts
+++ b/libs/nest-modules-order/src/lib/order-cancellation/order-cancellation.service.ts
@@ -96,7 +96,7 @@ export class OrderCancellationService {
           create: items.map((item) => ({
             orderItem: { connect: { id: item.orderItemId } },
             orderItemOption: { connect: { id: item.orderItemOptionId } },
-            amount: item.amount,
+            quantity: item.quantity,
             status,
           })),
         },
@@ -232,7 +232,7 @@ export class OrderCancellationService {
 
       const _items = items.map((i) => ({
         id: i.id, // 주문취소상품 고유번호
-        amount: i.amount, // 주문취소상품 개수
+        quantity: i.quantity, // 주문취소상품 개수
         status: i.status, // 주문취소상품 처리상태
         goodsName: i.orderItem.goods.goods_name, // 원래 주문한 상품명
         image: i.orderItem.goods.image?.[0]?.image, // 주문 상품 이미지
@@ -362,7 +362,7 @@ export class OrderCancellationService {
 
     const _items = items.map((i) => ({
       id: i.id, // 주문취소상품 고유번호
-      amount: i.amount, // 주문취소상품 개수
+      quantity: i.quantity, // 주문취소상품 개수
       status: i.status, // 주문취소상품 처리상태
       goodsName: i.orderItem.goods.goods_name, // 원래 주문한 상품명
       image: i.orderItem.goods.image?.[0]?.image, // 주문 상품 이미지

--- a/libs/nest-modules-return/src/lib/return.service.ts
+++ b/libs/nest-modules-return/src/lib/return.service.ts
@@ -43,7 +43,7 @@ export class ReturnService {
           create: items.map((item) => ({
             orderItem: { connect: { id: item.orderItemId } },
             orderItemOption: { connect: { id: item.orderItemOptionId } },
-            amount: item.amount,
+            quantity: item.quantity,
           })),
         },
         images: {
@@ -108,7 +108,7 @@ export class ReturnService {
 
       const _items = items.map((i) => ({
         id: i.id, // 반품 상품 고유번호
-        amount: i.amount, // 반품 상품 개수
+        quantity: i.quantity, // 반품 상품 개수
         status: i.status, // 반품 상품 처리상태
         goodsName: i.orderItem.goods.goods_name, // 원래 주문한 상품명
         image: i.orderItem.goods.image?.[0]?.image, // 주문 상품 이미지
@@ -189,7 +189,7 @@ export class ReturnService {
 
     const _items = items.map((i) => ({
       id: i.id, // 반품 상품 고유번호
-      amount: i.amount, // 반품 상품 개수
+      quantity: i.quantity, // 반품 상품 개수
       status: i.status, // 반품 상품 처리상태
       goodsName: i.orderItem.goods.goods_name, // 원래 주문한 상품명
       image: i.orderItem.goods.image?.[0]?.image, // 주문 상품 이미지

--- a/libs/nest-modules-seller/src/seller/settlement/seller-settlement.service.ts
+++ b/libs/nest-modules-seller/src/seller/settlement/seller-settlement.service.ts
@@ -201,7 +201,7 @@ export class SellerSettlementService {
               },
             },
             orderItemOption: true,
-            amount: true,
+            quantity: true,
             status: true,
           },
         },

--- a/libs/prisma-orm/prisma/migrations/20220720005741_/migration.sql
+++ b/libs/prisma-orm/prisma/migrations/20220720005741_/migration.sql
@@ -1,0 +1,40 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `amount` on the `ExchangeItem` table. All the data in the column will be lost.
+  - You are about to drop the column `amount` on the `ExportItem` table. All the data in the column will be lost.
+  - You are about to drop the column `amount` on the `OrderCancellationItem` table. All the data in the column will be lost.
+  - You are about to drop the column `amount` on the `RefundItem` table. All the data in the column will be lost.
+  - You are about to drop the column `amount` on the `ReturnItem` table. All the data in the column will be lost.
+  - You are about to drop the column `amount` on the `SellerOrderCancelRequestItem` table. All the data in the column will be lost.
+  - Added the required column `quantity` to the `ExchangeItem` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `quantity` to the `ExportItem` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `quantity` to the `OrderCancellationItem` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `quantity` to the `RefundItem` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `quantity` to the `ReturnItem` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `quantity` to the `SellerOrderCancelRequestItem` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `ExchangeItem` DROP COLUMN `amount`,
+    ADD COLUMN `quantity` INTEGER NOT NULL;
+
+-- AlterTable
+ALTER TABLE `ExportItem` DROP COLUMN `amount`,
+    ADD COLUMN `quantity` INTEGER NOT NULL;
+
+-- AlterTable
+ALTER TABLE `OrderCancellationItem` DROP COLUMN `amount`,
+    ADD COLUMN `quantity` INTEGER NOT NULL;
+
+-- AlterTable
+ALTER TABLE `RefundItem` DROP COLUMN `amount`,
+    ADD COLUMN `quantity` INTEGER NOT NULL;
+
+-- AlterTable
+ALTER TABLE `ReturnItem` DROP COLUMN `amount`,
+    ADD COLUMN `quantity` INTEGER NOT NULL;
+
+-- AlterTable
+ALTER TABLE `SellerOrderCancelRequestItem` DROP COLUMN `amount`,
+    ADD COLUMN `quantity` INTEGER NOT NULL;

--- a/libs/prisma-orm/prisma/schema.prisma
+++ b/libs/prisma-orm/prisma/schema.prisma
@@ -849,7 +849,7 @@ model SellerOrderCancelRequestItem {
   id                       Int                      @id @default(autoincrement())
   orderItemSeq             Int // 주문상품번호 fm_order_item.item_seq
   orderItemOptionSeq       Int // 주문상품옵션번호 fm_order_item_option.item_option_seq
-  amount                   Int // 취소할 주문상품옵션의 개수
+  quantity                 Int // 취소할 주문상품옵션의 개수
   sellerOrderCancelRequest SellerOrderCancelRequest @relation(fields: [orderSeq], references: [id], onDelete: Cascade)
   orderSeq                 Int
 }
@@ -1786,7 +1786,7 @@ model RefundItem {
   orderItem         OrderItem       @relation(fields: [orderItemId], references: [id]) // 연결된 주문상품
   orderItemOptionId Int // 주문상품 옵션 고유번호
   orderItemOption   OrderItemOption @relation(fields: [orderItemOptionId], references: [id]) // 연결된주문상품옵션
-  amount            Int // 개수
+  quantity          Int // 개수
 }
 
 // ****************
@@ -1837,7 +1837,7 @@ model ReturnItem {
   orderItem         OrderItem       @relation(fields: [orderItemId], references: [id]) // 연결된 주문상품
   orderItemOptionId Int // 주문상품 옵션 고유번호
   orderItemOption   OrderItemOption @relation(fields: [orderItemOptionId], references: [id]) // 연결된주문상품옵션
-  amount            Int // 개수
+  quantity          Int // 개수
   status            ProcessStatus   @default(requested) // 반품처리상태
   getBackFlag       Boolean         @default(false) // 회수(수거) 여부
 }
@@ -1901,7 +1901,7 @@ model ExchangeItem {
   orderItem         OrderItem             @relation(fields: [orderItemId], references: [id]) // 연결된 주문상품
   orderItemOptionId Int // 주문상품 옵션 고유번호
   orderItemOption   OrderItemOption       @relation(fields: [orderItemOptionId], references: [id]) // 연결된주문상품옵션
-  amount            Int // 개수
+  quantity          Int // 개수
   status            ExchangeProcessStatus @default(requested) // 교환처리상태
   getBackFlag       Boolean               @default(false) // 회수(수거) 여부
 }
@@ -1936,7 +1936,7 @@ model OrderCancellationItem {
   orderItem           OrderItem         @relation(fields: [orderItemId], references: [id]) // 연결된 주문상품
   orderItemOptionId   Int // 주문상품 옵션 고유번호
   orderItemOption     OrderItemOption   @relation(fields: [orderItemOptionId], references: [id]) // 연결된주문상품옵션
-  amount              Int // 개수
+  quantity            Int // 개수
   status              ProcessStatus     @default(requested) // 주문취소 처리상태
 }
 
@@ -1986,7 +1986,7 @@ model ExportItem {
   orderItem         OrderItem        @relation(fields: [orderItemId], references: [id]) // 연결된 주문상품
   orderItemOptionId Int // 주문상품 옵션 고유번호
   orderItemOption   OrderItemOption  @relation(fields: [orderItemOptionId], references: [id]) // 연결된주문상품옵션
-  amount            Int // 개수
+  quantity          Int // 개수
   status            OrderProcessStep @default(exportDone) // 출고상태 : 출고준비 | 출고완료(기본값) | 배송중 | 배송완료 -> 모두 OrderProcessStep 에 있어서 그대로 사용함
 }
 

--- a/libs/prisma-orm/prisma/seedData/dummyOrder.ts
+++ b/libs/prisma-orm/prisma/seedData/dummyOrder.ts
@@ -348,7 +348,7 @@ export const createDummyOrderWithCancellation = async (): Promise<void> => {
         create: {
           orderItemId,
           orderItemOptionId,
-          amount: 1,
+          quantity: 1,
         },
       },
     },
@@ -372,7 +372,7 @@ export const createDummyOrderWithExchange = async (): Promise<void> => {
         create: {
           orderItemId,
           orderItemOptionId,
-          amount: 1,
+          quantity: 1,
         },
       },
       images: { create: [{ imageUrl: 'https://dummyimage.com/300' }] },
@@ -396,7 +396,7 @@ export const createDummyOrderWithReturn = async (): Promise<void> => {
         create: {
           orderItemId,
           orderItemOptionId,
-          amount: 1,
+          quantity: 1,
         },
       },
       images: { create: [{ imageUrl: 'https://dummyimage.com/300' }] },
@@ -440,7 +440,7 @@ export const createDummyOrderWithSupport = async (): Promise<void> => {
       items: {
         create: [
           {
-            amount: 1,
+            quantity: 1,
             status: 'purchaseConfirmed',
             orderItemId: order1.orderItemId,
             orderItemOptionId: order1.orderItemOptionId,
@@ -468,7 +468,7 @@ export const createDummyOrderWithSupport = async (): Promise<void> => {
       items: {
         create: [
           {
-            amount: 1,
+            quantity: 1,
             status: 'purchaseConfirmed',
             orderItemId: order2.orderItemId,
             orderItemOptionId: order2.orderItemOptionId,

--- a/libs/shared-types/src/lib/dto/exchange.dto.ts
+++ b/libs/shared-types/src/lib/dto/exchange.dto.ts
@@ -39,7 +39,7 @@ export class CreateExchangeItemDto {
 
   /** 개수 */
   @IsNumber()
-  amount: number;
+  quantity: number;
 }
 
 /** 교환 생성 dto */

--- a/libs/shared-types/src/lib/dto/kkshowExport.dto.ts
+++ b/libs/shared-types/src/lib/dto/kkshowExport.dto.ts
@@ -31,7 +31,7 @@ export class KkshowExportItem {
 
   @IsNumber()
   /**  출고개수 */
-  amount: number;
+  quantity: number;
 }
 
 /** 크크쇼 단일출고처리 생성 dto */

--- a/libs/shared-types/src/lib/dto/orderCancellation.dto.ts
+++ b/libs/shared-types/src/lib/dto/orderCancellation.dto.ts
@@ -9,6 +9,7 @@ import {
   ValidateIf,
   ValidateNested,
 } from 'class-validator';
+import { CreateReturnItemDto } from './return.dto';
 
 // *------------ 주문취소 생성 dto ------------------
 /** 주문취소에 포함된 상품 dto */
@@ -23,7 +24,7 @@ export class OrderCancellationItemDto {
 
   /** 주문상품 옵션 취소할 개수 */
   @IsNumber()
-  amount: number;
+  quantity: number;
 }
 
 /** 주문취소생성 dto */

--- a/libs/shared-types/src/lib/dto/refund.dto.ts
+++ b/libs/shared-types/src/lib/dto/refund.dto.ts
@@ -23,7 +23,7 @@ export class CreateRefundItemDto {
 
   /** 개수 */
   @IsNumber()
-  amount: number;
+  quantity: number;
 }
 
 /** 환불받을 계좌정보 */

--- a/libs/shared-types/src/lib/dto/return.dto.ts
+++ b/libs/shared-types/src/lib/dto/return.dto.ts
@@ -40,7 +40,7 @@ export class CreateReturnItemDto {
 
   /** 개수 */
   @IsNumber()
-  amount: number;
+  quantity: number;
 }
 
 /** 반품 생성 dto */

--- a/libs/shared-types/src/lib/dto/sellerOrderCancel.dto.ts
+++ b/libs/shared-types/src/lib/dto/sellerOrderCancel.dto.ts
@@ -13,7 +13,7 @@ export class SellerOrderCancelRequestDto {
 
 export class SellerOrderCancelRequestItemDto {
   @IsNumber()
-  amount: number;
+  quantity: number;
 
   @IsNumber()
   orderItemSeq: number;

--- a/libs/shared-types/src/lib/res-types/exchange.res.ts
+++ b/libs/shared-types/src/lib/res-types/exchange.res.ts
@@ -7,7 +7,7 @@ export type ExchangeItemData = ExchangeReturnCancelItemBaseData & {
   /** 교환상품 고유번호 */
   id: ExchangeItem['id'];
   /** 교환상품 개수 */
-  amount: ExchangeItem['amount'];
+  quantity: ExchangeItem['quantity'];
   /** 교환상품 처리 상태 */
   status: ExchangeItem['status'];
 };

--- a/libs/shared-types/src/lib/res-types/orderCancellation.res.ts
+++ b/libs/shared-types/src/lib/res-types/orderCancellation.res.ts
@@ -40,7 +40,7 @@ export type OrderCancellationItemData = ExchangeReturnCancelItemBaseData & {
   /** 주문취소상품 고유번호 */
   id: OrderCancellationItem['id'];
   /** 주문취소상품 개수 */
-  amount: OrderCancellationItem['amount'];
+  quantity: OrderCancellationItem['quantity'];
   /** 주문취소상품 처리 상태 */
   status: OrderCancellationItem['status'];
 };

--- a/libs/shared-types/src/lib/res-types/return.res.ts
+++ b/libs/shared-types/src/lib/res-types/return.res.ts
@@ -21,7 +21,7 @@ export type ReturnItemData = ExchangeReturnCancelItemBaseData & {
   /** 주문취소상품 고유번호 */
   id: ReturnItem['id'];
   /** 주문취소상품 개수 */
-  amount: ReturnItem['amount'];
+  quantity: ReturnItem['quantity'];
   /** 주문취소상품 처리 상태 */
   status: ReturnItem['status'];
 };

--- a/libs/shared-types/src/lib/res-types/sellerSettlements.res.ts
+++ b/libs/shared-types/src/lib/res-types/sellerSettlements.res.ts
@@ -15,7 +15,10 @@ import {
   SellerShop,
 } from '@prisma/client';
 
-type SellerSettlementTargetsExportItem = Pick<ExportItem, 'id' | 'amount' | 'status'> & {
+type SellerSettlementTargetsExportItem = Pick<
+  ExportItem,
+  'id' | 'quantity' | 'status'
+> & {
   orderItem: {
     channel: OrderItem['channel'];
     goods: {


### PR DESCRIPTION
문제
- 테이블 컬럼 중 amount가 개수, 금액 두 의미로 여기저기서 사용되고 있다
- 코드 작성시 개수와 금액을 혼동할 여지가 있다

수정방안
- '금액' 의미하는 amount 컬럼은 그대로 사용
- '개수' 의미하는 amount 컬럼은 quantity 로 컬럼명 변경 (교환,반품,환불, 결제취소 테이블에서 amount를 개수의 의미로 사용하고 있었음 -> 해당 테이블에서 컬럼명을 수정함)


수정 후
- 가격, 할인액 등 금액을 의미하는 컬럼은 amount를 사용
- 상품 개수를 의미하는 컬럼은 quantity 사용

