### PR TITLE
feat(kkshow): 회원가입시 닉네임 입력 추가

### DIFF
--- a/libs/components-shared/src/lib/signup/SignupForm.tsx
+++ b/libs/components-shared/src/lib/signup/SignupForm.tsx
@@ -5,6 +5,7 @@ import {
   FormControl,
   FormErrorMessage,
   FormLabel,
+  HStack,
   Input,
   Stack,
   Text,
@@ -163,24 +164,57 @@ export function SignupForm({
       userType,
     ],
   );
+  const grayText = useColorModeValue('gray.500', 'gray.400');
   return (
     <CenterBox enableShadow header={{ title: '크크쇼 시작하기', desc: '' }}>
       <Stack mt={4} spacing={4} as="form" onSubmit={handleSubmit(onSubmit)}>
-        <FormControl isInvalid={!!errors.name}>
-          <FormLabel htmlFor="name">이름</FormLabel>
-          <Input
-            id="name"
-            type="text"
-            placeholder="김크크쇼"
-            autoComplete="off"
-            isReadOnly={phase === 2}
-            {...register('name', {
-              required: '이름을 작성해주세요.',
-              minLength: { value: 2, message: '이름은 2글자 이상이어야 합니다.' },
-            })}
-          />
-          <FormErrorMessage>{errors.name && errors.name.message}</FormErrorMessage>
-        </FormControl>
+        <HStack align="baseline">
+          <FormControl isInvalid={!!errors.name}>
+            <FormLabel htmlFor="name">
+              이름
+              <Text fontSize="xs" color={grayText} as="span">
+                (실명)
+              </Text>
+            </FormLabel>
+            <Input
+              id="name"
+              type="text"
+              placeholder="홍길동"
+              autoComplete="off"
+              isReadOnly={phase === 2}
+              {...register('name', {
+                required: '이름을 작성해주세요.',
+                minLength: { value: 2, message: '이름은 2글자 이상이어야 합니다.' },
+              })}
+            />
+            <FormErrorMessage fontSize="xs">
+              {errors.name && errors.name.message}
+            </FormErrorMessage>
+          </FormControl>
+
+          {userType === 'customer' && (
+            <FormControl isInvalid={!!errors.nickname}>
+              <FormLabel htmlFor="nickname">
+                닉네임
+                <Text fontSize="xs" color={grayText} as="span">
+                  (선택사항)
+                </Text>
+              </FormLabel>
+              <Input
+                id="nickname"
+                type="text"
+                placeholder="크크티비"
+                autoComplete="off"
+                isReadOnly={phase === 2}
+                {...register('nickname')}
+              />
+              <FormErrorMessage fontSize="xs">
+                {errors.nickname && errors.nickname.message}
+              </FormErrorMessage>
+            </FormControl>
+          )}
+        </HStack>
+
         <FormControl isInvalid={!!errors.email}>
           <FormLabel htmlFor="email">이메일</FormLabel>
           <Input
@@ -191,16 +225,14 @@ export function SignupForm({
             autoComplete="off"
             {...register('email', { ...emailRegisterOptions })}
           />
-          <FormErrorMessage>{errors.email && errors.email.message}</FormErrorMessage>
+          <FormErrorMessage fontSize="xs">
+            {errors.email && errors.email.message}
+          </FormErrorMessage>
         </FormControl>
         <FormControl isInvalid={!!errors.password}>
           <FormLabel htmlFor="password">
             암호
-            <Text
-              fontSize="xs"
-              color={useColorModeValue('gray.500', 'gray.400')}
-              as="span"
-            >
+            <Text fontSize="xs" color={grayText} as="span">
               (문자,숫자,특수문자 포함 8자 이상)
             </Text>
           </FormLabel>
@@ -211,7 +243,7 @@ export function SignupForm({
             placeholder="********"
             {...register('password', { ...passwordRegisterOptions })}
           />
-          <FormErrorMessage>
+          <FormErrorMessage fontSize="xs">
             {errors.password && errors.password.message}
           </FormErrorMessage>
         </FormControl>
@@ -219,11 +251,7 @@ export function SignupForm({
         <FormControl isInvalid={!!errors.repassword}>
           <FormLabel htmlFor="password">
             암호 확인
-            <Text
-              fontSize="xs"
-              color={useColorModeValue('gray.500', 'gray.400')}
-              as="span"
-            >
+            <Text fontSize="xs" color={grayText} as="span">
               (동일한 암호를 입력하세요.)
             </Text>
           </FormLabel>
@@ -239,7 +267,7 @@ export function SignupForm({
                 value === watch('password') || '암호가 동일하지 않습니다.',
             })}
           />
-          <FormErrorMessage>
+          <FormErrorMessage fontSize="xs">
             {errors.repassword && errors.repassword.message}
           </FormErrorMessage>
         </FormControl>
@@ -276,7 +304,9 @@ export function SignupForm({
                 </Text>
               )}
             </Flex>
-            <FormErrorMessage>{errors.code && errors.code.message}</FormErrorMessage>
+            <FormErrorMessage fontSize="xs">
+              {errors.code && errors.code.message}
+            </FormErrorMessage>
 
             <Flex alignItems="center" my={1}>
               <Text fontSize="sm" color="gray.500">

--- a/libs/nest-modules-customer/src/lib/customer.controller.ts
+++ b/libs/nest-modules-customer/src/lib/customer.controller.ts
@@ -22,6 +22,7 @@ import {
   HttpCacheInterceptor,
   UserPayload,
 } from '@project-lc/nest-core';
+import * as __multer from 'multer';
 import { JwtAuthGuard } from '@project-lc/nest-modules-authguard';
 import { CustomerCouponService } from '@project-lc/nest-modules-coupon';
 import { MailVerificationService } from '@project-lc/nest-modules-mail-verification';

--- a/libs/nest-modules-customer/src/lib/customer.service.ts
+++ b/libs/nest-modules-customer/src/lib/customer.service.ts
@@ -24,7 +24,7 @@ export class CustomerService {
         data: {
           email: dto.email,
           password: hashedPw,
-          nickname: '',
+          nickname: dto.nickname || '',
           name: dto.name,
           agreementFlag: true,
         },

--- a/libs/shared-types/src/lib/dto/signUp.dto.ts
+++ b/libs/shared-types/src/lib/dto/signUp.dto.ts
@@ -1,7 +1,9 @@
-import { IsEmail, IsString, Length } from 'class-validator';
+import { IsEmail, IsOptional, IsString, Length } from 'class-validator';
 
 export class SignUpDto {
   @IsEmail() email: string;
+
+  @IsOptional() @IsString() nickname?: string;
 
   @IsString() name: string;
 


### PR DESCRIPTION
# 문제

- 이름을 닉네임처럼 입력함
- 주문시 닉네임을 입력하지 않음

# 해결 방안

- 이름(본명)
- 닉네임(후원메시지에 표시)
- ‘김크크쇼’(닉네임같은 이름)를 ‘홍길동’으로 변경
- 이름 밑에 닉네임을 입력할 수 있도록한다. (이름과 닉네임을 구분한다.)
- 닉네임은 선택사항

# 기대 효과

- 닉네임과 이름을 헷갈리지 않도록

# 할일

- [x]  ‘이름’ 항목명을 ‘이름(실명)’ 으로 수정한다
- [x]  ‘이름' 항목의 플레이스홀더를 홍길동으로 변경한다
- [x]  닉네임 정보입력란 추가

# 테스트케이스

- [ ]  이름항목의 플레이스홀더가 올바르게 ‘홍길동’으로 적용되어있다
- [ ]  닉네임 입력란이 올바르게 보여진다
- [ ]  크크쇼-회원가입 닉네임 입력하지 않아도 가입 진행할 수 있다.
- [ ]  크크쇼-회원가입 닉네임 입력시 닉네임이 곧바로 설정된다.