### PR TITLE
feat: 후원메시지 닉네임 설정 추가 + 최초닉네임설정

### DIFF
--- a/libs/components-web-kkshow/src/lib/goods/GoodsViewPurchaseBox.tsx
+++ b/libs/components-web-kkshow/src/lib/goods/GoodsViewPurchaseBox.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-nested-ternary */
-import { CloseIcon, Icon } from '@chakra-ui/icons';
+import { CloseIcon } from '@chakra-ui/icons';
 import {
   Accordion,
   AccordionButton,
@@ -19,6 +19,7 @@ import {
   Grid,
   GridItem,
   IconButton,
+  Input,
   ListItem,
   Modal,
   ModalBody,
@@ -40,6 +41,7 @@ import { ClickableUnderlinedText } from '@project-lc/components-core/ClickableUn
 import {
   useCartMutation,
   useCustomerInfo,
+  useCustomerInfoMutation,
   useIsThisGoodsNowOnLive,
   useLiveShoppingNowOnLive,
   useProfile,
@@ -293,16 +295,26 @@ export function GoodsViewPurchaseBox({
 function GoodsViewBroadcasterSupportBox({
   goods,
 }: GoodsViewPurchaseBoxProps): JSX.Element | null {
-  const { selectedBc, handleSelectBc, supportMessage, onSupMsgChange } =
-    useGoodsViewStore(
-      (s) => ({
-        selectedBc: s.selectedBc,
-        handleSelectBc: s.handleSelectBc,
-        supportMessage: s.supportMessage,
-        onSupMsgChange: s.onSupMsgChange,
-      }),
-      shallow,
-    );
+  const { data: profile } = useProfile();
+  const { data: customer } = useCustomerInfo(profile?.id);
+  const {
+    selectedBc,
+    handleSelectBc,
+    supportMessage,
+    onSupMsgChange,
+    supportNickname,
+    onSupNickChange,
+  } = useGoodsViewStore(
+    (s) => ({
+      selectedBc: s.selectedBc,
+      handleSelectBc: s.handleSelectBc,
+      supportMessage: s.supportMessage,
+      onSupMsgChange: s.onSupMsgChange,
+      supportNickname: s.supportNickname,
+      onSupNickChange: s.onSuNickChange,
+    }),
+    shallow,
+  );
   const relatedBroadcasters = useMemo(() => {
     const livBcs =
       goods.LiveShopping?.map((liv) => liv.broadcaster).filter((x) => !!x) || [];
@@ -340,6 +352,11 @@ function GoodsViewBroadcasterSupportBox({
 
   // 현재 상품과 연결된 현재 판매중인 라이브쇼핑 목록
   const ls = useLiveShoppingNowOnLive({ goodsId: goods.id });
+
+  // 후원닉네임 최초값 설정 (등록된 닉네임 있는 경우)
+  useEffect(() => {
+    if (customer) onSupNickChange(customer?.nickname || '');
+  }, [customer, onSupNickChange]);
 
   if (relatedBroadcasters.length === 0) return null;
   return (
@@ -404,6 +421,15 @@ function GoodsViewBroadcasterSupportBox({
               </Box>
 
               <Box flex={1}>
+                <Text>후원 닉네임</Text>
+                <FormControl>
+                  <Input
+                    rounded="md"
+                    placeholder="후원 닉네임"
+                    value={supportNickname}
+                    onChange={(e) => onSupNickChange(e.target.value)}
+                  />
+                </FormControl>
                 <Text>
                   방송인 후원 메시지{' '}
                   <Text fontSize="xs" as="span" color="GrayText">
@@ -462,15 +488,6 @@ function GoodsViewSupportNotice(): JSX.Element {
               방송인이 라이브쇼핑 방송 중인 경우 후원메시지는 방송 화면에 전송됩니다.
             </Text>
           </ListItem>
-          <ListItem>
-            <Text>
-              방송인에게 선물하기 버튼{' '}
-              <Text as="span">
-                <Icon as={GoGift} verticalAlign="middle" />
-              </Text>{' '}
-              을 클릭하여 이 상품을 후원 방송인에게 선물할 수 있습니다.
-            </Text>
-          </ListItem>
         </UnorderedList>
       </Collapse>
     </Box>
@@ -492,6 +509,7 @@ function GoodsViewButtonSet({
   const selectedOpts = useGoodsViewStore((s) => s.selectedOpts);
   const selectedBc = useGoodsViewStore((s) => s.selectedBc);
   const supportMessage = useGoodsViewStore((s) => s.supportMessage);
+  const supportNickname = useGoodsViewStore((s) => s.supportNickname);
 
   /** 선택 상품 옵션 합계 정보 */
   const totalInfo = useMemo(() => {
@@ -552,6 +570,9 @@ function GoodsViewButtonSet({
     return SellType.normal;
   }, [isNowLive, selectedBc]);
 
+  // 닉네임 수정 요청
+  const nicknameMutation = useCustomerInfoMutation(customer?.id || -1);
+
   // 장바구니 담기
   const createCartItem = useCartMutation();
   const handleCartClick = useCallback((): void => {
@@ -579,7 +600,7 @@ function GoodsViewButtonSet({
         support: selectedBc
           ? {
               broadcasterId: selectedBc.id,
-              nickname: customer?.nickname || '', // 소비자 닉네임, 비회원의 경우 빈값처리
+              nickname: supportNickname || '',
               message: supportMessage,
               liveShoppingId: connectedLiveShoppingId,
               // 라이브쇼핑 후원의 경우 상품홍보 후원으로는 포함시키지 않는다. (수수료 두번 처리될 가능성)
@@ -589,7 +610,19 @@ function GoodsViewButtonSet({
             }
           : undefined,
       })
-      .then(() => cartDoneDialog.onOpen())
+      .then(() => {
+        // 로그인되어있으며, 기본 설정된 닉네임이 없는 경우 후원닉네임 입력한 값을 기본 닉네임으로 설정
+        if (
+          profile.data?.id &&
+          profile.data?.type === 'customer' &&
+          customer &&
+          !customer?.nickname &&
+          supportNickname
+        ) {
+          nicknameMutation.mutateAsync({ nickname: supportNickname });
+        }
+        cartDoneDialog.onOpen();
+      })
       .catch(() => {
         toast({
           status: 'error',
@@ -597,18 +630,22 @@ function GoodsViewButtonSet({
         });
       });
   }, [
-    cartDoneDialog,
-    createCartItem,
-    customer?.nickname,
     executePurchaseCheck,
     goods.LiveShopping,
-    goods.id,
     goods.productPromotion,
+    goods.id,
     goods.shippingGroupId,
-    selectedBc,
+    createCartItem,
     selectedOpts,
     sellType,
+    selectedBc,
+    supportNickname,
     supportMessage,
+    profile.data?.id,
+    profile.data?.type,
+    customer,
+    cartDoneDialog,
+    nicknameMutation,
     toast,
   ]);
 
@@ -659,7 +696,7 @@ function GoodsViewButtonSet({
               ? {
                   broadcasterId: selectedBc.id,
                   message: supportMessage,
-                  nickname: customer?.nickname || '', // 소비자 닉네임, 비회원의 경우 빈값처리
+                  nickname: supportNickname || '', // 소비자 닉네임, 비회원의 경우 빈값처리
                   avatar: selectedBc.avatar,
                   liveShoppingId: connectedLiveShoppingId,
                   // 라이브쇼핑 후원의 경우 상품홍보 후원으로는 포함시키지 않는다. (수수료 두번 처리될 가능성)
@@ -677,6 +714,17 @@ function GoodsViewButtonSet({
         router.push(`/login?from=purchase&nextpage=/payment`);
         return;
       }
+      // 로그인되어있으며, 설정된 닉네임이 없는 경우, 입력한 후원닉네임을 기본 닉네임으로 설정
+      if (
+        profile.data?.id &&
+        profile.data?.type === 'customer' &&
+        customer &&
+        !customer?.nickname &&
+        supportNickname
+      ) {
+        nicknameMutation.mutateAsync({ nickname: supportNickname });
+      }
+
       router.push('/payment');
     },
     [
@@ -692,12 +740,15 @@ function GoodsViewButtonSet({
       totalInfo.price,
       selectedBc,
       profile.data?.id,
+      profile.data?.type,
       selectedOpts,
       sellType,
       supportMessage,
-      customer?.nickname,
+      supportNickname,
+      customer,
       router,
       isNowLive,
+      nicknameMutation,
     ],
   );
 

--- a/libs/components-web-kkshow/src/lib/payment/OrderItemSupport.tsx
+++ b/libs/components-web-kkshow/src/lib/payment/OrderItemSupport.tsx
@@ -10,6 +10,7 @@ import {
   FormLabel,
   Input,
   Spinner,
+  Stack,
   Text,
 } from '@chakra-ui/react';
 import { useBroadcaster } from '@project-lc/hooks';
@@ -51,28 +52,37 @@ export function OrderItemSupport({
     <Flex>
       <Avatar size={avatarSize} src={broadcaster?.avatar || ''} mr={2} />
       <Box>
-        <Text fontWeight="semibold">{broadcaster?.userNickname}</Text>
-        <FormControl
-          isInvalid={
-            !!(errors.orderItems && errors.orderItems[orderItemIndex].support?.message)
-          }
-        >
-          <FormLabel mb={0} fontSize="xs">
-            구매후원메시지 (최대 30자)
-          </FormLabel>
-          <Input
-            size="sm"
-            {...register(`orderItems.${orderItemIndex}.support.message`, {
-              max: {
-                value: 30,
-                message: '후원메시지는 최대 30자까지 작성 가능합니다.',
-              },
-            })}
-          />
-          <FormErrorMessage>
-            {errors?.orderItems?.[orderItemIndex]?.support?.message}
-          </FormErrorMessage>
-        </FormControl>
+        <Text mt={2} fontWeight="semibold">
+          {broadcaster?.userNickname}
+        </Text>
+        <Stack>
+          <FormControl mt={2}>
+            <FormLabel mb={0} fontSize="xs">
+              후원닉네임
+            </FormLabel>
+            <Input {...register(`orderItems.${orderItemIndex}.support.nickname`)} />
+          </FormControl>
+          <FormControl
+            isInvalid={
+              !!(errors.orderItems && errors.orderItems[orderItemIndex].support?.message)
+            }
+          >
+            <FormLabel mb={0} fontSize="xs">
+              구매후원메시지 (최대 30자)
+            </FormLabel>
+            <Input
+              {...register(`orderItems.${orderItemIndex}.support.message`, {
+                max: {
+                  value: 30,
+                  message: '후원메시지는 최대 30자까지 작성 가능합니다.',
+                },
+              })}
+            />
+            <FormErrorMessage>
+              {errors?.orderItems?.[orderItemIndex]?.support?.message}
+            </FormErrorMessage>
+          </FormControl>
+        </Stack>
       </Box>
     </Flex>
   );

--- a/libs/components-web-kkshow/src/lib/payment/OrderItemSupport.tsx
+++ b/libs/components-web-kkshow/src/lib/payment/OrderItemSupport.tsx
@@ -79,7 +79,7 @@ export function OrderItemSupport({
               })}
             />
             <FormErrorMessage>
-              {errors?.orderItems?.[orderItemIndex]?.support?.message}
+              {errors?.orderItems?.[orderItemIndex]?.support?.message?.message}
             </FormErrorMessage>
           </FormControl>
         </Stack>

--- a/libs/components-web-kkshow/src/lib/payment/OrderPaymentForm.tsx
+++ b/libs/components-web-kkshow/src/lib/payment/OrderPaymentForm.tsx
@@ -84,7 +84,6 @@ export function OrderPaymentForm(): JSX.Element | null {
           ? {
               ...oi.support,
               broadcasterId: oi.support?.broadcasterId || null,
-              nickname: customer?.nickname || '',
             }
           : undefined,
       })),

--- a/libs/components-web-kkshow/src/lib/payment/ReceiptOrderItemInfo.tsx
+++ b/libs/components-web-kkshow/src/lib/payment/ReceiptOrderItemInfo.tsx
@@ -1,4 +1,5 @@
 import {
+  Avatar,
   Box,
   Center,
   Divider,
@@ -29,7 +30,7 @@ export function ReceiptOrderItemInfo({
 
       {data?.map((item) => (
         <Box key={item.id}>
-          <Grid templateColumns="repeat(8, 2fr)">
+          <Grid templateColumns="repeat(8, 2fr)" alignItems="start">
             <GridItem colSpan={8}>
               <HStack>
                 <BsShopWindow />
@@ -37,36 +38,50 @@ export function ReceiptOrderItemInfo({
               </HStack>
             </GridItem>
             <GridItem colSpan={5} mb={4}>
-              <Link
-                isTruncated
-                href={`${getCustomerWebHost()}/goods/${item.goods.id}`}
-                fontWeight="bold"
-                colorScheme="blue"
-                isExternal
-              >
-                <Flex direction="row" alignItems="center">
-                  <ChakraNextImage
-                    layout="intrinsic"
-                    src={`${item.goods.image[0].image}`}
-                    width={70}
-                    height={70}
-                  />
-                  <Flex direction="column" ml={1}>
-                    <Text>{item.goods.goods_name}</Text>
-                    {item.options.map((option) => (
-                      <Flex key={option.id} fontSize="xs">
-                        <Text as="span">옵션 : {option.value}</Text>
-                        <TextDotConnector mr={2} ml={2} />
-                        <Text>{option.quantity}개</Text>
-                        <TextDotConnector mr={2} ml={2} />
-                        <Text as="span">
-                          {Number(option.discountPrice).toLocaleString()}원
-                        </Text>
+              <Flex direction="row" alignItems="start" gap={2}>
+                <ChakraNextImage
+                  layout="intrinsic"
+                  src={`${item.goods.image[0].image}`}
+                  width={70}
+                  height={70}
+                  rounded="md"
+                />
+                <Flex direction="column" ml={1}>
+                  <Link
+                    isTruncated
+                    isExternal
+                    colorScheme="blue"
+                    href={`${getCustomerWebHost()}/goods/${item.goods.id}`}
+                  >
+                    <Text fontWeight="bold">{item.goods.goods_name}</Text>
+                  </Link>
+                  {item.options.map((option) => (
+                    <Flex key={option.id} fontSize="xs">
+                      <Text as="span">옵션 : {option.value}</Text>
+                      <TextDotConnector mr={2} ml={2} />
+                      <Text>{option.quantity}개</Text>
+                      <TextDotConnector mr={2} ml={2} />
+                      <Text as="span">
+                        {Number(option.discountPrice).toLocaleString()}원
+                      </Text>
+                    </Flex>
+                  ))}
+
+                  {item.support && (
+                    <Box mt={2} fontSize="sm">
+                      <Text fontWeight="bold">방송인 후원정보</Text>
+                      <Flex align="start" gap={1}>
+                        <Avatar src={item.support?.broadcaster.avatar || ''} size="sm" />
+                        <Box>
+                          <Text mt={2}>{item.support?.broadcaster.userNickname}</Text>
+                          <Text>후원닉네임: {item.support?.nickname}</Text>
+                          <Text>후원메시지: {item.support?.message}</Text>
+                        </Box>
                       </Flex>
-                    ))}
-                  </Flex>
+                    </Box>
+                  )}
                 </Flex>
-              </Link>
+              </Flex>
             </GridItem>
             <GridItem>
               <Center w="100%" h="100%">

--- a/libs/stores/src/lib/goodsViewStore.tsx
+++ b/libs/stores/src/lib/goodsViewStore.tsx
@@ -22,6 +22,8 @@ interface GoodsViewStore {
   handleSelectBc: (v: SelectedBc | null) => void;
   supportMessage: string;
   onSupMsgChange: (msg: string) => void;
+  supportNickname: string;
+  onSuNickChange: (msg: string) => void;
 }
 export const useGoodsViewStore = create<GoodsViewStore>((set, get) => ({
   selectedNavIdx: 0,
@@ -82,5 +84,9 @@ export const useGoodsViewStore = create<GoodsViewStore>((set, get) => ({
   onSupMsgChange: (msg: string) => {
     if (msg.length > 30) return;
     set({ supportMessage: msg });
+  },
+  supportNickname: '',
+  onSuNickChange: (nick: string) => {
+    set({ supportNickname: nick });
   },
 }));


### PR DESCRIPTION
# 일감개요

- 구매메시지 입력시 닉네임을 입력할수 있는 입력칸 추가
- 닉네임이 없는 상태에서 입력된 닉네임은 계정의 기본닉네임으로 설정됨
- 닉네임이 있는 상태에서는 구매메시지 닉네임칸에 기본적으로 작성되어있도록 구성
- 닉네임이 있어도 구매메시지에 입력한 닉네임으로 응원메시지 송출되도록 구성
- 비회원도 닉네임 입력 가능

# 할일

- front: 상품상세페이지
    - [x]  구매메시지 입력시 닉네임을 입력할수 있는 입력칸 추가
    - [x]  닉네임이 있는 상태에서는 구매메시지 닉네임칸에 기본적으로 작성되어있도록 구성

- front: 구매페이지(결제페이지)
    - [x]  닉네임 표시 추가
    - [x]  닉네임 수정 추가
    - [x]  상품상세에서 작성한 구매메시지가 기본적으로 작성되어있도록 구성

- front: 주문완료페이지
    - [x]  후원 정보 표시 추가 (닉,메시지, 후원방송인)
            
- back: 장바구니 처리
    - [x]  닉네임이 없는 상태에서 입력된 닉네임은 계정의 기본닉네임으로 설정요청 처리
- back: 구매 처리
    - [x]  닉네임이 없는 상태에서 입력된 닉네임은 계정의 기본닉네임으로 설정요청 처리

# 테스트케이스

- 상품상세페이지
- [ ]  상품상세페이지에서 구매메시지 입력시 닉네임 입력칸이 있다
- [ ]  상품상세페이지에서 구매메시지 입력시 닉네임 입력칸이 올바르게 동작한다
- [ ]  로그인 되어있으며 닉네임이 있는 구매자계정의 경우 상품상세페이지에서 구매메시지 입력시 닉네임이 기본적으로 작성되어 있다
- 구매페이지(결제페이지)
- [ ]  상품정보 - 후원정보에 닉네임이 표시된다
- [ ]  상품정보 - 후원정보에 닉네임이 올바르게 수정된다
- [ ]  상품상세페이지에서 작성한 닉네임으로 올바르게 작성되어 있다
- 주문완료페이지
- [ ]  방송인 후원 정보 포함된 경우, 주문 상품정보에 후원 정보가 올바르게 표시된다
- 장바구니담기시 닉네임 처리
- [ ]  후원정보를 작성한 상품을 장바구니에 담았을 때, 로그인되어있으며, 닉네임이 없는 구매자 계정인 경우 후원정보에 입력한 후원닉네임으로 계정의 닉네임이 자동 설정된다
- 구매시 닉네임처리
- [ ]  후원정보를 작성한 상품을 구매했을 때, 로그인되어있으며, 닉네임이 없는 구매자 계정인 경우 후원정보에 입력한 후원닉네임으로 계정의 닉네임이 자동 설정된다