### PR TITLE
fix(kkshow): 홍보페이지 없는 경우 방송인 검색결과 목록 미반영 처리

### DIFF
--- a/libs/nest-modules-kkshow-search/src/kkshow-search/kkshow-search.service.ts
+++ b/libs/nest-modules-kkshow-search/src/kkshow-search/kkshow-search.service.ts
@@ -97,11 +97,12 @@ export class KkshowSearchService {
         _goods.LiveShopping.forEach((liveShopping) => {
           if (
             liveShopping.broadcaster?.userNickname &&
-            !ID_SET.has(`bc:${liveShopping.broadcaster.userNickname}`)
+            !ID_SET.has(`bc:${liveShopping.broadcaster.userNickname}`) &&
+            liveShopping.broadcaster.BroadcasterPromotionPage?.url
           ) {
             broadcasters.push({
               title: liveShopping.broadcaster.userNickname,
-              linkUrl: liveShopping.broadcaster.BroadcasterPromotionPage.url,
+              linkUrl: liveShopping.broadcaster.BroadcasterPromotionPage?.url,
               imageUrl: liveShopping.broadcaster.avatar,
             });
             ID_SET.add(`bc:${liveShopping.broadcaster.userNickname}`);
@@ -128,7 +129,11 @@ export class KkshowSearchService {
         ID_SET.add(`goods:${_goods.goods_name}`);
       }
 
-      if (broadcaster?.userNickname && !ID_SET.has(`bc:${broadcaster.userNickname}`)) {
+      if (
+        broadcaster?.userNickname &&
+        !ID_SET.has(`bc:${broadcaster.userNickname}`) &&
+        broadcaster.BroadcasterPromotionPage?.url
+      ) {
         broadcasters.push({
           title: broadcaster?.userNickname,
           linkUrl: broadcaster.BroadcasterPromotionPage?.url,


### PR DESCRIPTION
# 할일

- [x]  버그 조사
    
    홍보페이지가 설정되지 않은 방송인이 상품/라이브/방송인 등 검색결과에 포함되는 경우 이어질 URL을 가져오지 못해 검색 자체가 실행이 되지 않는 오류.
    
    → 상품 검색시 상품에 연결된 라이브쇼핑을 내부적으로 조회하여, 해당 라이브쇼핑에 연결된 방송인을 방송인 검색결과 목록에 채워넣는데, 이 과정 중 라이브쇼핑에 연결되었으나 홍보페이지가 설정되지않은 방송인이 있는 경우 문제가 발생
    → 현재 라이브쇼핑 등록시 홍보페이지가 자동으로 생성되도록 구성되어 있으므로 앞으로는 이 문제가 발생하지 않을 것임.
    → 이 문제는 라이브쇼핑 등록시 홍보페이지 자동 생성 기능이 구현되기 이전에 라이브쇼핑을 진행한 방송인이 존재하여 생기는 오류.
    
    ⇒ 처리방안: **방송인 홍보페이지 URL이 없으면 방송인 검색결과에 포함되지 않도록 한다.**
    
- [x]  버그 수정