### PR TITLE
improve: 상품목록 모바일 레이아웃 수정

### DIFF
--- a/libs/components-web-kkshow/src/lib/promotion-page/PromotionPageGoodsDisplay.tsx
+++ b/libs/components-web-kkshow/src/lib/promotion-page/PromotionPageGoodsDisplay.tsx
@@ -47,7 +47,7 @@ export function PromotinoPageGoodsDisplay({
         <Box py={2} px={1}>
           <NextLink href={`/goods/${item.goods.id}?bc=${broadcasterId}`} passHref>
             <LinkOverlay>
-              <Text noOfLines={1}>
+              <Text noOfLines={2} fontSize={['sm', 'md']}>
                 {isLive && (
                   <Badge variant="solid" colorScheme="red" mr={1}>
                     LIVE
@@ -57,15 +57,20 @@ export function PromotinoPageGoodsDisplay({
               </Text>
             </LinkOverlay>
           </NextLink>
-          <Text color="GrayText" fontSize="sm" noOfLines={1}>
+          <Text
+            color="GrayText"
+            fontSize="sm"
+            noOfLines={1}
+            display={{ base: 'none', sm: 'block' }}
+          >
             {item.goods.summary}
           </Text>
 
           <Box>
-            <Flex fontSize="xl" gap={2} maxW={270}>
+            <Flex fontSize={['sm', 'md', 'xl']} gap={2} maxW={270}>
               <Text>
                 {isDiscounted ? (
-                  <Text as="span" color="red">
+                  <Text as="span" color="red" fontWeight="bold">
                     {getDiscountedRate(
                       Number(defaultOpt.consumer_price),
                       Number(defaultOpt.price),
@@ -75,7 +80,7 @@ export function PromotinoPageGoodsDisplay({
                 ) : null}
                 {getLocaleNumber(defaultOpt.price)}원{' '}
                 {isDiscounted ? (
-                  <RedLinedText color="GrayText" as="span" fontSize="sm">
+                  <RedLinedText color="GrayText" as="span" fontSize={['xs', 'sm']}>
                     {getLocaleNumber(defaultOpt.consumer_price)}원
                   </RedLinedText>
                 ) : null}

--- a/libs/components-web-kkshow/src/lib/promotion-page/PromotionPageGoodsList.tsx
+++ b/libs/components-web-kkshow/src/lib/promotion-page/PromotionPageGoodsList.tsx
@@ -49,7 +49,7 @@ export function PromotionPageGoodsList({
             <Text as="h5" fontSize="xl" fontWeight="bold">
               현재 라이브 진행중 상품
             </Text>
-            <SimpleGrid mt={4} columns={[1, 2, 3]} spacing={4}>
+            <SimpleGrid mt={4} columns={[2, 2, 3]} spacing={4}>
               {liveShopping.data?.map((x) => (
                 <PromotinoPageGoodsDisplay
                   broadcasterId={broadcasterId}
@@ -66,7 +66,7 @@ export function PromotionPageGoodsList({
           <Text as="h5" fontSize="xl" fontWeight="bold">
             홍보중 상품
           </Text>
-          <SimpleGrid mt={4} columns={[1, 2, 3]} spacing={4}>
+          <SimpleGrid mt={4} columns={[2, 2, 3]} spacing={4}>
             {promotionItems &&
               promotionItems.pages.map((page, idx) => (
                 <Fragment key={idx}>

--- a/libs/components-web-kkshow/src/lib/shopping/category/CategoryGoodsList.tsx
+++ b/libs/components-web-kkshow/src/lib/shopping/category/CategoryGoodsList.tsx
@@ -87,7 +87,7 @@ export function CategoryGoodsList(): JSX.Element | null {
         ))}
       </SimpleGrid>
 
-      <SimpleGrid my={10} gap={6} columns={[1, 2, 4]}>
+      <SimpleGrid my={10} gap={6} columns={[2, 3, 4]}>
         {data?.pages?.map((goodsList, idx) => (
           <Fragment key={`GoodsOutlineByCategory${idx}`}>
             {goodsList?.edges?.map((goodsOutline) => (
@@ -99,7 +99,7 @@ export function CategoryGoodsList(): JSX.Element | null {
               >
                 <GoodsDisplay
                   goods={makeGoodsOutlineToGoodsDisplay(goodsOutline)}
-                  detailProps={{ noOfLines: 2 }}
+                  detailProps={{ noOfLines: 2, fontSize: { base: 'sm', md: 'lg' } }}
                 />
               </GridItem>
             ))}


### PR DESCRIPTION
모바일화면 1개씩 보이는 것 → 2개씩

- 카테고리별 상품목록
- 방송인 홍보페이지 상품 목록
    - 라이브중
    - 홍보중

# 할일

- [x]  모바일화면 상품 목록 레이아웃 수정
    - [x]  카테고리별 상품목록
    - [x]  방송인 홍보페이지 상품 목록            

# 테스트케이스

- [ ]  카테고리별 상품목록이 모바일 화면에서 2 컬럼으로 보여진다
    - [ ]  글자크기 등이 올바르게 보여진다
- [ ]  방송인 홍보페이지 상품목록이 모바일 화면에서 2 컬럼으로 보여진다
    - [ ]  글자크기 등이 올바르게 보여진다