### PR TITLE
fix(kkshow): 후원메시지 입력 줌인되지 않도록 수정

### DIFF
--- a/libs/components-web-kkshow/src/lib/goods/GoodsViewPurchaseBox.tsx
+++ b/libs/components-web-kkshow/src/lib/goods/GoodsViewPurchaseBox.tsx
@@ -415,7 +415,6 @@ function GoodsViewBroadcasterSupportBox({
                     minH="55px"
                     resize="none"
                     rounded="md"
-                    size="sm"
                     placeholder="방송인 후원 메시지 도네이션 표시글"
                     value={supportMessage}
                     onChange={(e) => onSupMsgChange(e.target.value)}


### PR DESCRIPTION
# [크크쇼] (iOS) 상품 구매메시지 입력시 줌인된 상태를 다시 줌아웃할 수 없는 버그

1. (버그 - iOS)상품 구매메시지 입력시 해당 입력창으로 줌인되고, 모두 작성이후 화면 스프레드시 다시 줌아웃되지 않음

# 할일

- 상품구매 후원메시지 입력시 줌인되지 않도록 구성
    - [x]  상품구매 후원메시지 입력창(Textarea) 크기 수정

# 테스트케이스

- [ ]  상품구매 후원메시지 입력시 줌인되지 않는다.