### PR TITLE
feat: 출고 조회 기능 추가

### DIFF
--- a/apps/admin/pages/order/exports/[exportCode].tsx
+++ b/apps/admin/pages/order/exports/[exportCode].tsx
@@ -58,7 +58,7 @@ export default function ExportsDetail(): JSX.Element {
             <Stack>
               {exp.data.bundleExports.map((bundle) => (
                 <Box key={bundle.exportCode}>
-                  <NextLink passHref href={`/mypage/orders/exports/${bundle.exportCode}`}>
+                  <NextLink passHref href={`/orders/exports/${bundle.exportCode}`}>
                     <Link color="blue.500" fontSize="sm">
                       {bundle.exportCode}
                     </Link>

--- a/apps/admin/pages/order/exports/[exportCode].tsx
+++ b/apps/admin/pages/order/exports/[exportCode].tsx
@@ -1,0 +1,80 @@
+import { Box, Button, Center, Link, Stack, Text } from '@chakra-ui/react';
+import { SectionWithTitle } from '@project-lc/components-layout/SectionWithTitle';
+import { ExportDetailSummary } from '@project-lc/components-seller/ExportDetailSummary';
+import { ExportDetailTitle } from '@project-lc/components-seller/ExportDetailTitle';
+import { DeliveryTrackingList } from '@project-lc/components-shared/delivery-tracking/DeliveryTracking';
+import { OrderDetailLoading } from '@project-lc/components-shared/order/OrderDetailLoading';
+import { useExportByCode } from '@project-lc/hooks';
+import NextLink from 'next/link';
+import { useRouter } from 'next/router';
+import AdminPageLayout from '@project-lc/components-admin/AdminPageLayout';
+
+export default function ExportsDetail(): JSX.Element {
+  const router = useRouter();
+  const exportCode = router.query.exportCode as string;
+  const exp = useExportByCode(exportCode, { enabled: !!exportCode });
+
+  if (exp.isLoading) {
+    return (
+      <AdminPageLayout>
+        <OrderDetailLoading />
+      </AdminPageLayout>
+    );
+  }
+
+  if (!exp.isLoading && !exp.data) {
+    return (
+      <AdminPageLayout>
+        <Box m="auto" maxW="4xl">
+          <Stack spacing={2}>
+            <Center>
+              <Text>출고 데이터를 불러오지 못했습니다.</Text>
+            </Center>
+            <Center>
+              <Text>없는 출고이거나 올바르지 못한 출고번호입니다.</Text>
+            </Center>
+            <Center>
+              <Button onClick={() => router.push('/order/exports')}>돌아가기</Button>
+            </Center>
+          </Stack>
+        </Box>
+      </AdminPageLayout>
+    );
+  }
+
+  return (
+    <AdminPageLayout>
+      <Stack m="auto" maxW="4xl" mt={{ base: 2, md: 8 }} spacing={6} p={2}>
+        <Box as="section">
+          <ExportDetailTitle exportData={exp.data} />
+        </Box>
+
+        <Box as="section">
+          <ExportDetailSummary exportData={exp.data} />
+        </Box>
+
+        {exp.data.bundleExportCode && (
+          <SectionWithTitle title="합포장 출고 정보">
+            <Stack>
+              {exp.data.bundleExports.map((bundle) => (
+                <Box key={bundle.exportCode}>
+                  <NextLink passHref href={`/mypage/orders/exports/${bundle.exportCode}`}>
+                    <Link color="blue.500" fontSize="sm">
+                      {bundle.exportCode}
+                    </Link>
+                  </NextLink>
+                </Box>
+              ))}
+            </Stack>
+          </SectionWithTitle>
+        )}
+
+        <SectionWithTitle title="출고 주문 정보">
+          <Stack spacing={4}>
+            <DeliveryTrackingList orderCode={exp.data.order.orderCode} />
+          </Stack>
+        </SectionWithTitle>
+      </Stack>
+    </AdminPageLayout>
+  );
+}

--- a/apps/admin/pages/order/exports/[exportCode].tsx
+++ b/apps/admin/pages/order/exports/[exportCode].tsx
@@ -58,7 +58,7 @@ export default function ExportsDetail(): JSX.Element {
             <Stack>
               {exp.data.bundleExports.map((bundle) => (
                 <Box key={bundle.exportCode}>
-                  <NextLink passHref href={`/orders/exports/${bundle.exportCode}`}>
+                  <NextLink passHref href={`/order/exports/${bundle.exportCode}`}>
                     <Link color="blue.500" fontSize="sm">
                       {bundle.exportCode}
                     </Link>

--- a/apps/admin/pages/order/exports/index.tsx
+++ b/apps/admin/pages/order/exports/index.tsx
@@ -1,0 +1,16 @@
+import { Box, Heading } from '@chakra-ui/react';
+import { AdminOrderExportList } from '@project-lc/components-admin/AdminOrderExportList';
+import AdminPageLayout from '@project-lc/components-admin/AdminPageLayout';
+
+export function ExportsIndex(): JSX.Element {
+  return (
+    <AdminPageLayout>
+      <Box>
+        <Heading>출고목록</Heading>
+        <AdminOrderExportList />
+      </Box>
+    </AdminPageLayout>
+  );
+}
+
+export default ExportsIndex;

--- a/apps/web-seller/pages/mypage/orders/exports/[exportCode].tsx
+++ b/apps/web-seller/pages/mypage/orders/exports/[exportCode].tsx
@@ -52,19 +52,21 @@ export default function ExportsDetail(): JSX.Element {
           <ExportDetailSummary exportData={exp.data} />
         </Box>
 
-        <SectionWithTitle title="합포장 출고 정보">
-          <Stack>
-            {exp.data.bundleExports.map((bundle) => (
-              <Box key={bundle.exportCode}>
-                <NextLink passHref href={`/mypage/orders/exports/${bundle.exportCode}`}>
-                  <Link color="blue.500" fontSize="sm">
-                    {bundle.exportCode}
-                  </Link>
-                </NextLink>
-              </Box>
-            ))}
-          </Stack>
-        </SectionWithTitle>
+        {exp.data.bundleExportCode && (
+          <SectionWithTitle title="합포장 출고 정보">
+            <Stack>
+              {exp.data.bundleExports.map((bundle) => (
+                <Box key={bundle.exportCode}>
+                  <NextLink passHref href={`/mypage/orders/exports/${bundle.exportCode}`}>
+                    <Link color="blue.500" fontSize="sm">
+                      {bundle.exportCode}
+                    </Link>
+                  </NextLink>
+                </Box>
+              ))}
+            </Stack>
+          </SectionWithTitle>
+        )}
 
         <SectionWithTitle title="출고 주문 정보">
           <Stack spacing={4}>

--- a/libs/components-admin/src/lib/AdminOrderExportList.tsx
+++ b/libs/components-admin/src/lib/AdminOrderExportList.tsx
@@ -1,0 +1,122 @@
+import { Box, Link, Text } from '@chakra-ui/react';
+import { GridColumns, GridRowData, GridRowId, GridToolbar } from '@material-ui/data-grid';
+import { OrderProcessStep } from '@prisma/client';
+import { ChakraDataGrid } from '@project-lc/components-core/ChakraDataGrid';
+import { OrderStatusBadge } from '@project-lc/components-shared/order/OrderStatusBadge';
+import { useExports } from '@project-lc/hooks';
+import { convertkkshowOrderStatusToString } from '@project-lc/shared-types';
+import dayjs from 'dayjs';
+import NextLink from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+
+const columns: GridColumns = [
+  {
+    width: 130,
+    field: 'exportCode',
+    headerName: '출고번호',
+    renderCell: ({ row }) => (
+      <NextLink href={`/order/exports/${row.exportCode}`} passHref>
+        <Link href={`/order/exports/${row.exportCode}`}>
+          <Text as="button" size="sm" color="blue">
+            {row.exportCode}
+          </Text>
+        </Link>
+      </NextLink>
+    ),
+  },
+  {
+    minWidth: 180,
+    field: 'orderItem_name',
+    headerName: '주문상품명',
+    valueGetter: ({ row }: GridRowData) =>
+      row.items.length > 1
+        ? `${row.items[0].goodsName} 외 ${row.items.length} 개의 상품`
+        : row.items[0].goodsName,
+    flex: 1,
+  },
+  {
+    width: 130,
+    field: 'seller.sellerShop.shopName',
+    headerName: '판매자',
+    valueGetter: ({ row }: GridRowData) => row.seller?.sellerShop?.shopName,
+  },
+  {
+    width: 120,
+    field: 'order.ordererName',
+    headerName: '주문자',
+    valueGetter: ({ row }) => row.order.ordererName,
+    renderCell: ({ row }) => <Text>{row.order.ordererName}</Text>,
+  },
+  { width: 120, field: 'deliveryCompany', headerName: '배송사' },
+  { width: 120, field: 'deliveryNumber', headerName: '송장번호' },
+  {
+    field: 'status',
+    headerName: '출고상태',
+    valueGetter: ({ row }) => convertkkshowOrderStatusToString(row.status),
+    renderCell: ({ row }) => (
+      <Box lineHeight={2}>
+        <OrderStatusBadge step={row.status as OrderProcessStep} />
+      </Box>
+    ),
+  },
+  {
+    field: 'createDate',
+    headerName: '출고날짜',
+    valueFormatter: ({ row }) => dayjs(row.exportDate).format('YYYY-MM-DD HH:mm:ss'),
+    valueGetter: ({ row }) => row.exportDate,
+    type: 'date',
+    width: 160,
+  },
+];
+
+export function AdminOrderExportList(): JSX.Element {
+  const mapPageToNextCursor = useRef<{ [page: number]: GridRowId }>({});
+  const rowsPerPageOptions = useRef<number[]>([1, 10, 20, 50, 100]); // 페이지당 행 select
+  const [pageSize, setPageSize] = useState(100); // 페이지당 행 기본 100개
+  const [page, setPage] = useState(0); // 페이지
+  const handlePageChange = (newPage: number): void => {
+    setPage(newPage);
+  };
+
+  const { data, isLoading } = useExports({
+    withSellerInfo: true,
+    skip: page,
+    take: pageSize,
+  });
+  useEffect(() => {
+    if (!isLoading && data?.edges && data.nextCursor) {
+      // 다음페이지 존재하는 경우 page에 해당하는 인덱스에 skip의 값을 저장해둠
+      mapPageToNextCursor.current[page] = data.nextCursor;
+    }
+  }, [data, isLoading, page]);
+
+  // mui datagrid serverside 페이지네이션 참고 https://github.com/mui/mui-x/blob/v5.11.1/docs/data/data-grid/pagination/CursorPaginationGrid.tsx
+  // Some API clients return undefined while loading
+  // Following lines are here to prevent `rowCountState` from being undefined during the loading
+  const [rowCountState, setRowCountState] = useState(data?.totalCount || 0);
+  useEffect(() => {
+    setRowCountState((prevRowCountState) =>
+      data?.totalCount ? data.totalCount : prevRowCountState,
+    );
+  }, [data, setRowCountState]);
+  return (
+    <ChakraDataGrid
+      components={{ Toolbar: GridToolbar }}
+      columns={columns}
+      page={page}
+      rowsPerPageOptions={rowsPerPageOptions.current}
+      onPageSizeChange={(newPageSize) => setPageSize(newPageSize)}
+      rows={data?.edges || []}
+      minH={500}
+      autoHeight
+      loading={isLoading}
+      disableSelectionOnClick
+      pageSize={pageSize}
+      pagination
+      rowCount={rowCountState}
+      density="compact"
+      paginationMode="server"
+      onPageChange={handlePageChange}
+    />
+  );
+}

--- a/libs/components-constants/src/lib/navigation.ts
+++ b/libs/components-constants/src/lib/navigation.ts
@@ -231,8 +231,8 @@ export const broadcasterCenterMypageNavLinks: Array<MypageLink> = [
 /** 관리자 페이지 상단 네비바 링크 */
 export const adminNavItems: Array<NavItem> = [
   {
-    label: '크크마켓',
-    href: 'https://k-kmarket.com/',
+    label: '크크쇼',
+    href: 'https://크크쇼.com/',
     isExternal: true,
   },
 ];
@@ -299,6 +299,7 @@ export const adminSidebarMenuList: SidebarMenuLink[] = [
       { name: '주문 목록', href: '/order/list', icon: FcList },
       { name: '환불요청 처리', href: '/order/refund', icon: FcMoneyTransfer },
       { name: '마일리지 설정', href: '/order/mileage-setting', icon: FcRating },
+      { name: '출고 목록', href: '/order/exports', icon: FcList },
     ],
   },
   {

--- a/libs/components-shared/src/lib/delivery-tracking/DeliveryTracking.tsx
+++ b/libs/components-shared/src/lib/delivery-tracking/DeliveryTracking.tsx
@@ -147,7 +147,7 @@ export function DeliveryTrackingList({
   );
   return (
     <Box mt={4} mb={40}>
-      {exportsData.data?.list.map((exp) => (
+      {exportsData.data?.edges.map((exp) => (
         <DeliveryTracking key={exp.exportCode} exportData={exp} />
       ))}
     </Box>

--- a/libs/shared-types/src/lib/dto/kkshowExport.dto.ts
+++ b/libs/shared-types/src/lib/dto/kkshowExport.dto.ts
@@ -91,4 +91,9 @@ export class FindExportListDto extends DefaultPaginationDto {
   @IsOptional()
   @Type(() => String)
   orderCode?: string;
+
+  @Type(() => Boolean)
+  @IsOptional()
+  @IsBoolean()
+  withSellerInfo?: boolean = false;
 }

--- a/libs/shared-types/src/lib/res-types/export.res.ts
+++ b/libs/shared-types/src/lib/res-types/export.res.ts
@@ -5,7 +5,10 @@ import {
   GoodsImages,
   Order,
   OrderItemOption,
+  Seller,
+  SellerShop,
 } from '@prisma/client';
+import { PaginationResult } from '../core/paginationResult';
 
 /** ExportItemOption 형태로 바꾸기 전 출고상세조회시 출고상품 형태 */
 export type findExportItemData = ExportItem & {
@@ -43,14 +46,14 @@ export type ExportRes = Export & {
   items: ExportItemOption[];
   order: Order;
   bundleExports: Export[];
+  seller?: Seller & { sellerShop?: SellerShop };
 }; // order의 주문자정보, 받는사람정보, 배송메모 필요
 
 export type ExportListItem = Omit<ExportRes, 'bundleExports'>;
 /** 출고 목록 조회 리턴값 */
-export type ExportListRes = {
-  list: ExportListItem[];
+export interface ExportListRes extends PaginationResult<ExportListItem> {
   totalCount: number;
-};
+}
 
 /** 출고 생성 리턴값 */
 export type ExportCreateRes = {


### PR DESCRIPTION
- 현재 출고정보를 어디서도 확인할 수 없음
- 관리자에서 출고 관련된 사항들을 조회할 수 있어야 한다. ( 판매자 센터에서 등록한 출고 정보 )
- 페이지처리
    - 판매자별 필터링 (모두 불러온다음 필터링 or 판매자 클릭시 해당 판매자 정보만 or …)
    - 기간별 필터링
- 출고 상세 정보 조회

# 할일

- [x]  출고정보조회 목록
- [x]  페이지네이션
- [x]  기간필터링
- [x]  개별출고상세정보페이지

# 테스트케이스

- [x]  출고목록을 올바르게 확인할 수 있다.
- [x]  페이지네이션이 올바르게 작동한다.
- [x]  판매자별로 필터링할 수 있다.
- [x]  기간별로 필터링할 수 있다.
- [x]  출고 상세 정보를 조회할 수 있다.