### PR TITLE
[판매자센터] 상품 승인되지 않아도 라이브 쇼핑 진행 요청에서 상품 선택 가능

### DIFF
--- a/apps/admin/pages/live-shopping/[liveShoppingId].tsx
+++ b/apps/admin/pages/live-shopping/[liveShoppingId].tsx
@@ -5,6 +5,9 @@ import {
   AccordionIcon,
   AccordionItem,
   AccordionPanel,
+  Alert,
+  AlertDescription,
+  AlertTitle,
   Box,
   Button,
   Divider,
@@ -48,6 +51,7 @@ import dayjs from 'dayjs';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
+import { GoodsConfirmationStatuses } from '@prisma/client';
 
 function getDuration(startDate: Date, endDate: Date): string {
   if (startDate && startDate) {
@@ -173,14 +177,36 @@ export function LiveShoppingDetail(): JSX.Element {
         )}
         <Grid templateColumns="repeat(2, 1fr)" justifyItems="start" gap={4}>
           <Stack spacing={5}>
-            <Stack direction="row">
-              <Text as="span">상품명 :</Text>
-              <Text color="blue">
-                {liveShopping[0].broadcaster
-                  ? `${liveShopping[0].goods.goods_name} + ${liveShopping[0].broadcaster.userNickname}`
-                  : `${liveShopping[0].goods.goods_name}`}
-              </Text>
-            </Stack>
+            <Box>
+              <Stack direction="row">
+                <Text as="span">상품명 :</Text>
+                <Text color="blue">
+                  <Text as="span" color="red">
+                    {liveShopping[0].goods.confirmation?.status !==
+                    GoodsConfirmationStatuses.confirmed
+                      ? `(검수미완료) `
+                      : ''}
+                  </Text>
+                  {liveShopping[0].broadcaster
+                    ? `${liveShopping[0].goods.goods_name} + ${liveShopping[0].broadcaster.userNickname}`
+                    : `${liveShopping[0].goods.goods_name}`}
+                </Text>
+              </Stack>
+              {liveShopping[0].goods.confirmation?.status !==
+                GoodsConfirmationStatuses.confirmed && (
+                <Alert status="info" variant="left-accent" rounded="md">
+                  <AlertDescription>
+                    검수 미완료 상태이므로 상품 검수부터 진행해야 합니다.
+                    <Button
+                      size="xs"
+                      onClick={() => router.push(`/goods/${liveShopping[0].goodsId}`)}
+                    >
+                      상품 검수 이동하기
+                    </Button>
+                  </AlertDescription>
+                </Alert>
+              )}
+            </Box>
             <Stack direction="row">
               <Text as="span">판매자 :</Text>
               <Text color="blue">
@@ -375,7 +401,7 @@ export function LiveShoppingDetail(): JSX.Element {
 
               <Stack>
                 <Text>
-                  영상 URL (https://youtu.be/4pIuCJTMXQU 와 같은 형태로 입력해주세요)
+                  영상 URL ( https://youtu.be/4pIuCJTMXQU 와 같은 형태로 입력해주세요 )
                 </Text>
                 <Input
                   placeholder="https://youtu.be/4pIuCJTMXQU"

--- a/apps/web-seller/pages/mypage/live/regist.tsx
+++ b/apps/web-seller/pages/mypage/live/regist.tsx
@@ -9,7 +9,7 @@ export function Live(): JSX.Element {
 
   return (
     <MypageLayout>
-      <Container maxWidth="container.xl" my={12}>
+      <Container maxWidth="container.xl" my={[3, 6, 12]}>
         <Box as="section" mb={10}>
           <Flex direction="row" alignItems="center" justifyContent="space-between">
             <Button

--- a/libs/components-admin/src/lib/AdminLiveShoppingList.tsx
+++ b/libs/components-admin/src/lib/AdminLiveShoppingList.tsx
@@ -1,3 +1,4 @@
+import NextLink from 'next/link';
 import { Box, Button, Heading, Tooltip, Text, Link } from '@chakra-ui/react';
 import { ExternalLinkIcon } from '@chakra-ui/icons';
 import { GridColumns, GridRowData } from '@material-ui/data-grid';
@@ -7,6 +8,7 @@ import { useAdminLiveShoppingList, useProfile } from '@project-lc/hooks';
 import { getLiveShoppingProgress, LiveShoppingWithGoods } from '@project-lc/shared-types';
 import dayjs from 'dayjs';
 import { getCustomerWebHost } from '@project-lc/utils';
+import { GoodsConfirmationStatuses } from '@prisma/client';
 
 export function AdminLiveShoppingList({
   onRowClick,
@@ -31,10 +33,12 @@ export function AdminLiveShoppingList({
       flex: 1,
       renderCell: ({ row }) => (
         <Tooltip label="상세페이지로 이동">
-          <Link href={`/live-shopping/${row.id}`} color="blue">
-            {row.liveShoppingName ||
-              '라이브 쇼핑명은 라이브 쇼핑 확정 후, 등록하면 됩니다.'}
-          </Link>
+          <NextLink href={`/live-shopping/${row.id}`} passHref>
+            <Link color="blue">
+              {row.liveShoppingName ||
+                '라이브 쇼핑명은 라이브 쇼핑 확정 후, 등록하면 됩니다.'}
+            </Link>
+          </NextLink>
         </Tooltip>
       ),
     },
@@ -56,7 +60,15 @@ export function AdminLiveShoppingList({
             </Link>
           </Tooltip>
         ) : (
-          <Text>{row.goods.goods_name}</Text>
+          <Text>
+            <Text as="span" color="red" fontSize="xs">
+              {row.goods.confirmation &&
+              row.goods.confirmation?.status !== GoodsConfirmationStatuses.confirmed
+                ? '(검수미완료) '
+                : ''}
+            </Text>
+            {row.goods.goods_name}
+          </Text>
         ),
     },
     {

--- a/libs/components-core/src/lib/ChakraAutoComplete.tsx
+++ b/libs/components-core/src/lib/ChakraAutoComplete.tsx
@@ -13,6 +13,7 @@ import {
   List,
   ListItem,
   Spinner,
+  Text,
   useColorModeValue,
 } from '@chakra-ui/react';
 import { useAutocomplete } from '@material-ui/lab';
@@ -65,9 +66,9 @@ export function ChakraAutoComplete<T = any>({
       <Box {...getRootProps()}>
         {label ? (
           <FormLabel {...getInputLabelProps()}>
-            <Heading as="h6" size="sm">
+            <Text as="h6" size="sm" fontWeight="bold">
               {label}
-            </Heading>
+            </Text>
           </FormLabel>
         ) : null}
 

--- a/libs/components-seller/src/lib/LiveShoppingList.tsx
+++ b/libs/components-seller/src/lib/LiveShoppingList.tsx
@@ -106,12 +106,35 @@ export function LiveShoppingList(): JSX.Element {
   };
   const columns: GridColumns = [
     {
+      headerName: '',
+      field: '',
+      width: 140,
+      sortable: false,
+      disableColumnMenu: true,
+      renderCell: ({ row }: GridRowData) => (
+        <Stack direction="row">
+          <Button size="xs" colorScheme="blue" onClick={() => handleDetailOnOpen(row)}>
+            상세보기
+          </Button>
+          {row.progress === 'registered' ? (
+            <Button
+              size="xs"
+              colorScheme="orange"
+              onClick={() => handleDeleteClick(row.id)}
+            >
+              삭제
+            </Button>
+          ) : null}
+        </Stack>
+      ),
+    },
+    {
       field: 'liveShoppingName',
       headerName: '라이브 쇼핑명',
       minWidth: 250,
       flex: 1,
       valueFormatter: ({ row }) =>
-        row.liveShoppingName || '(라이브 쇼핑명은 라이브 쇼핑 확정 후, 등록됩니다.)',
+        row.liveShoppingName || '(라이브쇼핑 진행 확정 후 등록예정)',
     },
     {
       field: 'goods_name',
@@ -122,7 +145,13 @@ export function LiveShoppingList(): JSX.Element {
         return (
           <Tooltip label="상품페이지로 이동">
             <Link href={`${getCustomerWebHost()}/goods/${row.goodsId}`} isExternal>
-              {row.goods.goods_name} <ExternalLinkIcon mx="2px" />
+              <Text as="span" fontSize="xs">
+                {row.goods?.confirmation &&
+                row.goods?.confirmation?.status !== 'confirmed'
+                  ? '(검수미완료) '
+                  : ''}
+              </Text>
+              {row.goods.goods_name} <ExternalLinkIcon mx="2px" />{' '}
             </Link>
           </Tooltip>
         );
@@ -218,29 +247,6 @@ export function LiveShoppingList(): JSX.Element {
         }
         return <Text>업로드대기</Text>;
       },
-    },
-    {
-      headerName: '',
-      field: '',
-      width: 100,
-      sortable: false,
-      disableColumnMenu: true,
-      renderCell: ({ row }: GridRowData) => (
-        <Stack direction="row">
-          <Button size="xs" colorScheme="blue" onClick={() => handleDetailOnOpen(row)}>
-            상세보기
-          </Button>
-          {row.progress === 'registered' ? (
-            <Button
-              size="xs"
-              colorScheme="orange"
-              onClick={() => handleDeleteClick(row.id)}
-            >
-              삭제
-            </Button>
-          ) : null}
-        </Stack>
-      ),
     },
   ];
 

--- a/libs/components-seller/src/lib/LiveShoppingRegistForm.tsx
+++ b/libs/components-seller/src/lib/LiveShoppingRegistForm.tsx
@@ -1,22 +1,24 @@
 import {
   Alert,
   AlertIcon,
+  Badge,
   Box,
   Button,
   Collapse,
   Flex,
   FormControl,
   FormErrorMessage,
-  Heading,
   Image,
   Input,
   InputGroup,
   InputRightAddon,
+  ListItem,
   Radio,
   RadioGroup,
   Spinner,
   Stack,
   Text,
+  UnorderedList,
   useDisclosure,
   useMergeRefs,
   useToast,
@@ -34,7 +36,6 @@ import {
   ApprovedGoodsListItem,
   LiveShoppingInput,
   LiveShoppingRegistDTO,
-  LIVE_SHOPPING_PROGRESS,
 } from '@project-lc/shared-types';
 import { liveShoppingRegist } from '@project-lc/stores';
 import dayjs from 'dayjs';
@@ -99,9 +100,7 @@ export function LiveShoppingRegistForm(): JSX.Element {
       desiredPeriod: data.desiredPeriod,
     };
 
-    if (contacts.data) {
-      dto.contactId = contacts.data.id;
-    }
+    if (contacts.data) dto.contactId = contacts.data.id;
     dto.requests = data.requests;
 
     const goodsId = watch('goods_id');
@@ -159,7 +158,6 @@ export function LiveShoppingRegistForm(): JSX.Element {
                     }
                   }}
                 />
-
                 {selectedGoods && (
                   <Box mt={2}>
                     <GoodsSummary goodsId={selectedGoods.id} />
@@ -215,9 +213,9 @@ function LiveShoppingDesiredPeriod(): JSX.Element {
   }, [isOpen]);
   return (
     <Stack>
-      <Heading as="h6" size="sm">
+      <Text as="h6" size="sm" fontWeight="bold">
         희망 진행 기간
-      </Heading>
+      </Text>
       <RadioGroup
         value={watch('desiredPeriod')}
         onChange={(newV) => {
@@ -270,9 +268,9 @@ function LiveShoppingDesiredCommission(): JSX.Element {
 
   return (
     <FormControl isInvalid={!!errors.desiredCommission}>
-      <Heading as="h6" size="sm">
+      <Text as="h6" size="sm" fontWeight="bold">
         희망 판매 수수료
-      </Heading>
+      </Text>
       <Text color="gray.500" fontSize="sm">
         판매수수료가 높을수록 방송인 매칭 조율이 원만하며, 진행이 빠를 수 있습니다.
       </Text>
@@ -302,29 +300,50 @@ interface GoodsSummaryProps {
 }
 function GoodsSummary({ goodsId }: GoodsSummaryProps): JSX.Element | null {
   const goods = useGoodsById(goodsId);
-
-  const goodsFirstImage = useMemo(
-    () => goods.data?.image.find((i) => i.cut_number === 1),
-    [goods.data?.image],
+  const goodsFirstImage = useMemo(() => goods.data?.image?.[0], [goods.data?.image]);
+  const isConfirmRequired = useMemo(
+    () => goods.data?.confirmation.status !== 'confirmed',
+    [goods.data?.confirmation.status],
   );
-
   if (goods.isLoading) return <Spinner />;
-  if (!goods.data) return null;
   if (goods.isError) return null;
+  if (!goods.data) return null;
 
   return (
-    <Flex maxW="300px" alignItems="center">
+    <Flex gap={2}>
+      {goodsFirstImage && (
+        <Image
+          rounded="md"
+          width={50}
+          height={50}
+          alt={goods.data.goods_name}
+          objectFit="cover"
+          src={goodsFirstImage.image}
+        />
+      )}
+
       <Box>
-        {goodsFirstImage && <Image width={50} height={50} src={goodsFirstImage.image} />}
-      </Box>
-      <Box ml={2}>
-        <Text fontWeight="bold" isTruncated>
-          {goods.data.goods_name}
+        {isConfirmRequired && (
+          <Badge variant="subtle" colorScheme="red">
+            검수 미완료 상태
+          </Badge>
+        )}
+        <Text fontWeight="bold">{goods.data.goods_name}</Text>
+        <Text>{goods.data.summary}</Text>
+        <Text color="gray" fontSize="sm">
+          {dayjs(goods.data.regist_date).format('YYYY년 MM월 DD일 HH:mm:ss')} 등록
         </Text>
-        <Text isTruncated>{goods.data.summary}</Text>
-        <Text isTruncated>
-          {dayjs(goods.data.regist_date).format('YYYY년 MM월 DD일 HH:mm:ss')}
-        </Text>
+
+        {isConfirmRequired && (
+          <UnorderedList mt={2}>
+            <ListItem color="gray" fontSize="sm">
+              <Text>
+                검수 미완료 상태의 상품은 상품 검수가 거절되는 경우 라이브쇼핑도 함께
+                거절될 수 있습니다.
+              </Text>
+            </ListItem>
+          </UnorderedList>
+        )}
       </Box>
     </Flex>
   );

--- a/libs/components-seller/src/lib/LiveShoppingRegistManagerContacts.tsx
+++ b/libs/components-seller/src/lib/LiveShoppingRegistManagerContacts.tsx
@@ -3,12 +3,12 @@ import {
   FormControl,
   FormErrorMessage,
   FormLabel,
-  Heading,
   Input,
   InputGroup,
   Radio,
   RadioGroup,
   Stack,
+  Text,
 } from '@chakra-ui/react';
 import { useDefaultContacts, useProfile } from '@project-lc/hooks';
 import { emailRegisterOptions, LiveShoppingInput } from '@project-lc/shared-types';
@@ -56,9 +56,9 @@ export function LiveShoppingManagerContacts(): JSX.Element {
 
   return (
     <Stack spacing={2}>
-      <Heading as="h6" size="sm">
+      <Text as="h6" size="sm" fontWeight="bold">
         담당자 연락처
-      </Heading>
+      </Text>
 
       <Stack spacing={2}>
         {!data ? (

--- a/libs/components-seller/src/lib/LiveShoppingRegistRequestField.tsx
+++ b/libs/components-seller/src/lib/LiveShoppingRegistRequestField.tsx
@@ -1,5 +1,5 @@
 import { WarningIcon } from '@chakra-ui/icons';
-import { Box, Heading, Stack, Text, Textarea } from '@chakra-ui/react';
+import { Box, Stack, Text, Textarea } from '@chakra-ui/react';
 import { LiveShoppingInput } from '@project-lc/shared-types';
 import { useFormContext } from 'react-hook-form';
 
@@ -19,21 +19,19 @@ export function LiveShoppingRegistRequestField(): JSX.Element {
     <Box w="100%">
       <Stack spacing={2}>
         <Stack direction="row">
-          <Heading as="h6" size="sm">
+          <Text as="h6" size="sm" fontWeight="bold">
             요청사항
-          </Heading>
+          </Text>
           <Text fontSize="xs">(최대 500자)</Text>
         </Stack>
         <Textarea
           placeholder={examplePlaceholder}
           height={300}
           resize="none"
+          size="sm"
           isInvalid={!!errors.requests}
           {...register('requests', {
-            maxLength: {
-              value: 500,
-              message: '500자 이하로 작성해주세요.',
-            },
+            maxLength: { value: 500, message: '500자 이하로 작성해주세요.' },
           })}
         />
         {errors.requests && (

--- a/libs/components-shared/src/lib/LiveShoppingDetailDialog.tsx
+++ b/libs/components-shared/src/lib/LiveShoppingDetailDialog.tsx
@@ -13,6 +13,7 @@ import {
   Stack,
   Text,
 } from '@chakra-ui/react';
+import { GoodsConfirmationStatuses } from '@prisma/client';
 import { GridTableItem } from '@project-lc/components-layout/GridTableItem';
 import { LiveShoppingWithGoods, LIVE_SHOPPING_PROGRESS } from '@project-lc/shared-types';
 import dayjs from 'dayjs';
@@ -57,8 +58,18 @@ export function LiveShoppingDetailDialog(
                 />
               )}
 
-              {type === 'broadcaster' && (
+              {type === 'broadcaster' ? (
                 <GridTableItem title="상품명" value={liveShopping.goods.goods_name} />
+              ) : (
+                <GridTableItem
+                  title="상품명"
+                  value={
+                    (liveShopping.goods.confirmation?.status !==
+                    GoodsConfirmationStatuses.confirmed
+                      ? '(검수미완료) '
+                      : '') + liveShopping.goods.goods_name
+                  }
+                />
               )}
 
               <GridTableItem

--- a/libs/nest-modules-goods/src/goods/goods.service.ts
+++ b/libs/nest-modules-goods/src/goods/goods.service.ts
@@ -649,19 +649,10 @@ export class GoodsService {
     const goodsIds = await this.prisma.goods.findMany({
       where: {
         seller: { id: sellerId },
-        AND: {
-          confirmation: {
-            status: 'confirmed',
-          },
-          goods_status: 'normal',
-        },
+        AND: { goods_status: 'normal', confirmation: { status: { not: 'rejected' } } },
       },
       select: {
-        confirmation: {
-          select: {
-            firstmallGoodsConnectionId: true,
-          },
-        },
+        confirmation: { select: { firstmallGoodsConnectionId: true } },
         goods_name: true,
         id: true,
       },

--- a/libs/nest-modules-liveshopping/src/live-shopping/live-shopping.service.ts
+++ b/libs/nest-modules-liveshopping/src/live-shopping/live-shopping.service.ts
@@ -71,7 +71,13 @@ export class LiveShoppingService {
       },
       include: {
         goods: {
-          select: { goods_name: true, summary: true, image: true, options: true },
+          select: {
+            goods_name: true,
+            summary: true,
+            image: true,
+            options: true,
+            confirmation: { select: { status: true } },
+          },
         },
         seller: { select: { sellerShop: true } },
         broadcaster: {

--- a/libs/shared-types/src/lib/res-types/liveShoppingWithGoods.res.ts
+++ b/libs/shared-types/src/lib/res-types/liveShoppingWithGoods.res.ts
@@ -3,6 +3,7 @@ import {
   BroadcasterChannel,
   BroadcasterPromotionPage,
   Goods,
+  GoodsConfirmation,
   GoodsImages,
   GoodsOptions,
   LiveShopping,
@@ -17,6 +18,7 @@ export interface LiveShoppingWithGoods extends LiveShopping {
     summary: string;
     image: GoodsImages[];
     options: GoodsOptions[];
+    confirmation?: Pick<GoodsConfirmation, 'status'>;
   };
   seller: {
     sellerShop: SellerShop;


### PR DESCRIPTION
# 개요

- 문제 정의
소상공인은 판매자 센터에 들어오는 횟수가 적을 수록 좋다.
- 현상황 
상품을 등록하고 상품 승인되기까지 기다리다 승인되면 이후 라이브 쇼핑을 등록한다.
- 기대 효과
상품을 등록 후 바로 라이브 쇼핑을 등록할 수 있다.
- 변경 사항 
상품 승인 되지 않아도 라이브 쇼핑 등록 페이지에서 상품 선택이 가능하다.

# 할일

- 판매자
    - [x]  라이브쇼핑 등록시 검수 완료되지 않은 상품 선택가능하도록 수정
    - [x]  검수완료되지 않은 상품이 등록된 경우 상품 검수 미완료 표시 추가
        - [x]  등록화면
        - [x]  라이브쇼핑 목록
        - [x]  상세정보
- 관리자
    - [x]  관리자 라이브쇼핑 관리 검수 미완료 표시 추가
        - [x]  라이브쇼핑 목록
        - [x]  라이브쇼핑 정보 수정
            - [x]  미완료시 검수페이지로 이동 기능

# 테스트케이스

판매자

- [ ]  라이브쇼핑 등록시 검수미완료된 상품도 선택가능하다
- [ ]  검수완료되지 않은 상품이 등록된 경우 상품 검수 미완료 표시가 올바르게 보여진다.
    - [ ]  등록화면
    - [ ]  라이브쇼핑 목록
    - [ ]  상세정보

관리자

- [ ]  라이브쇼핑 목록에 상품이 검수 미완료인경우 미완료 표시가 올바르게 보여진다.
- [ ]  라이브쇼핑 정보 수정창에서 검수 미완료인 경우 미완료 표시가 올바르게 보여진다.
    - [ ]  검수 미완료시 해당 상품 검수페이지로 이동할 수 있는 버튼이 올바르게 보여진다
    - [ ]  검수 미완료시 해당 상품 검수페이지로 이동할 수 있는 버튼이 올바르게 작동한다.