### PR TITLE
fix(kkshow) : 사용한 쿠폰도 보유쿠폰에 표시되는 버그 수정

### DIFF
--- a/libs/components-shared/src/lib/CouponBadge.tsx
+++ b/libs/components-shared/src/lib/CouponBadge.tsx
@@ -89,7 +89,7 @@ export function ActionTypeBadge(value: CouponLogType): JSX.Element {
       return (
         <Box lineHeight={2}>
           <Badge variant="outline" colorScheme="blue">
-            적립
+            발급
           </Badge>
         </Box>
       );

--- a/libs/components-web-kkshow/src/lib/mypage/benefits/Benefits.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/benefits/Benefits.tsx
@@ -22,7 +22,7 @@ export function Benefits(): JSX.Element {
     <Grid templateColumns="repeat(2, 2fr)" mt={5} gap={2}>
       <GridItem mb={5}>
         <Flex justifyContent="space-between">
-          <Text>보유쿠폰 수</Text>
+          <Text>사용 가능한 쿠폰 수</Text>
           <Flex>
             <Text fontWeight="bold">{validCoupons.length} 장</Text>
           </Flex>
@@ -36,9 +36,9 @@ export function Benefits(): JSX.Element {
       <GridItem colSpan={2}>
         <Tabs>
           <TabList>
-            <Tab fontSize={{ base: 'sm', sm: 'md' }}>보유 쿠폰목록</Tab>
-            <Tab fontSize={{ base: 'sm', sm: 'md' }}>쿠폰 사용내역</Tab>
-            <Tab fontSize={{ base: 'sm', sm: 'md' }}>마일리지 사용내역</Tab>
+            <Tab fontSize={{ base: 'sm', sm: 'md' }}>사용 가능한 쿠폰목록</Tab>
+            <Tab fontSize={{ base: 'sm', sm: 'md' }}>쿠폰 변동 내역</Tab>
+            <Tab fontSize={{ base: 'sm', sm: 'md' }}>마일리지 변동 내역</Tab>
           </TabList>
 
           <TabPanels>

--- a/libs/components-web-kkshow/src/lib/mypage/benefits/Benefits.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/benefits/Benefits.tsx
@@ -9,22 +9,22 @@ import {
   Tabs,
   Text,
 } from '@chakra-ui/react';
-import { useCustomerCouponList, useCustomerMileage } from '@project-lc/hooks';
+import { useCustomerMileage } from '@project-lc/hooks';
 import { CustomerCouponHistoryList } from './CustomerCouponHistoryList';
-import { CustomerCouponList } from './CustomerCouponList';
+import { CustomerCouponList, useValidCustomerCouponList } from './CustomerCouponList';
 import { CustomerMileagenHistoryList } from './CustomerMileageHistory';
 
 export function Benefits(): JSX.Element {
-  const { data: coupons } = useCustomerCouponList();
+  const { validCoupons } = useValidCustomerCouponList();
   const { data: mileage } = useCustomerMileage();
-  const couponLength = coupons?.length;
+
   return (
     <Grid templateColumns="repeat(2, 2fr)" mt={5} gap={2}>
       <GridItem mb={5}>
         <Flex justifyContent="space-between">
           <Text>보유쿠폰 수</Text>
           <Flex>
-            <Text fontWeight="bold">{couponLength} 장</Text>
+            <Text fontWeight="bold">{validCoupons.length} 장</Text>
           </Flex>
         </Flex>
         <Flex justifyContent="space-between">

--- a/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponHistoryList.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponHistoryList.tsx
@@ -7,7 +7,7 @@ import { ActionTypeBadge } from '@project-lc/components-shared/CouponBadge';
 
 const column: GridColumns = [
   {
-    width: 120,
+    width: 200,
     field: 'couponName',
     headerName: '쿠폰명',
     valueGetter: ({ row }: GridRowData) => row.customerCoupon.coupon.name,

--- a/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponList.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponList.tsx
@@ -23,7 +23,7 @@ export function CustomerCouponList(): JSX.Element {
 
   const columns: GridColumns = [
     {
-      width: 120,
+      width: 200,
       field: 'couponName',
       headerName: '이름',
       valueGetter: ({ row }) => row.coupon.name,

--- a/libs/components-web-kkshow/src/lib/payment/Discount.tsx
+++ b/libs/components-web-kkshow/src/lib/payment/Discount.tsx
@@ -23,10 +23,11 @@ import {
 import { GridColDef, GridRowData } from '@material-ui/data-grid';
 import { ChakraDataGrid } from '@project-lc/components-core/ChakraDataGrid';
 import SectionWithTitle from '@project-lc/components-layout/SectionWithTitle';
-import { useCustomerCouponList, useCustomerMileage } from '@project-lc/hooks';
+import { useCustomerMileage } from '@project-lc/hooks';
 import { CreateOrderForm } from '@project-lc/shared-types';
 import { checkCouponAvailable, getLocaleNumber } from '@project-lc/utils-frontend';
 import { useFormContext } from 'react-hook-form';
+import { useValidCustomerCouponList } from '../mypage/benefits/CustomerCouponList';
 
 /** 적립금 사용시 100원 단위로 변경하기 위한 timeout 이벤트 저장 */
 let debounce: NodeJS.Timeout | null = null;
@@ -48,7 +49,7 @@ export function Discount(): JSX.Element {
   const discountCodeDialog = useDisclosure();
 
   const { data: customerMileage } = useCustomerMileage();
-  const { data: customerCoupons } = useCustomerCouponList();
+  const { validCoupons: customerCoupons } = useValidCustomerCouponList();
 
   const {
     resetField,
@@ -238,7 +239,7 @@ function CouponSelectDialog({
   orderPrice,
   orderItemIdList,
 }: CouponSelectDialogProps): JSX.Element {
-  const { data: customerCoupons } = useCustomerCouponList();
+  const { validCoupons: customerCoupons } = useValidCustomerCouponList();
 
   const couponList = customerCoupons
     ? customerCoupons.map((c) => {

--- a/libs/components-web-kkshow/src/lib/payment/Discount.tsx
+++ b/libs/components-web-kkshow/src/lib/payment/Discount.tsx
@@ -100,10 +100,14 @@ export function Discount(): JSX.Element {
           <Text fontWeight="semibold">쿠폰할인</Text>
           <Flex alignItems="center" gap={2}>
             <Input size="sm" maxW={150} isReadOnly {...register('usedCouponAmount')} />
-            {customerCoupons && customerCoupons.length > 0 && (
+            {customerCoupons && customerCoupons.length > 0 ? (
               <Button size="xs" colorScheme="blue" onClick={couponSelectDialog.onOpen}>
                 쿠폰사용
               </Button>
+            ) : (
+              <Text color="GrayText" fontSize="xs">
+                사용 가능한 쿠폰이 없습니다
+              </Text>
             )}
 
             {watch('couponId') ? (
@@ -175,11 +179,10 @@ export function Discount(): JSX.Element {
               ) : null}
             </Flex>
 
-            {customerMileage && (
-              <FormHelperText color="GrayText">
-                보유한 총 적립금 {getLocaleNumber(customerMileage.mileage) || 0} 원
-              </FormHelperText>
-            )}
+            <FormHelperText color="GrayText">
+              보유 적립금 총{' '}
+              {customerMileage ? getLocaleNumber(customerMileage.mileage) : 0} 원
+            </FormHelperText>
 
             <FormErrorMessage>{errors.usedMileageAmount?.message}</FormErrorMessage>
           </FormControl>

--- a/libs/utils-frontend/src/lib/checkCouponAvailable.ts
+++ b/libs/utils-frontend/src/lib/checkCouponAvailable.ts
@@ -42,7 +42,7 @@ export function checkCouponAvailable({
   // 최소주문금액 확인
   if (orderPrice < minOrderAmountWon) {
     available = false;
-    reasons.push(`주문 상품금액이 ${minOrderAmountWon}원 이상이어야 적용가능합니다.`);
+    reasons.push(`주문금액이 ${minOrderAmountWon}원 이상이어야 적용가능합니다.`);
   }
 
   // 쿠폰적용 가능한 상품 포함되었는지 확인


### PR DESCRIPTION
- 혜택관리 페이지 문구 수정
  - 보유쿠폰 => 사용 가능한 쿠폰
  - 보유 쿠폰목록 => 사용 가능한 쿠폰목록
  - 쿠폰 사용내역 => 쿠폰 변동 내역
  - 발급된 쿠폰의 유형 : '적립' => '발급'
- 마이페이지 보유쿠폰 목록과 결제페이지 쿠폰목록에서 사용했거나, 기간이 지난 쿠폰은 표시되지 않도록 수정함
- 결제페이지에서 쿠폰 적용시 결제금액이 올바르게 표시되지 않는 문제는 동일한 현상이 발생하지 않아 조치를 취하지 않음
- 결제페이지에서 쿠폰 적용시 퍼센트 할인쿠폰의 할인율이 할인금액으로 들어가는 문제 수정

**테스트 케이스**
- [ ]  사용기간이 지난 쿠폰, 이미 사용한 쿠폰은 사용 가능한 쿠폰 목록에 표시되지 않는다
    - [ ]  마이페이지 > 혜택관리
    - [ ]  결제페이지 > 쿠폰
- [ ]  쿠폰 변동 내역에 ‘적립'이 아닌 ‘발급'이라고 표시된다