### PR TITLE
[크크쇼] 방송인 홍보페이지 버그수정 + 소개글기능추가

### DIFF
--- a/apps/admin/pages/broadcaster/promotion-page/[promotionPageId].tsx
+++ b/apps/admin/pages/broadcaster/promotion-page/[promotionPageId].tsx
@@ -37,6 +37,7 @@ export function BroadcasterPromotionPageDetail(): JSX.Element {
           promotionPageId={promotionPageId}
           onDeleteSuccess={goBackToList}
         />
+
         <Divider my={10} />
 
         {/* 상품홍보페이지에 연결된 상품홍보 영역 */}

--- a/apps/web-kkshow/pages/bc/[broadcasterId].tsx
+++ b/apps/web-kkshow/pages/bc/[broadcasterId].tsx
@@ -14,7 +14,7 @@ import {
 import KkshowLayout from '@project-lc/components-web-kkshow/KkshowLayout';
 import { PromotionPageGoodsList } from '@project-lc/components-web-kkshow/promotion-page/PromotionPageGoodsList';
 import { PromotionPageProfile } from '@project-lc/components-web-kkshow/promotion-page/PromotionPageProfile';
-import { useBroadcaster } from '@project-lc/hooks';
+import { useBroadcaster, usePromotionPage } from '@project-lc/hooks';
 import { useRouter } from 'next/router';
 import { useMemo } from 'react';
 
@@ -22,6 +22,7 @@ export function BroadcasterPromotionPage(): JSX.Element {
   const router = useRouter();
   const broadcasterId = router.query.broadcasterId as string;
   const bc = useBroadcaster({ id: broadcasterId });
+  const promotionPage = usePromotionPage(broadcasterId);
 
   const tabInfo = useMemo(
     () => [
@@ -47,8 +48,7 @@ export function BroadcasterPromotionPage(): JSX.Element {
   }
 
   if (!bc.data) return null;
-
-  if (bc.data && !bc.data.userNickname)
+  if ((bc.data && !bc.data.userNickname) || !promotionPage.data)
     return (
       <Box>
         <KkshowLayout>

--- a/libs/components-admin/src/lib/AdminBroadcasterPromotionPageDetail.tsx
+++ b/libs/components-admin/src/lib/AdminBroadcasterPromotionPageDetail.tsx
@@ -1,4 +1,4 @@
-import { ExternalLinkIcon } from '@chakra-ui/icons';
+import { DeleteIcon, ExternalLinkIcon } from '@chakra-ui/icons';
 import {
   Alert,
   AlertDescription,
@@ -6,6 +6,7 @@ import {
   AlertTitle,
   Box,
   Button,
+  ButtonGroup,
   Heading,
   Link,
   Stack,
@@ -31,7 +32,7 @@ export function AdminBroadcasterPromotionPageDetail({
 }: AdminBroadcasterPromotionPageDetailProps): JSX.Element {
   const toast = useToast();
 
-  const { id, url, broadcaster } = pageData;
+  const { id, url, broadcaster, comment } = pageData;
   const { userNickname } = broadcaster;
 
   // 페이지 삭제
@@ -51,11 +52,17 @@ export function AdminBroadcasterPromotionPageDetail({
         <Heading mt={4} size="lg">
           {userNickname}의 상품홍보페이지
         </Heading>
-        <Button onClick={deleteDialog.onOpen}>삭제</Button>
       </Stack>
 
+      <ButtonGroup my={2} size="sm">
+        <AdminBroadcasterPromotionPageUpdateSection pageData={pageData} />
+        <Button leftIcon={<DeleteIcon />} onClick={deleteDialog.onOpen}>
+          삭제
+        </Button>
+      </ButtonGroup>
+
       <Stack direction="row">
-        <Text>페이지 id : </Text>
+        <Text>페이지 고유ID : </Text>
         <Text>{id}</Text>
       </Stack>
 
@@ -65,14 +72,25 @@ export function AdminBroadcasterPromotionPageDetail({
       </Stack>
 
       <Stack direction="row">
+        <Text>방송인 소개글 : </Text>
+        <Box borderWidth="thin" rounded="md" p={1}>
+          {comment ? (
+            <Text whiteSpace="break-spaces" fontSize={{ base: 'sm', md: 'md' }}>
+              {comment}
+            </Text>
+          ) : (
+            '-'
+          )}
+        </Box>
+      </Stack>
+
+      <Stack direction="row">
         <Text>url : </Text>
         {url && (
           <Link href={url} isExternal color="blue.500">
             {url} <ExternalLinkIcon mx="2px" />
           </Link>
         )}
-
-        <AdminBroadcasterPromotionPageUpdateSection pageData={pageData} />
       </Stack>
 
       {/* 상품홍보페이지 삭제 모달창 */}

--- a/libs/components-admin/src/lib/AdminBroadcasterPromotionPageList.tsx
+++ b/libs/components-admin/src/lib/AdminBroadcasterPromotionPageList.tsx
@@ -8,7 +8,7 @@ import { useAdminBroadcasterPromotionPage } from '@project-lc/hooks';
 const columns: GridColumns = [
   {
     field: 'id',
-    headerName: '페이지id',
+    headerName: '고유ID',
     width: 120,
     renderCell: ({ row }: GridRowData) => {
       return (

--- a/libs/components-admin/src/lib/AdminBroadcasterPromotionPageUpdateSection.tsx
+++ b/libs/components-admin/src/lib/AdminBroadcasterPromotionPageUpdateSection.tsx
@@ -1,19 +1,23 @@
 import {
-  useDisclosure,
   Box,
   Button,
-  useToast,
+  ButtonGroup,
+  FormControl,
+  FormErrorMessage,
+  FormHelperText,
+  FormLabel,
+  Input,
   Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
+  ModalFooter,
   ModalHeader,
   ModalOverlay,
-  FormControl,
-  FormErrorMessage,
-  FormLabel,
-  Input,
   Stack,
+  Text,
+  useDisclosure,
+  useToast,
 } from '@chakra-ui/react';
 import {
   getAdminDuplicatePromotionPageFlag,
@@ -39,7 +43,7 @@ export function AdminBroadcasterPromotionPageUpdateModal({
     register,
     handleSubmit,
     watch,
-    formState: { errors },
+    formState: { errors, isDirty, isSubmitting },
   } = useForm<BroadcasterPromotionPageFormDataType>({
     defaultValues: {
       id: pageData.id,
@@ -71,15 +75,16 @@ export function AdminBroadcasterPromotionPageUpdateModal({
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>방송인 상품 홍보 페이지 url 수정</ModalHeader>
+        <ModalHeader>방송인 상품 홍보 페이지 URL 수정</ModalHeader>
         <ModalCloseButton />
         <ModalBody>
           <Stack as="form" onSubmit={handleSubmit(onSubmit)}>
             <FormControl isInvalid={!!errors.url}>
-              <FormLabel htmlFor="url">url</FormLabel>
+              <FormLabel htmlFor="url">방송인 홍보페이지 URL</FormLabel>
+
               <Input
                 id="url"
-                placeholder="https://k-kmarket.com/goods/catalog?code=00160001"
+                placeholder="https://www.xn--hp4b17xa.com/bc/방송인고유ID"
                 autoComplete="off"
                 {...register('url', {
                   required: 'url을 작성해주세요.',
@@ -92,15 +97,33 @@ export function AdminBroadcasterPromotionPageUpdateModal({
                 })}
               />
               <FormErrorMessage>{errors.url && errors.url.message}</FormErrorMessage>
+              <FormHelperText>
+                크크쇼 방송인 페이지URL입니다. 대부분의 경우 기본적으로 올바른 페이지가
+                자동생성되도록 구현되어 있습니다. 부득이하게 수정이 필요한 경우에만 작업을
+                진행하시기 바랍니다.
+              </FormHelperText>
+              <FormHelperText>
+                올바른URL형식:{' '}
+                <Text color="red.500" as="span">
+                  https://www.xn--hp4b17xa.com/bc/방송인고유ID
+                </Text>
+              </FormHelperText>
             </FormControl>
-            <Stack direction="row">
-              <Button type="submit" colorScheme="blue" disabled={!watch('url')}>
-                수정
-              </Button>
-              <Button onClick={onClose}>닫기</Button>
-            </Stack>
           </Stack>
         </ModalBody>
+        <ModalFooter>
+          <ButtonGroup>
+            <Button
+              type="submit"
+              colorScheme="blue"
+              disabled={!watch('url') || !isDirty}
+              isLoading={isSubmitting || updateRequest.isLoading}
+            >
+              수정
+            </Button>
+            <Button onClick={onClose}>닫기</Button>
+          </ButtonGroup>
+        </ModalFooter>
       </ModalContent>
     </Modal>
   );

--- a/libs/components-admin/src/lib/AdminBroadcasterPromotionPageUpdateSection.tsx
+++ b/libs/components-admin/src/lib/AdminBroadcasterPromotionPageUpdateSection.tsx
@@ -1,7 +1,9 @@
+import { EditIcon } from '@chakra-ui/icons';
 import {
   Box,
   Button,
   ButtonGroup,
+  ButtonProps,
   FormControl,
   FormErrorMessage,
   FormHelperText,
@@ -16,6 +18,7 @@ import {
   ModalOverlay,
   Stack,
   Text,
+  Textarea,
   useDisclosure,
   useToast,
 } from '@chakra-ui/react';
@@ -23,9 +26,11 @@ import {
   getAdminDuplicatePromotionPageFlag,
   useAdminBroadcasterPromotionPageUpdateMutation,
 } from '@project-lc/hooks';
-import { BroadcasterPromotionPageData } from '@project-lc/shared-types';
+import {
+  BroadcasterPromotionPageData,
+  BroadcasterPromotionPageUpdateDto,
+} from '@project-lc/shared-types';
 import { SubmitHandler, useForm } from 'react-hook-form';
-import { BroadcasterPromotionPageFormDataType } from './AdminBroadcasterPromotionPageCreateSection';
 
 export function AdminBroadcasterPromotionPageUpdateModal({
   isOpen,
@@ -35,7 +40,7 @@ export function AdminBroadcasterPromotionPageUpdateModal({
   isOpen: boolean;
   onClose: () => void;
   pageData: BroadcasterPromotionPageData;
-  defaultValues?: BroadcasterPromotionPageFormDataType;
+  defaultValues?: BroadcasterPromotionPageUpdateDto;
 }): JSX.Element {
   const toast = useToast();
 
@@ -44,23 +49,26 @@ export function AdminBroadcasterPromotionPageUpdateModal({
     handleSubmit,
     watch,
     formState: { errors, isDirty, isSubmitting },
-  } = useForm<BroadcasterPromotionPageFormDataType>({
+  } = useForm<BroadcasterPromotionPageUpdateDto>({
     defaultValues: {
       id: pageData.id,
       broadcasterId: pageData.broadcasterId,
       url: pageData.url || '',
+      comment: pageData.comment || '',
     },
   });
 
   const updateRequest = useAdminBroadcasterPromotionPageUpdateMutation();
 
-  const onSubmit: SubmitHandler<BroadcasterPromotionPageFormDataType> = (data) => {
+  const onSubmit: SubmitHandler<BroadcasterPromotionPageUpdateDto> = (data) => {
+    console.log(data);
     if (!data.id) return;
     updateRequest
       .mutateAsync({
         id: data.id,
         broadcasterId: data.broadcasterId || undefined,
         url: data.url,
+        comment: data.comment,
       })
       .then((res) => {
         toast({ title: '상품홍보페이지 url을 수정하였습니다', status: 'success' });
@@ -72,16 +80,17 @@ export function AdminBroadcasterPromotionPageUpdateModal({
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal isOpen={isOpen} onClose={onClose} isCentered>
       <ModalOverlay />
-      <ModalContent>
-        <ModalHeader>방송인 상품 홍보 페이지 URL 수정</ModalHeader>
+      <ModalContent as="form" onSubmit={handleSubmit(onSubmit)}>
+        <ModalHeader>방송인 상품홍보페이지 정보 수정</ModalHeader>
         <ModalCloseButton />
         <ModalBody>
-          <Stack as="form" onSubmit={handleSubmit(onSubmit)}>
+          <Stack>
             <FormControl isInvalid={!!errors.url}>
-              <FormLabel htmlFor="url">방송인 홍보페이지 URL</FormLabel>
-
+              <FormLabel fontWeight="bold" htmlFor="url">
+                방송인 홍보페이지 URL
+              </FormLabel>
               <Input
                 id="url"
                 placeholder="https://www.xn--hp4b17xa.com/bc/방송인고유ID"
@@ -89,6 +98,8 @@ export function AdminBroadcasterPromotionPageUpdateModal({
                 {...register('url', {
                   required: 'url을 작성해주세요.',
                   validate: async (_url) => {
+                    if (!_url) return 'URL을 입력해주세요';
+                    if (_url === pageData.url) return true;
                     const isDuplicateUrl = await getAdminDuplicatePromotionPageFlag(_url);
                     return (
                       !isDuplicateUrl || '이미 등록된 url 입니다. 다시 확인해주세요.'
@@ -108,6 +119,14 @@ export function AdminBroadcasterPromotionPageUpdateModal({
                   https://www.xn--hp4b17xa.com/bc/방송인고유ID
                 </Text>
               </FormHelperText>
+            </FormControl>
+
+            <FormControl isInvalid={!!errors.comment}>
+              <FormLabel fontWeight="bold">방송인 소개글</FormLabel>
+              <Textarea {...register('comment')} />
+              <FormHelperText>띄어쓰기, 문단나눔등이 모두 적용됩니다.</FormHelperText>
+              <FormHelperText>tip: 이모지를 활용하면 더 깔끔해보입니다.</FormHelperText>
+              <FormErrorMessage>{!!errors.comment?.message}</FormErrorMessage>
             </FormControl>
           </Stack>
         </ModalBody>
@@ -129,16 +148,17 @@ export function AdminBroadcasterPromotionPageUpdateModal({
   );
 }
 
-export interface AdminBroadcasterPromotionPageUpdateSectionProps {
+export interface AdminBroadcasterPromotionPageUpdateSectionProps extends ButtonProps {
   pageData: BroadcasterPromotionPageData;
 }
 export function AdminBroadcasterPromotionPageUpdateSection({
   pageData,
+  ...rest
 }: AdminBroadcasterPromotionPageUpdateSectionProps): JSX.Element {
   const { isOpen, onOpen, onClose } = useDisclosure();
   return (
     <Box>
-      <Button onClick={onOpen} size="xs">
+      <Button leftIcon={<EditIcon />} onClick={onOpen} {...rest}>
         수정
       </Button>
       <AdminBroadcasterPromotionPageUpdateModal

--- a/libs/components-web-kkshow/src/lib/promotion-page/PromotionPageProfile.tsx
+++ b/libs/components-web-kkshow/src/lib/promotion-page/PromotionPageProfile.tsx
@@ -6,6 +6,7 @@ import {
   usePromotionPage,
 } from '@project-lc/hooks';
 import { FaInstagram, FaTwitch, FaYoutube } from 'react-icons/fa';
+import { FiExternalLink } from 'react-icons/fi';
 
 interface PromotionPageProfileProps {
   broadcasterId: number | string;
@@ -16,6 +17,16 @@ export function PromotionPageProfile({
   const bc = useBroadcaster({ id: broadcasterId });
   const channels = useBroadcasterChannels(Number(broadcasterId));
   const { data: promotinoPage } = usePromotionPage(broadcasterId);
+  const getChannelLinkImage = (channelUrl: string): React.ReactNode => {
+    if (channelUrl.includes('twitch.com')) return <FaTwitch color="purple" />;
+    if (channelUrl.includes('youtube.com')) return <FaYoutube color="red" />;
+    if (channelUrl.includes('instagram.com')) return <FaInstagram />;
+    if (channelUrl.includes('afreecatv.com'))
+      return (
+        <Image draggable={false} src="/images/logo/icon-afreecatv-24.png" w="18px" />
+      );
+    return <FiExternalLink />;
+  };
   return (
     <Flex
       justifyContent="center"
@@ -30,43 +41,30 @@ export function PromotionPageProfile({
         src={bc.data?.avatar || ''}
       />
       <Text fontSize="2xl">{bc.data?.userNickname}</Text>
-      <Flex
-        my={4}
-        gap={4}
-        maxW="xl"
-        w="100%"
-        justify={channels.data?.length === 1 ? 'center' : 'space-between'}
-      >
-        {channels.data?.map((channel) => (
-          <Flex flexDir="column" justify="space-between" key={channel.id}>
-            {channel.url.includes('twitch.com') && <FaTwitch color="purple" />}
-            {channel.url.includes('youtube.com') && <FaYoutube color="red" />}
-            {channel.url.includes('instagram.com') && <FaInstagram />}
-            {channel.url.includes('afreecatv.com') && (
-              <Image
-                draggable={false}
-                src="/images/logo/icon-afreecatv-24.png"
-                w="18px"
-              />
-            )}
-            <Link
-              isExternal
-              href={channel.url}
-              maxW={150}
-              noOfLines={1}
-              fontSize={{ base: 'sm', md: 'md' }}
-            >
-              {channel.url}
-            </Link>
-          </Flex>
-        ))}
-      </Flex>
       {promotinoPage?.comment && (
         <Box mt={2} maxW="xl" w="100%">
           <Text fontWeight="bold">방송인 소개</Text>
           <Text whiteSpace="break-spaces" fontSize={{ base: 'sm', md: 'md' }}>
             {promotinoPage.comment}
           </Text>
+        </Box>
+      )}
+
+      {channels.data && (
+        <Box my={4} gap={4} maxW="xl" w="100%">
+          {channels.data?.map((channel) => (
+            <Flex justify="flex-start" align="center" gap={2} key={channel.id}>
+              {getChannelLinkImage(channel.url)}
+              <Link
+                isExternal
+                href={channel.url}
+                noOfLines={1}
+                fontSize={{ base: 'sm', md: 'md' }}
+              >
+                채널바로가기
+              </Link>
+            </Flex>
+          ))}
         </Box>
       )}
     </Flex>

--- a/libs/nest-modules-broadcaster/src/broadcaster/broadcaster-promotion-page.controller.ts
+++ b/libs/nest-modules-broadcaster/src/broadcaster/broadcaster-promotion-page.controller.ts
@@ -20,7 +20,7 @@ export class BroadcasterPromotionPageContoller {
   findPromotionPage(
     @Param('broadcasterId', ParseIntPipe) broadcasterId: Broadcaster['id'],
   ): Promise<BroadcasterPromotionPage> {
-    return this.broadcasterPromotionPageService.findById(broadcasterId);
+    return this.broadcasterPromotionPageService.findByBroadcasterId(broadcasterId);
   }
 
   @Get('goods')

--- a/libs/nest-modules-broadcaster/src/broadcaster/broadcaster-promotion-page.service.ts
+++ b/libs/nest-modules-broadcaster/src/broadcaster/broadcaster-promotion-page.service.ts
@@ -81,11 +81,12 @@ export class BroadcasterPromotionPageService {
   public async createPromotionPage(
     dto: BroadcasterPromotionPageDto,
   ): Promise<BroadcasterPromotionPage> {
-    const { url, broadcasterId } = dto;
+    const { comment, broadcasterId } = dto;
     const promotionPage = await this.prisma.broadcasterPromotionPage.create({
       data: {
-        url: url || `${getKkshowWebHost()}/bc/${broadcasterId}`,
+        url: `${getKkshowWebHost()}/bc/${broadcasterId}`,
         broadcaster: { connect: { id: broadcasterId } },
+        comment,
       },
     });
     return promotionPage;

--- a/libs/nest-modules-broadcaster/src/broadcaster/broadcaster-promotion-page.service.ts
+++ b/libs/nest-modules-broadcaster/src/broadcaster/broadcaster-promotion-page.service.ts
@@ -8,6 +8,7 @@ import {
   FindManyDto,
   PromotionPagePromotionGoodsRes,
 } from '@project-lc/shared-types';
+import { getKkshowWebHost } from '@project-lc/utils';
 
 @Injectable()
 export class BroadcasterPromotionPageService {
@@ -83,7 +84,7 @@ export class BroadcasterPromotionPageService {
     const { url, broadcasterId } = dto;
     const promotionPage = await this.prisma.broadcasterPromotionPage.create({
       data: {
-        url,
+        url: url || `${getKkshowWebHost()}/bc/${broadcasterId}`,
         broadcaster: { connect: { id: broadcasterId } },
       },
     });
@@ -97,9 +98,7 @@ export class BroadcasterPromotionPageService {
     const { id, ...updateData } = dto;
     const page = await this.prisma.broadcasterPromotionPage.update({
       where: { id },
-      data: {
-        ...updateData,
-      },
+      data: { ...updateData },
     });
     return page;
   }

--- a/libs/nest-modules-broadcaster/src/broadcaster/broadcaster.controller.ts
+++ b/libs/nest-modules-broadcaster/src/broadcaster/broadcaster.controller.ts
@@ -158,7 +158,6 @@ export class BroadcasterController {
   }
 
   /** 방송인 채널 목록 조회 */
-  @UseGuards(JwtAuthGuard)
   @UseInterceptors(HttpCacheInterceptor)
   @Get('/:broadcasterId/channel-list')
   getBroadcasterChannelList(

--- a/libs/prisma-orm/prisma/seed.ts
+++ b/libs/prisma-orm/prisma/seed.ts
@@ -13,6 +13,7 @@ import {
 } from '@prisma/client';
 import { cartSample, tempUserCartItemSample } from './seedData/cart';
 import { dummyCustomer } from './seedData/customer';
+import { createDummyBroadcaster } from './seedData/dummyBc';
 import {
   dummyCoupon,
   dummyCustomerCoupon,
@@ -129,17 +130,13 @@ async function createCustomer(): Promise<Customer> {
 }
 
 /** 방송인홍보페이지 생성 */
-let kkmarketCatalogCode = 11;
 async function createBroadcasterPromotionPage(
   broadcasterId: number,
 ): Promise<BroadcasterPromotionPage> {
-  const tempCatalogUrl = `https://k-kmarket.com/goods/catalog?code=00${kkmarketCatalogCode}`;
-  kkmarketCatalogCode += 1;
   return prisma.broadcasterPromotionPage.create({
     data: {
       broadcasterId,
-      url: tempCatalogUrl, // 임시로 크크마켓 카테고리 링크
-      comment: `✍️Senior 2D Artist 
+      comment: `✍️Senior 2D Artist
 @SecondDinnerGames
 🎨Illustrator for Hearthstone and MtG
 Past: Blur, Blizzard, Gearbox, Disney, Valve, Bethesda, etc.
@@ -483,6 +480,9 @@ async function main(): Promise<void> {
   await createDummyCustomerMileage();
   // 더미 마일리지 로그 생성
   await createDummyCustomerMileageLog();
+
+  // 더미 방송인 생성 2 (promotion page 존재하지 않는 방송인)
+  await createDummyBroadcaster(prisma);
 }
 
 main()

--- a/libs/prisma-orm/prisma/seedData/dummyBc.ts
+++ b/libs/prisma-orm/prisma/seedData/dummyBc.ts
@@ -1,0 +1,17 @@
+import { Broadcaster, PrismaClient } from '@prisma/client';
+import { COMMON_DUMMY_PASSWORD } from './dummyData';
+
+export const createDummyBroadcaster = async (
+  prisma: PrismaClient,
+): Promise<Broadcaster> => {
+  return prisma.broadcaster.create({
+    data: {
+      avatar: 'https://picsum.photos/300/300',
+      email: 'testbc2@gmail.com',
+      password: COMMON_DUMMY_PASSWORD,
+      overlayUrl: `/testbc2@gmail.com`,
+      userName: '테스트방송인',
+      userNickname: '테스트방송인닉네임',
+    },
+  });
+};

--- a/libs/shared-types/src/lib/dto/broadcasterPromotionPage.dto.ts
+++ b/libs/shared-types/src/lib/dto/broadcasterPromotionPage.dto.ts
@@ -1,11 +1,8 @@
 import { IsString, IsInt, IsOptional } from 'class-validator';
 
 export class BroadcasterPromotionPageDto {
-  @IsString()
-  url: string;
-
-  @IsInt()
-  broadcasterId: number;
+  @IsInt() broadcasterId: number;
+  @IsOptional() @IsString() comment?: string;
 }
 
 export class BroadcasterPromotionPageUpdateDto {
@@ -15,6 +12,10 @@ export class BroadcasterPromotionPageUpdateDto {
   @IsOptional()
   @IsString()
   url?: string;
+
+  @IsOptional()
+  @IsString()
+  comment?: string;
 
   @IsOptional()
   @IsInt()


### PR DESCRIPTION
### 할일

- [크크쇼]: 관리자에 의해 상품홍보페이지 등록되지 않은 방송인 홍보페이지 생성하지않도록 구성
    - [x]  홍보페이지 데이터 불러오기
    - [x]  홍보페이지 없는 경우 렌더링하지 않도록 구성
- [api] : 상품홍보페이지 BroadcasterPromotionPage.url이 없는 경우 `${getKkshowUrl()}/bc/${방송인아이디}` 로 등록되도록 (라이브쇼핑등록시, 상품홍보도 함께 등록하는 절차도 확인 필요)
    - [x]  기본값 등록되도록 수정
- [관리자]: 상품홍보페이지탭 → BroadcasterPromotionPage.url이 없는 경우 `${getKkshowUrl()}/bc/${방송인아이디}` 로 보여지도록 구성
    - [x]  상품홍보페이지 등록시 URL 입력하지 않고 기본값이 설정되도록 수정
    - [x]  상품홍보페이지 정보 수정은 그대로 되도록 구성해두고, 필요한 경우에만 사용할 수 있도록 도움말 추가
- [크크쇼]: 방송채널 링크 디자인 수정 (짧은 링크 하나만 있어도 …표시 되는 등)
    - [x]  비로그인시 방송인 채널 목록 불러오지 못하는 현상 수정
    - [x]  디자인 수정
- 간단한 수정사항으로 판단해 함꼐 진행함 → [관리자,API] 방송인 홍보페이지 알림말 등록/수정
    - [x]  방송인 소개글 등록
    - [x]  방송인 소개글 수정

### 테스트케이스

- 홍보페이지
- [ ]  생성되지 않은 방송인의 홍보페이지에 접속할수 없다
- [ ]  홍보페이지 채널 목록이 올바르게 보여진다
- 관리자
- [ ]  상품홍보페이지 등록시 URL 입력칸이 없다
- [ ]  소개글 입력칸이 있다
- [ ]  소개글을 입력하지않아도 폼을 제출할 수 있다
- [ ]  상품홍보페이지 등록시 올바른 URL이 자동으로 입력된다
- [ ]  상품홍보페이지 URL과 소개글을 수정할 수 있다