### PR TITLE
[http] useProfile 콘솔에 401 에러메시지 뜨지 않도록 개선 (보안)

### DIFF
--- a/apps/admin/pages/admin-manage/index.tsx
+++ b/apps/admin/pages/admin-manage/index.tsx
@@ -10,10 +10,7 @@ export function AdminManagePage(): JSX.Element {
   const { data: profile, isLoading: profileIsLoading } = useProfile();
 
   if (!profileIsLoading && profile?.adminClass !== 'super') {
-    toast({
-      title: '권한없는 계정',
-      status: 'error',
-    });
+    toast({ title: '권한없는 계정', status: 'error' });
     router.push('/admin');
   }
 

--- a/libs/hooks/src/lib/queries/useProfile.tsx
+++ b/libs/hooks/src/lib/queries/useProfile.tsx
@@ -3,18 +3,19 @@ import { AxiosError } from 'axios';
 import { useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
 import axios from '../../axios';
 
-export const getProfile = async (): Promise<UserProfileRes> => {
+type ProfileRes = UserProfileRes | null;
+export const getProfile = async (): Promise<ProfileRes> => {
   return axios
-    .get<UserProfileRes>('/auth/profile', {
+    .get<ProfileRes>('/auth/profile', {
       params: { appType: process.env.NEXT_PUBLIC_APP_TYPE },
     })
     .then((res) => res.data);
 };
 
 export const useProfile = (
-  options?: UseQueryOptions<UserProfileRes, AxiosError>,
-): UseQueryResult<UserProfileRes, AxiosError> => {
-  return useQuery<UserProfileRes, AxiosError>('Profile', getProfile, {
+  options?: UseQueryOptions<ProfileRes, AxiosError>,
+): UseQueryResult<ProfileRes, AxiosError> => {
+  return useQuery<ProfileRes, AxiosError>('Profile', getProfile, {
     retry: false,
     ...options,
   });


### PR DESCRIPTION
profile 요청의 catch 구문에서 에러미반환 처리