### PR TITLE
fix(overlay-controller): 관리자메시지보내기란 활성화 처리 구분 제거

### DIFF
--- a/apps/overlay-controller/src/lib/admin.js
+++ b/apps/overlay-controller/src/lib/admin.js
@@ -301,7 +301,6 @@ $(document).ready(function ready() {
   $('#panel-activate-checkbox').click(function panelActivateButton() {
     $('.mid-area')
       .find('button')
-      .not('.admin-to-bc-live-state-board-box button')
       .prop('disabled', (_, val) => !val);
   });
 

--- a/apps/overlay-controller/src/lib/admin.js
+++ b/apps/overlay-controller/src/lib/admin.js
@@ -19,7 +19,6 @@ const liveShoppingStateSocket = io(
 socket.on('creator list from server', (data) => {
   if (data && data.length !== 0) {
     $('#connection-status').text('✔️ 정상');
-    $('.admin-to-bc-live-state-board-box button').attr('disabled', false);
   } else {
     $('#connection-status').text('❌ 연결되지 않음');
   }


### PR DESCRIPTION
- 크리에이터 연결이 됐음에도 크리에이터 연결 되지 않음으로 표시 → **연결되지않음으로 표시된 경우 관리자 메시지 보내기란이 비활성화되도록 처리되어 있음**
- 관리자 메시지 보내기가 활성화 되지 않음

# 할일

- [x]  관리자메시지보내기란 연결상태와 상관없이 전체활성화 버튼에 따라 비활성화/활성화 처리 진행되도록 구성

# 테스트케이스

- [ ]  관리자메시지 보내기란이 연결상태와 상관없이 전체 활성화 버튼에 따라 활성화/비활성화 된다