### PR TITLE
fix(seller) : 주문목록 필터링 - 취소요청, 환불요청, 교환요청 배지 표시 

### DIFF
--- a/libs/components-seller/src/lib/kkshow-order/OrderFilterConsole.tsx
+++ b/libs/components-seller/src/lib/kkshow-order/OrderFilterConsole.tsx
@@ -210,37 +210,35 @@ export function OrderFilterConsole(): JSX.Element {
             )}
             <Divider />
             {(
-              Object.keys(kkshowOrderStatuses) as Array<keyof typeof kkshowOrderStatuses>
+              Object.keys(KkshowOrderCancelEnum) as Array<
+                keyof typeof kkshowOrderStatuses
+              >
             ).map((orderStatus) => {
               return (
-                <>
-                  {Object.keys(KkshowOrderCancelEnum).includes(orderStatus) && (
-                    <Checkbox
-                      m={1}
-                      aria-label={`order-status-${kkshowOrderStatuses[orderStatus].name}`}
-                      key={`extended-${orderStatus}`}
-                      colorScheme={kkshowOrderStatuses[orderStatus].chakraColor}
-                      isChecked={watch('searchExtendedStatus')?.includes(orderStatus)}
-                      onChange={(_) => {
-                        const prev = getValues('searchExtendedStatus');
-                        if (!prev) {
-                          return setValue('searchExtendedStatus', [orderStatus]);
-                        }
-                        if (prev.includes(orderStatus)) {
-                          return setValue(
-                            'searchExtendedStatus',
-                            prev.filter((x) => x !== orderStatus),
-                          );
-                        }
-                        return setValue('searchExtendedStatus', prev.concat(orderStatus));
-                      }}
-                    >
-                      <Badge colorScheme={kkshowOrderStatuses[orderStatus].chakraColor}>
-                        {kkshowOrderStatuses[orderStatus].name}
-                      </Badge>
-                    </Checkbox>
-                  )}
-                </>
+                <Checkbox
+                  m={1}
+                  aria-label={`order-status-${kkshowOrderStatuses[orderStatus].name}`}
+                  key={`extended-${orderStatus}`}
+                  colorScheme={kkshowOrderStatuses[orderStatus].chakraColor}
+                  isChecked={watch('searchExtendedStatus')?.includes(orderStatus)}
+                  onChange={(_) => {
+                    const prev = getValues('searchExtendedStatus');
+                    if (!prev) {
+                      return setValue('searchExtendedStatus', [orderStatus]);
+                    }
+                    if (prev.includes(orderStatus)) {
+                      return setValue(
+                        'searchExtendedStatus',
+                        prev.filter((x) => x !== orderStatus),
+                      );
+                    }
+                    return setValue('searchExtendedStatus', prev.concat(orderStatus));
+                  }}
+                >
+                  <Badge colorScheme={kkshowOrderStatuses[orderStatus].chakraColor}>
+                    {kkshowOrderStatuses[orderStatus].name}
+                  </Badge>
+                </Checkbox>
               );
             })}
           </Box>

--- a/libs/components-seller/src/lib/kkshow-order/OrderList.tsx
+++ b/libs/components-seller/src/lib/kkshow-order/OrderList.tsx
@@ -9,12 +9,7 @@ import {
   useBreakpoint,
   useDisclosure,
 } from '@chakra-ui/react';
-import {
-  GridColumns,
-  GridRowId,
-  GridToolbarContainer,
-  GridRowData,
-} from '@material-ui/data-grid';
+import { GridColumns, GridRowId, GridToolbarContainer } from '@material-ui/data-grid';
 import { OrderItemOption, ProcessStatus } from '@prisma/client';
 import { ChakraDataGrid } from '@project-lc/components-core/ChakraDataGrid';
 import { TooltipedText } from '@project-lc/components-core/TooltipedText';
@@ -31,8 +26,8 @@ import dayjs from 'dayjs';
 import NextLink from 'next/link';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { FaTruck } from 'react-icons/fa';
-import { KkshowOrderStatusBadge } from '../KkshowOrderStatusBadge';
 import ExportManyDialog from '../ExportManyDialog';
+import { KkshowOrderStatusBadge } from '../KkshowOrderStatusBadge';
 import OrderListDownloadDialog from './OrderListDownloadDialog';
 
 const columns: GridColumns = [
@@ -140,37 +135,32 @@ const columns: GridColumns = [
 ];
 
 function OrderStatusBadge(row: OrderDataWithRelations): JSX.Element {
-  // 환불/재배송(=반품/교환), 혹은 주문취소 요청이 있는경우
-  // 요청이 완료되었음에도 '취소요청' 등으로 표시되는 문제가 있어서
-  // 해당 요청이 모두 완료되지 않은 경우에만 해당 요청 상태로 표시하도록 수정하였습니다
-  if (
+  // 완료되지 않은 환불(반품), 교환요청이 있는경우 주문의 상태 옆에 취소요청, 교환요청, 반품요청 배지를 표시함
+  const hasUncompletedReturnRequest =
     row.returns &&
     row.returns.length > 0 &&
-    !row.returns.every((r) => r.status === ProcessStatus.complete)
-  ) {
-    return <KkshowOrderStatusBadge orderStatus="returns" />;
-  }
-  // 환불은 주문취소, 환불/재배송요청(=반품/교환요청)의 결과로 생기는 데이터입니다
-  // refunds가 존재한다 === (주문취소에 대한 환불처리가 완료되었음 || 환불(=반품) 요청에 대한 환불처리가 완료되었음)을 의미
-  // refunds가 존재한다 !== 환불요청이 존재한다
-  // if (row.refunds.length) {
-  //   return <KkshowOrderStatusBadge orderStatus="refunds" />;
-  // }
-  if (
+    !row.returns.every((r) => r.status === ProcessStatus.complete);
+  const hasUncompletedExchangeRequest =
     row.exchanges &&
     row.exchanges.length > 0 &&
-    !row.exchanges.every((e) => e.status === ProcessStatus.complete)
-  ) {
-    return <KkshowOrderStatusBadge orderStatus="exchanges" />;
-  }
-  if (
+    !row.exchanges.every((e) => e.status === ProcessStatus.complete);
+  const hasUncompletedCancelRequest =
     row.orderCancellations &&
     row.orderCancellations.length > 0 &&
-    !row.orderCancellations.every((c) => c.status === ProcessStatus.complete)
-  ) {
-    return <KkshowOrderStatusBadge orderStatus="orderCancellations" />;
-  }
-  return <KkshowOrderStatusBadge orderStatus={row.step} />;
+    !row.orderCancellations.every((c) => c.status === ProcessStatus.complete);
+
+  return (
+    <>
+      <KkshowOrderStatusBadge orderStatus={row.step} />
+      {hasUncompletedReturnRequest && <KkshowOrderStatusBadge orderStatus="returns" />}
+      {hasUncompletedExchangeRequest && (
+        <KkshowOrderStatusBadge orderStatus="exchanges" />
+      )}
+      {hasUncompletedCancelRequest && (
+        <KkshowOrderStatusBadge orderStatus="orderCancellations" />
+      )}
+    </>
+  );
 }
 
 export function OrderList(): JSX.Element {

--- a/libs/nest-modules-order/src/lib/order.service.ts
+++ b/libs/nest-modules-order/src/lib/order.service.ts
@@ -756,12 +756,23 @@ export class OrderService {
     // 주문상품옵션 중 자기 상품옵션만 남기기
     // 자기상품옵션 상태에 기반한 주문상태 표시
   */
-  private postProcessSellerOrders(
+  private async postProcessSellerOrders(
     orders: OrderDataWithRelations[],
     sellerId: number, // 판매자 고유번호
-  ): OrderDataWithRelations[] {
+  ): Promise<OrderDataWithRelations[]> {
+    const sellerShippingGroupList = await this.prisma.shippingGroup.findMany({
+      where: { sellerId },
+    });
     return orders.map((o) => {
-      const { orderItems, ...orderRestData } = o;
+      const {
+        orderItems,
+        exchanges,
+        returns,
+        orderCancellations,
+        shippings,
+        exports,
+        ...orderRestData
+      } = o;
 
       // 주문상품옵션 중 판매자 본인의 상품옵션만 남기기
       const sellerGoodsOrderItems = orderItems.filter(
@@ -775,16 +786,69 @@ export class OrderService {
           o.step,
           sellerGoodsOrderItems.flatMap((oi) => oi.options),
         );
+      } // * 판매자 본인의 배송비정책과 연결된 주문배송비정보만 보내기
+      let sellerShippings = shippings;
+
+      if (sellerShippingGroupList.length > 0) {
+        const shippingGroupIdList = sellerShippingGroupList.map((g) => g.id);
+        sellerShippings = shippings.filter((s) =>
+          shippingGroupIdList.includes(s.shippingGroupId),
+        );
       }
 
-      // if (dto.searchExtendedStatus.length) {
-      //   dto.searchExtendedStatus.map((item) => `${item}`)
-      // }
+      // * 판매자 상품이 포함된 교환/반품/취소/출고 데이터, 상품만 보내기
+      // 해당 판매자의 상품인 주문상품id (OrderItem.id) 목록
+      const sellerOrderItemsIdList = sellerGoodsOrderItems.map((item) => item.id);
+      // 판매자의 상품이 포함된 교환(재배송)요청
+      const sellerExchanges = exchanges
+        .map((ex) => ({
+          ...ex,
+          // 교환요청 상품 중 판매자의 상품만 필터
+          exchangeItems: ex.exchangeItems.filter((item) =>
+            sellerOrderItemsIdList.includes(item.orderItemId),
+          ),
+        }))
+        .filter((ex) => ex.exchangeItems.length > 0); // 판매자 상품이 포함된 교환요청만 필터
+
+      // 판매자 상품이 포함된 주문취소요청
+      const sellerOrderCancellations = orderCancellations
+        .map((oc) => ({
+          ...oc,
+          items: oc.items.filter((item) =>
+            sellerOrderItemsIdList.includes(item.orderItemId),
+          ),
+        }))
+        .filter((oc) => oc.items.length > 0);
+
+      // 판매자 상품이 포함된 반품요청
+      const sellerReturns = returns
+        .map((r) => ({
+          ...r,
+          items: r.items.filter((item) =>
+            sellerOrderItemsIdList.includes(item.orderItemId),
+          ),
+        }))
+        .filter((r) => r.items.length > 0);
+
+      // 판매자의 상품이 포함된 출고정보
+      const sellerExports = exports
+        .map((e) => ({
+          ...e,
+          items: e.items.filter((item) =>
+            sellerOrderItemsIdList.includes(item.orderItemId),
+          ),
+        }))
+        .filter((e) => e.items.length > 0);
 
       return {
         ...orderRestData,
         step: displaySellerOrderStep,
         orderItems: sellerGoodsOrderItems,
+        exchanges: sellerExchanges,
+        returns: sellerReturns,
+        orderCancellations: sellerOrderCancellations,
+        exports: sellerExports,
+        shippings: sellerShippings,
       };
     });
   }
@@ -797,7 +861,7 @@ export class OrderService {
 
     // 주문상품옵션 중 자기 상품옵션만 남기기
     // 자기상품옵션 상태에 기반한 주문상태 표시
-    const ordersWithOnlySellerGoodsOrderItems = this.postProcessSellerOrders(
+    const ordersWithOnlySellerGoodsOrderItems = await this.postProcessSellerOrders(
       orders,
       dto.sellerId,
     );


### PR DESCRIPTION
- ‘취소요청’ 상태의 주문이 ‘결제확인’ 필터에 포함됨 => 취소요청, 반품요청, 교환요청의 경우 주문/주문상품옵션의 상태가 아님
  - 이 세 경우가 포함되는 주문은 주문의 기존 상태 + 해당 상태를 같이 보여주는 방식으로 수정

**테스트케이스**
- 주문 상태가 ‘출고완료' 이고 해당 주문에 대해 소비자가 ‘환불요청’을 한 경우
    - [ ]  주문 상태에 ‘출고완료', ‘환불요청' 배지 두가지가 모두 표시된다
    - [ ]  해당 주문은 ‘출고완료' 필터를 적용해도 목록에 표시되고, ‘환불요청' 필터를 적용해도 목록에 표시된다
- 주문목록에서 판매자의 상품이 포함된 취소요청, 반품요청, 교환요청이 있는 경우에만 배지를 표시한다
    - 판매자1의 상품, 판매자2의 상품을 함께 구매(주문A) ⇒ 판매자2의 상품만 환불요청 한 경우
        - [ ]  판매자1의 주문목록에서 주문A는 환불요청 배지가 표시되지 않는다
        - [ ]  판매자2의 주문목록에서 주문A는 환불요청 배지가 표시된다