### PR TITLE
[크크쇼] 라이브상품 페이지로의 접근성 개선

### DIFF
--- a/apps/web-kkshow/pages/mypage/info.tsx
+++ b/apps/web-kkshow/pages/mypage/info.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Stack, Text, useDisclosure } from '@chakra-ui/react';
+import { Box, Flex, Stack, Text } from '@chakra-ui/react';
 import { PasswordCheckForm } from '@project-lc/components-shared/PasswordCheckForm';
 import CustomerMypageLayout from '@project-lc/components-web-kkshow/mypage/CustomerMypageLayout';
 import { UserInfo } from '@project-lc/components-web-kkshow/mypage/info/UserInfo';
@@ -8,7 +8,6 @@ import { useEffect, useState } from 'react';
 export function Info(): JSX.Element {
   const title = '내 정보 수정';
   const { data: profileData } = useProfile();
-  const { onClose } = useDisclosure();
   const [isValidated, setIsValidated] = useState(false);
 
   const onConfirm = (): void => {
@@ -50,11 +49,7 @@ export function Info(): JSX.Element {
 
               <Box>
                 <Text>비밀번호</Text>
-                <PasswordCheckForm
-                  email={profileData?.email}
-                  onCancel={onClose}
-                  onConfirm={onConfirm}
-                />
+                <PasswordCheckForm email={profileData?.email} onConfirm={onConfirm} />
               </Box>
             </Stack>
           </Stack>

--- a/libs/components-shared/src/lib/GoogleLoginButton.tsx
+++ b/libs/components-shared/src/lib/GoogleLoginButton.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@chakra-ui/react';
 import { FcGoogle } from 'react-icons/fc';
 import { getApiHost } from '@project-lc/utils';
-import { UserType, USER_TYPE_KEY } from '@project-lc/shared-types';
+import { NEXT_PAGE_PARAM_KEY, UserType, USER_TYPE_KEY } from '@project-lc/shared-types';
 import { useNextpageUrlParam } from '@project-lc/hooks';
 import { useMemo } from 'react';
 
@@ -12,7 +12,7 @@ export function GoogleLoginButton({ userType }: UserTypeProps): JSX.Element {
   const nextPage = useNextpageUrlParam();
   const href = useMemo(() => {
     const defaultHref = `${getApiHost()}/social/google/login?${USER_TYPE_KEY}=${userType}`;
-    if (nextPage) return `${defaultHref}&nextpage=${nextPage}`;
+    if (nextPage) return `${defaultHref}&${NEXT_PAGE_PARAM_KEY}=${nextPage}`;
     return defaultHref;
   }, [nextPage, userType]);
   return (

--- a/libs/components-shared/src/lib/GoogleLoginButton.tsx
+++ b/libs/components-shared/src/lib/GoogleLoginButton.tsx
@@ -2,16 +2,24 @@ import { Button } from '@chakra-ui/react';
 import { FcGoogle } from 'react-icons/fc';
 import { getApiHost } from '@project-lc/utils';
 import { UserType, USER_TYPE_KEY } from '@project-lc/shared-types';
+import { useNextpageUrlParam } from '@project-lc/hooks';
+import { useMemo } from 'react';
 
 export interface UserTypeProps {
   userType: UserType;
 }
 export function GoogleLoginButton({ userType }: UserTypeProps): JSX.Element {
+  const nextPage = useNextpageUrlParam();
+  const href = useMemo(() => {
+    const defaultHref = `${getApiHost()}/social/google/login?${USER_TYPE_KEY}=${userType}`;
+    if (nextPage) return `${defaultHref}&nextpage=${nextPage}`;
+    return defaultHref;
+  }, [nextPage, userType]);
   return (
     <Button
       as="a"
       isFullWidth
-      href={`${getApiHost()}/social/google/login?${USER_TYPE_KEY}=${userType}`}
+      href={href}
       bg="white"
       color="black"
       _hover={{ boxShadow: 'lg' }}

--- a/libs/components-shared/src/lib/KakaoLoginButton.tsx
+++ b/libs/components-shared/src/lib/KakaoLoginButton.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@chakra-ui/react';
 import { RiKakaoTalkFill } from 'react-icons/ri';
 import { getApiHost } from '@project-lc/utils';
-import { USER_TYPE_KEY } from '@project-lc/shared-types';
+import { NEXT_PAGE_PARAM_KEY, USER_TYPE_KEY } from '@project-lc/shared-types';
 import { useNextpageUrlParam } from '@project-lc/hooks';
 import { useMemo } from 'react';
 import { UserTypeProps } from './GoogleLoginButton';
@@ -11,7 +11,7 @@ export function KakaoLoginButton({ userType }: UserTypeProps): JSX.Element {
   const nextPage = useNextpageUrlParam();
   const href = useMemo(() => {
     const defaultHref = `${getApiHost()}/social/kakao/login?${USER_TYPE_KEY}=${userType}`;
-    if (nextPage) return `${defaultHref}&nextpage=${nextPage}`;
+    if (nextPage) return `${defaultHref}&${NEXT_PAGE_PARAM_KEY}=${nextPage}`;
     return defaultHref;
   }, [nextPage, userType]);
   return (

--- a/libs/components-shared/src/lib/KakaoLoginButton.tsx
+++ b/libs/components-shared/src/lib/KakaoLoginButton.tsx
@@ -2,15 +2,23 @@ import { Button } from '@chakra-ui/react';
 import { RiKakaoTalkFill } from 'react-icons/ri';
 import { getApiHost } from '@project-lc/utils';
 import { USER_TYPE_KEY } from '@project-lc/shared-types';
+import { useNextpageUrlParam } from '@project-lc/hooks';
+import { useMemo } from 'react';
 import { UserTypeProps } from './GoogleLoginButton';
 
 const KAKAO_COLOR = '#FEE500';
 export function KakaoLoginButton({ userType }: UserTypeProps): JSX.Element {
+  const nextPage = useNextpageUrlParam();
+  const href = useMemo(() => {
+    const defaultHref = `${getApiHost()}/social/kakao/login?${USER_TYPE_KEY}=${userType}`;
+    if (nextPage) return `${defaultHref}&nextpage=${nextPage}`;
+    return defaultHref;
+  }, [nextPage, userType]);
   return (
     <Button
       as="a"
       isFullWidth
-      href={`${getApiHost()}/social/kakao/login?${USER_TYPE_KEY}=${userType}`}
+      href={href}
       bg={KAKAO_COLOR}
       color="black"
       boxShadow="md"

--- a/libs/components-shared/src/lib/LoginForm.tsx
+++ b/libs/components-shared/src/lib/LoginForm.tsx
@@ -23,7 +23,7 @@ import {
   useCartMigrationMutation,
   useNextpageUrlParam,
 } from '@project-lc/hooks';
-import { LoginUserDto, UserType } from '@project-lc/shared-types';
+import { LoginUserDto, NEXT_PAGE_PARAM_KEY, UserType } from '@project-lc/shared-types';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import { useCallback, useState } from 'react';
@@ -149,14 +149,14 @@ export function LoginForm({
           </Button>
 
           {/* 비회원 주문 링크 */}
-          {router.query.from === 'purchase' && router.query.nextpage && (
+          {router.query.from === 'purchase' && router.query[NEXT_PAGE_PARAM_KEY] && (
             <Box mt={4}>
               <Text>
                 비회원으로 구매하시겠습니까?{' '}
                 <ClickableUnderlinedText
                   color="blue.500"
                   fontSize="md"
-                  onClick={() => router.push(router.query.nextpage as string)}
+                  onClick={() => router.push(router.query[NEXT_PAGE_PARAM_KEY] as string)}
                   as="span"
                 >
                   비회원 구매
@@ -179,7 +179,7 @@ export function LoginForm({
           <Text fontSize="sm">
             처음 오셨나요?
             <NextLink
-              href={nextPage ? `/signup?nextpage=${nextPage}` : '/signup'}
+              href={nextPage ? `/signup?${NEXT_PAGE_PARAM_KEY}=${nextPage}` : '/signup'}
               passHref
             >
               <Link

--- a/libs/components-shared/src/lib/LoginForm.tsx
+++ b/libs/components-shared/src/lib/LoginForm.tsx
@@ -21,6 +21,7 @@ import {
   useLoginMutation,
   InactiveUserPayload,
   useCartMigrationMutation,
+  useNextpageUrlParam,
 } from '@project-lc/hooks';
 import { LoginUserDto, UserType } from '@project-lc/shared-types';
 import NextLink from 'next/link';
@@ -40,6 +41,7 @@ export function LoginForm({
   userType,
 }: LoginFormProps): JSX.Element {
   const router = useRouter();
+  const nextPage = useNextpageUrlParam();
   const {
     handleSubmit,
     register,
@@ -68,20 +70,18 @@ export function LoginForm({
       });
       if (user && (user as InactiveUserPayload).inactiveFlag) {
         setToActivateEmail((user as InactiveUserPayload).sub);
-        router.push('/activate');
+        router.push('/activate', { query: router.query });
         return;
       }
       if (user) {
         cartMutation.mutateAsync({ customerId: user.id });
-        const nextPage = router.query.nextpage as string;
-        if (nextPage) {
-          router.push(nextPage.startsWith('/') ? nextPage : `/${nextPage}`);
-        } else {
+        if (nextPage) router.push(nextPage);
+        else {
           router.push('/mypage');
         }
       }
     },
-    [login, setValue, setToActivateEmail, router, cartMutation],
+    [login, setValue, setToActivateEmail, router, cartMutation, nextPage],
   );
 
   function getMessage(statusCode: number | undefined): string {
@@ -178,7 +178,10 @@ export function LoginForm({
           </NextLink>
           <Text fontSize="sm">
             처음 오셨나요?
-            <NextLink href="/signup" passHref>
+            <NextLink
+              href={nextPage ? `/signup?nextpage=${nextPage}` : '/signup'}
+              passHref
+            >
               <Link
                 ml={2}
                 color={useColorModeValue('blue.500', 'blue.400')}

--- a/libs/components-shared/src/lib/LoginForm.tsx
+++ b/libs/components-shared/src/lib/LoginForm.tsx
@@ -70,7 +70,7 @@ export function LoginForm({
       });
       if (user && (user as InactiveUserPayload).inactiveFlag) {
         setToActivateEmail((user as InactiveUserPayload).sub);
-        router.push('/activate', { query: router.query });
+        router.push('/activate');
         return;
       }
       if (user) {

--- a/libs/components-shared/src/lib/NaverLoginButton.tsx
+++ b/libs/components-shared/src/lib/NaverLoginButton.tsx
@@ -2,7 +2,7 @@ import { Button } from '@chakra-ui/react';
 import { ChakraNextImage } from '@project-lc/components-core/ChakraNextImage';
 import naverLogo from '@project-lc/components-core/images/naver.png';
 import { useNextpageUrlParam } from '@project-lc/hooks';
-import { USER_TYPE_KEY } from '@project-lc/shared-types';
+import { NEXT_PAGE_PARAM_KEY, USER_TYPE_KEY } from '@project-lc/shared-types';
 import { getApiHost } from '@project-lc/utils';
 import { useMemo } from 'react';
 import { UserTypeProps } from './GoogleLoginButton';
@@ -12,7 +12,7 @@ export function NaverLoginButton({ userType }: UserTypeProps): JSX.Element {
   const nextPage = useNextpageUrlParam();
   const href = useMemo(() => {
     const defaultHref = `${getApiHost()}/social/naver/login?${USER_TYPE_KEY}=${userType}`;
-    if (nextPage) return `${defaultHref}&nextpage=${nextPage}`;
+    if (nextPage) return `${defaultHref}&${NEXT_PAGE_PARAM_KEY}=${nextPage}`;
     return defaultHref;
   }, [nextPage, userType]);
   return (

--- a/libs/components-shared/src/lib/NaverLoginButton.tsx
+++ b/libs/components-shared/src/lib/NaverLoginButton.tsx
@@ -1,17 +1,25 @@
 import { Button } from '@chakra-ui/react';
 import { ChakraNextImage } from '@project-lc/components-core/ChakraNextImage';
 import naverLogo from '@project-lc/components-core/images/naver.png';
+import { useNextpageUrlParam } from '@project-lc/hooks';
 import { USER_TYPE_KEY } from '@project-lc/shared-types';
 import { getApiHost } from '@project-lc/utils';
+import { useMemo } from 'react';
 import { UserTypeProps } from './GoogleLoginButton';
 
 const NAVER_COLOR = '#03c75a';
 export function NaverLoginButton({ userType }: UserTypeProps): JSX.Element {
+  const nextPage = useNextpageUrlParam();
+  const href = useMemo(() => {
+    const defaultHref = `${getApiHost()}/social/naver/login?${USER_TYPE_KEY}=${userType}`;
+    if (nextPage) return `${defaultHref}&nextpage=${nextPage}`;
+    return defaultHref;
+  }, [nextPage, userType]);
   return (
     <Button
       as="a"
       isFullWidth
-      href={`${getApiHost()}/social/naver/login?${USER_TYPE_KEY}=${userType}`}
+      href={href}
       bg={NAVER_COLOR}
       boxShadow="md"
       _hover={{ boxShadow: 'lg' }}

--- a/libs/components-shared/src/lib/PasswordCheckForm.tsx
+++ b/libs/components-shared/src/lib/PasswordCheckForm.tsx
@@ -15,7 +15,7 @@ export interface PasswordCheckFormData {
 }
 export interface PasswordCheckFormProps {
   email?: string;
-  onCancel: () => void;
+  onCancel?: () => void;
   onConfirm: () => void;
   onFail?: () => void;
 }
@@ -72,7 +72,7 @@ export function PasswordCheckForm(props: PasswordCheckFormProps): JSX.Element {
         <FormErrorMessage>{errors.password?.message}</FormErrorMessage>
       </FormControl>
       <ButtonGroup mt={2} width="100%" justifyContent="flex-end">
-        <Button onClick={onCancel}>취소</Button>
+        {onCancel && <Button onClick={onCancel}>취소</Button>}
         <Button colorScheme="blue" type="submit" disabled={!watch('password')}>
           비밀번호 확인
         </Button>

--- a/libs/components-shared/src/lib/signup/SignupForm.tsx
+++ b/libs/components-shared/src/lib/signup/SignupForm.tsx
@@ -20,6 +20,7 @@ import {
   useSellerSignupMutation,
   useCountdown,
   useCustomerSignupMutation,
+  useNextpageUrlParam,
 } from '@project-lc/hooks';
 import {
   emailCodeRegisterOptions,
@@ -40,6 +41,7 @@ export function SignupForm({
   userType = 'seller',
 }: SignupFormProps): JSX.Element {
   const router = useRouter();
+  const nextPage = useNextpageUrlParam();
   const toast = useToast();
 
   const { clearTimer, startCountdown, seconds } = useCountdown();
@@ -143,14 +145,11 @@ export function SignupForm({
       } else if (userType === 'customer') {
         user = await customerSignup.mutateAsync(data).catch(handleSignupError);
       }
-
       if (user) {
         // 로그인 과정이 수행
-        await login.mutateAsync({
-          email: data.email,
-          password: data.password,
-        });
-        router.push('/mypage');
+        await login.mutateAsync({ email: data.email, password: data.password });
+        if (nextPage) router.push(nextPage);
+        else router.push('/mypage');
       }
     },
     [
@@ -159,6 +158,7 @@ export function SignupForm({
       handleSignupError,
       login,
       router,
+      nextPage,
       sellerSignup,
       userType,
     ],

--- a/libs/components-web-kkshow/src/lib/KkshowNavbar.tsx
+++ b/libs/components-web-kkshow/src/lib/KkshowNavbar.tsx
@@ -16,7 +16,7 @@ import CountBadge from '@project-lc/components-shared/CountBadge';
 import { KkshowLogoVariant, KksLogo } from '@project-lc/components-shared/KksLogo';
 import { PersonalPopoverMenu } from '@project-lc/components-shared/navbar/NavbarRightButtonSection';
 import { useCart, useIsLoggedIn } from '@project-lc/hooks';
-import { KkshowNavbarVariant } from '@project-lc/shared-types';
+import { KkshowNavbarVariant, NEXT_PAGE_PARAM_KEY } from '@project-lc/shared-types';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import { useMemo } from 'react';
@@ -220,7 +220,7 @@ function LoginButton(): JSX.Element {
         px={0}
         variant="unstyle"
         color="current"
-        onClick={() => router.push('/login?nextpage=/')}
+        onClick={() => router.push(`/login?${NEXT_PAGE_PARAM_KEY}=/`)}
       >
         로그인
       </Button>

--- a/libs/components-web-kkshow/src/lib/cart/CartActions.tsx
+++ b/libs/components-web-kkshow/src/lib/cart/CartActions.tsx
@@ -8,7 +8,7 @@ import {
   useProductPromotions,
   useProfile,
 } from '@project-lc/hooks';
-import { CartItemRes } from '@project-lc/shared-types';
+import { CartItemRes, NEXT_PAGE_PARAM_KEY } from '@project-lc/shared-types';
 import { OrderShippingData, useCartStore, useKkshowOrderStore } from '@project-lc/stores';
 import { checkGoodsPurchasable } from '@project-lc/utils-frontend';
 import { useRouter } from 'next/router';
@@ -204,7 +204,7 @@ export function CartActions(): JSX.Element {
 
     // 비회원 주문 로그인화면으로 이동, 로그인 이후 페이지를 주문페이지로
     if (!profile.data?.id) {
-      router.push(`/login?from=purchase&nextpage=/payment`);
+      router.push(`/login?from=purchase&${NEXT_PAGE_PARAM_KEY}=/payment`);
       return;
     }
     router.push('/payment');

--- a/libs/components-web-kkshow/src/lib/goods/GoodsInquiryFormDialog.tsx
+++ b/libs/components-web-kkshow/src/lib/goods/GoodsInquiryFormDialog.tsx
@@ -20,7 +20,7 @@ import {
 } from '@chakra-ui/react';
 import { Goods } from '@prisma/client';
 import { useGoodsById, useGoodsInquiryMutation, useProfile } from '@project-lc/hooks';
-import { GoodsInquiryCreateDto } from '@project-lc/shared-types';
+import { GoodsInquiryCreateDto, NEXT_PAGE_PARAM_KEY } from '@project-lc/shared-types';
 
 import { useRouter } from 'next/router';
 import { FormProvider, useForm, useFormContext } from 'react-hook-form';
@@ -102,7 +102,7 @@ export function GoodsInquiryForm({
   };
 
   const onLoginClick = (): void => {
-    router.push('/login', { query: { nextpage: `/goods/${goodsId}` } });
+    router.push('/login', { query: { [NEXT_PAGE_PARAM_KEY]: `/goods/${goodsId}` } });
   };
 
   if (!profile.data?.id) {

--- a/libs/components-web-kkshow/src/lib/goods/GoodsViewPurchaseBox.tsx
+++ b/libs/components-web-kkshow/src/lib/goods/GoodsViewPurchaseBox.tsx
@@ -48,6 +48,7 @@ import {
   getLiveShoppingIsNowLive,
   GoodsByIdRes,
   GoodsRelatedBroadcaster,
+  NEXT_PAGE_PARAM_KEY,
   SpecialPriceItem,
 } from '@project-lc/shared-types';
 import { useGoodsViewStore, useKkshowOrderStore } from '@project-lc/stores';
@@ -674,7 +675,7 @@ function GoodsViewButtonSet({
 
       // 비회원 주문 로그인화면으로 이동, 로그인 이후 페이지를 주문페이지로
       if (!profile.data?.id) {
-        router.push(`/login?from=purchase&nextpage=/payment`);
+        router.push(`/login?from=purchase&${NEXT_PAGE_PARAM_KEY}=/payment`);
         return;
       }
       router.push('/payment');

--- a/libs/hooks/src/index.ts
+++ b/libs/hooks/src/index.ts
@@ -197,6 +197,7 @@ export * from './lib/useGoodsOnLive';
 export * from './lib/useHorizontalScroll';
 export * from './lib/useManualMainCategories';
 export * from './lib/useMyLocationOrigin';
+export * from './lib/useNextpageUrlParam';
 export * from './lib/useOrderExportableCheck';
 export * from './lib/useSocialLoginFailAlarm';
 export * from './lib/useTerms';

--- a/libs/hooks/src/lib/useNextpageUrlParam.tsx
+++ b/libs/hooks/src/lib/useNextpageUrlParam.tsx
@@ -1,0 +1,9 @@
+import { useRouter } from 'next/router';
+
+export const useNextpageUrlParam = (): string | null => {
+  const router = useRouter();
+  const nextPage = router.query.nextpage as string;
+  if (!nextPage) return null;
+  return nextPage.startsWith('/') ? nextPage : `/${nextPage}`;
+};
+export default useNextpageUrlParam;

--- a/libs/hooks/src/lib/useNextpageUrlParam.tsx
+++ b/libs/hooks/src/lib/useNextpageUrlParam.tsx
@@ -1,8 +1,9 @@
+import { NEXT_PAGE_PARAM_KEY } from '@project-lc/shared-types';
 import { useRouter } from 'next/router';
 
 export const useNextpageUrlParam = (): string | null => {
   const router = useRouter();
-  const nextPage = router.query.nextpage as string;
+  const nextPage = router.query[NEXT_PAGE_PARAM_KEY] as string;
   if (!nextPage) return null;
   return nextPage.startsWith('/') ? nextPage : `/${nextPage}`;
 };

--- a/libs/nest-core/src/lib/middlewares/socialLoginUserType.middleware.ts
+++ b/libs/nest-core/src/lib/middlewares/socialLoginUserType.middleware.ts
@@ -20,6 +20,10 @@ export class SocialLoginUserTypeMiddleware implements NestMiddleware {
       res.cookie(USER_TYPE_KEY, req.query[USER_TYPE_KEY]);
     }
 
+    if (req.query.nextpage) {
+      res.cookie('nextpage', req.query.nextpage);
+    }
+
     next();
   }
 }

--- a/libs/nest-core/src/lib/middlewares/socialLoginUserType.middleware.ts
+++ b/libs/nest-core/src/lib/middlewares/socialLoginUserType.middleware.ts
@@ -1,5 +1,5 @@
 import { Injectable, NestMiddleware } from '@nestjs/common';
-import { USER_TYPE_KEY } from '@project-lc/shared-types';
+import { NEXT_PAGE_PARAM_KEY, USER_TYPE_KEY } from '@project-lc/shared-types';
 import { Request, Response, NextFunction } from 'express';
 
 /** 소셜로그인 시 로그인 시도한 유저 타입을 req.cookie에 저장하기 위한 미들웨어
@@ -20,8 +20,8 @@ export class SocialLoginUserTypeMiddleware implements NestMiddleware {
       res.cookie(USER_TYPE_KEY, req.query[USER_TYPE_KEY]);
     }
 
-    if (req.query.nextpage) {
-      res.cookie('nextpage', req.query.nextpage);
+    if (req.query[NEXT_PAGE_PARAM_KEY]) {
+      res.cookie(NEXT_PAGE_PARAM_KEY, req.query[NEXT_PAGE_PARAM_KEY]);
     }
 
     next();

--- a/libs/nest-modules-auth/src/social/social.controller.ts
+++ b/libs/nest-modules-auth/src/social/social.controller.ts
@@ -13,7 +13,12 @@ import {
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { JwtAuthGuard } from '@project-lc/nest-modules-authguard';
-import { SocialAccounts, UserType, USER_TYPE_KEY } from '@project-lc/shared-types';
+import {
+  NEXT_PAGE_PARAM_KEY,
+  SocialAccounts,
+  UserType,
+  USER_TYPE_KEY,
+} from '@project-lc/shared-types';
 import { getBroadcasterWebHost, getCustomerWebHost, getWebHost } from '@project-lc/utils';
 import { getUserTypeFromRequest } from '@project-lc/utils-backend';
 import { Request, Response } from 'express';
@@ -125,9 +130,8 @@ export class SocialController {
     // 로그인 기록 생성
     this.loginHistoryService.createLoginStamp(req, loginMethod);
 
-    console.log(nextpage);
     res.clearCookie(USER_TYPE_KEY);
-    res.clearCookie('nextpage');
+    res.clearCookie(NEXT_PAGE_PARAM_KEY);
     if (userType === 'customer') return res.redirect(hostUrl + (nextpage || ''));
     return res.redirect(`${hostUrl}/mypage`);
   }

--- a/libs/nest-modules-auth/src/social/social.controller.ts
+++ b/libs/nest-modules-auth/src/social/social.controller.ts
@@ -115,6 +115,7 @@ export class SocialController {
     const userType: UserType = getUserTypeFromRequest(req);
     if (!userType) throw new BadRequestException('userType cookie must be defined');
     const userPayload = this.socialService.login(userType, req, res);
+    const { nextpage } = req.cookies;
     const hostUrl = this.getFrontUrl(userType);
 
     if (userPayload.inactiveFlag) {
@@ -124,8 +125,10 @@ export class SocialController {
     // 로그인 기록 생성
     this.loginHistoryService.createLoginStamp(req, loginMethod);
 
+    console.log(nextpage);
     res.clearCookie(USER_TYPE_KEY);
-    if (userType === 'customer') return res.redirect(hostUrl);
+    res.clearCookie('nextpage');
+    if (userType === 'customer') return res.redirect(hostUrl + (nextpage || ''));
     return res.redirect(`${hostUrl}/mypage`);
   }
 

--- a/libs/prisma-orm/prisma/migrations/20220819051912_/migration.sql
+++ b/libs/prisma-orm/prisma/migrations/20220819051912_/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE `CustomerCoupon` DROP FOREIGN KEY `CustomerCoupon_customerId_fkey`;
+
+-- AddForeignKey
+ALTER TABLE `CustomerCoupon` ADD CONSTRAINT `CustomerCoupon_customerId_fkey` FOREIGN KEY (`customerId`) REFERENCES `Customer`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/libs/prisma-orm/prisma/migrations/20220819053840_/migration.sql
+++ b/libs/prisma-orm/prisma/migrations/20220819053840_/migration.sql
@@ -1,0 +1,20 @@
+-- social account 액세스,리프레시 토큰 길이에 따른 오류로 인해 Varchar(191) -> Text 로 타입 수정
+-- AlterTable
+ALTER TABLE `BroadcasterSocialAccount` MODIFY `accessToken` TEXT NULL,
+    MODIFY `refreshToken` TEXT NULL;
+
+-- AlterTable
+ALTER TABLE `CustomerSocialAccount` MODIFY `accessToken` TEXT NULL,
+    MODIFY `refreshToken` TEXT NULL;
+
+-- AlterTable
+ALTER TABLE `InactiveBroadcasterSocialAccount` MODIFY `accessToken` TEXT NULL,
+    MODIFY `refreshToken` TEXT NULL;
+
+-- AlterTable
+ALTER TABLE `InactiveSellerSocialAccount` MODIFY `accessToken` TEXT NULL,
+    MODIFY `refreshToken` TEXT NULL;
+
+-- AlterTable
+ALTER TABLE `SellerSocialAccount` MODIFY `accessToken` TEXT NULL,
+    MODIFY `refreshToken` TEXT NULL;

--- a/libs/prisma-orm/prisma/schema.prisma
+++ b/libs/prisma-orm/prisma/schema.prisma
@@ -1421,7 +1421,7 @@ model CustomerCoupon {
   couponId   Int
   coupon     Coupon              @relation(fields: [couponId], references: [id], onDelete: Cascade)
   customerId Int
-  customer   Customer            @relation(fields: [customerId], references: [id])
+  customer   Customer            @relation(fields: [customerId], references: [id], onDelete: Cascade)
   issueDate  DateTime            @default(now()) // 발급일
   status     CouponStatus        @default(notUsed) // 쿠폰상태
   logs       CustomerCouponLog[] // 쿠폰사용내역

--- a/libs/prisma-orm/prisma/schema.prisma
+++ b/libs/prisma-orm/prisma/schema.prisma
@@ -176,8 +176,8 @@ model SellerSocialAccount {
   name         String
   registDate   DateTime @default(now())
   profileImage String?
-  accessToken  String?
-  refreshToken String?
+  accessToken  String?  @db.Text()
+  refreshToken String?  @db.Text()
   sellerId     Int
   seller       Seller   @relation(fields: [sellerId], references: [id], onDelete: Cascade)
 
@@ -563,8 +563,8 @@ model BroadcasterSocialAccount {
   name          String
   registDate    DateTime    @default(now())
   profileImage  String?
-  accessToken   String?
-  refreshToken  String?
+  accessToken   String?     @db.Text
+  refreshToken  String?     @db.Text
   broadcasterId Int
   broadcaster   Broadcaster @relation(fields: [broadcasterId], references: [id], onDelete: Cascade)
 
@@ -983,8 +983,8 @@ model InactiveBroadcasterSocialAccount {
   name          String
   registDate    DateTime            @default(now())
   profileImage  String?
-  accessToken   String?
-  refreshToken  String?
+  accessToken   String?             @db.Text()
+  refreshToken  String?             @db.Text()
   broadcasterId Int
   broadcaster   InactiveBroadcaster @relation(fields: [broadcasterId], references: [id], onDelete: Cascade)
 
@@ -997,8 +997,8 @@ model InactiveSellerSocialAccount {
   name         String
   registDate   DateTime       @default(now())
   profileImage String?
-  accessToken  String?
-  refreshToken String?
+  accessToken  String?        @db.Text()
+  refreshToken String?        @db.Text()
   sellerId     Int
   seller       InactiveSeller @relation(fields: [sellerId], references: [id], onDelete: Cascade)
 
@@ -1317,8 +1317,8 @@ model CustomerSocialAccount {
   name         String // 이름
   registDate   DateTime @default(now()) // 생성일
   profileImage String? // 프로필사진
-  accessToken  String? // 액세스토큰
-  refreshToken String? // 리프레시토큰
+  accessToken  String?  @db.Text() // 액세스토큰
+  refreshToken String?  @db.Text() // 리프레시토큰
   customerId   Int // 소비자 고유번호
   customer     Customer @relation(fields: [customerId], references: [id], onDelete: Cascade)
 

--- a/libs/shared-types/src/index.ts
+++ b/libs/shared-types/src/index.ts
@@ -8,6 +8,7 @@ export * from './lib/constants/exchangeReturnCancelProcessDict';
 export * from './lib/constants/kkshowOrderStatuses';
 export * from './lib/constants/koreaProvinces';
 export * from './lib/constants/liveShoppingProgress';
+export * from './lib/constants/nextpageParamKey';
 export * from './lib/constants/orderProcessStepDict';
 export * from './lib/constants/orderStats';
 export * from './lib/constants/payment';

--- a/libs/shared-types/src/lib/constants/nextpageParamKey.ts
+++ b/libs/shared-types/src/lib/constants/nextpageParamKey.ts
@@ -1,0 +1,1 @@
+export const NEXT_PAGE_PARAM_KEY = 'nextpage';


### PR DESCRIPTION
# 문제점

크크마켓에서 현재 라이브 판매중인 상품을 찾기 어려움

### 문제가 발생하는 흐름

- 채팅링크클릭 → 상품페이지 → 옵션선택 → 메시지 작성 → 구매 → 회원가입필요 → 회원가입진행 → 크크마켓메인으로 이동되어 다시 라이브중인 상품을 찾아들어가야 하는데, 크크마켓에서는 찾을 수 없음. → 다시 방송화면으로 돌아가 채팅링크 클릭 → 구매

# 해결방법

1. 회원가입 이후 이동될 페이지 기능 추가
    - 현재 회원가입 이후 고정적으로 크크쇼 메인으로 이동되도록 구성되어있음.
    - 회원가입 이후 필요한 페이지로 이동할 수 있는 기능 추가 필요 (상품구매 → 회원가입 루트로 넘어왔다면 구매페이지로 이동)
2. ~~크크쇼메인 또는 크크마켓메인에 라이브쇼핑 진행중인 상품으로 이동될 수 있는 링크를 구성~~

# 할일

- [x]  회원가입 이후 이동될 페이지 기능 추가
    - [x]  이메일회원가입
    - [x]  소셜회원가입

# 테스트케이스

1. 테스트 시나리오1: 상품페이지 → 주문 → 이메일 회원가입
    - [ ]  회원가입 이후 올바르게 구매페이지로 이동된다
    - [ ]  구매 상품/옵션 정보가 올바르게 지정되어 있다
2. 테스트 시나리오2: 상품페이지 → 주문 → 소셜 회원가입
    1. 구글
        - [ ]  회원가입 이후 올바르게 구매페이지로 이동된다
        - [ ]  구매 상품/옵션 정보가 올바르게 지정되어 있다
    2. 네이버
        - [ ]  회원가입 이후 올바르게 구매페이지로 이동된다
        - [ ]  구매 상품/옵션 정보가 올바르게 지정되어 있다
    3. 카카오
        - [ ]  회원가입 이후 올바르게 구매페이지로 이동된다
        - [ ]  구매 상품/옵션 정보가 올바르게 지정되어 있다