### PR TITLE
[크크쇼] 구매메시지 개선

### DIFF
--- a/apps/overlay-controller/src/lib/admin.js
+++ b/apps/overlay-controller/src/lib/admin.js
@@ -627,7 +627,7 @@ $(document).ready(function ready() {
             productName,
             purchaseNum: soldPrice,
             nickname: customerNickname,
-            nonMemberOrderFlag: true,
+            simpleMessageFlag: true,
             message: '',
           });
         }

--- a/apps/overlay/src/lib/overlayClient.js
+++ b/apps/overlay/src/lib/overlayClient.js
@@ -463,10 +463,7 @@ socket.on('get right-top purchase message', async (data) => {
 
 // 비회원 응원메세지
 socket.on('get non client purchase message', async (data) => {
-  const { nickname } = data;
-  const { productName } = data;
-  const price = data.purchaseNum;
-
+  const { nickname, productName, purchaseNum: price } = data;
   messageHtml = `
   <div class="donation-wrapper">
     <iframe src="/audio/alarm-type-1.wav"

--- a/libs/components-web-kkshow/src/lib/payment/OrderItemSupport.tsx
+++ b/libs/components-web-kkshow/src/lib/payment/OrderItemSupport.tsx
@@ -62,6 +62,7 @@ export function OrderItemSupport({
             </FormLabel>
             <Input {...register(`orderItems.${orderItemIndex}.support.nickname`)} />
           </FormControl>
+
           <FormControl
             isInvalid={
               !!(errors.orderItems && errors.orderItems[orderItemIndex].support?.message)
@@ -79,7 +80,7 @@ export function OrderItemSupport({
               })}
             />
             <FormErrorMessage>
-              {errors?.orderItems?.[orderItemIndex]?.support?.message}
+              {errors?.orderItems?.[orderItemIndex]?.support?.message?.message}
             </FormErrorMessage>
           </FormControl>
         </Stack>

--- a/libs/components-web-kkshow/src/lib/payment/OrderPaymentForm.tsx
+++ b/libs/components-web-kkshow/src/lib/payment/OrderPaymentForm.tsx
@@ -1,5 +1,5 @@
 import { Grid, GridItem, Heading, Stack } from '@chakra-ui/react';
-import { useCustomerInfo, useProfile } from '@project-lc/hooks';
+import { useProfile } from '@project-lc/hooks';
 import { CreateOrderForm } from '@project-lc/shared-types';
 import { useCartStore, useKkshowOrderStore } from '@project-lc/stores';
 import { getCustomerWebHost } from '@project-lc/utils';
@@ -146,6 +146,7 @@ export function OrderPaymentForm(): JSX.Element | null {
         py={6}
         mb={{ base: 0, lg: 20 }}
         as="form"
+        id="order-payment-form"
         onSubmit={methods.handleSubmit(onSubmit)}
       >
         <GridItem colSpan={7}>

--- a/libs/components-web-kkshow/src/lib/payment/OrderPaymentForm.tsx
+++ b/libs/components-web-kkshow/src/lib/payment/OrderPaymentForm.tsx
@@ -2,7 +2,11 @@ import { Grid, GridItem, Heading, Stack } from '@chakra-ui/react';
 import { useCustomerInfo, useProfile } from '@project-lc/hooks';
 import { CreateOrderForm } from '@project-lc/shared-types';
 import { useCartStore, useKkshowOrderStore } from '@project-lc/stores';
+import { getCustomerWebHost } from '@project-lc/utils';
 import { setCookie } from '@project-lc/utils-frontend';
+import { loadTossPayments } from '@tosspayments/payment-sdk';
+import dayjs from 'dayjs';
+import { nanoid } from 'nanoid';
 import { useEffect } from 'react';
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { BuyerInfo } from './BuyerInfo';
@@ -10,13 +14,36 @@ import { DeliveryAddress } from './DeliveryAddress';
 import { Discount } from './Discount';
 import { GiftBox } from './Gift';
 import { OrderItemInfo } from './OrderItemInfo';
-import { doPayment, getOrderPrice, PaymentBox } from './Payment';
+import { getOrderPrice, PaymentBox } from './Payment';
 import PaymentNotice from './PaymentNotice';
 import { PaymentSelection } from './PaymentSelection';
 
+export async function doPayment(
+  paymentType: '카드' | '계좌이체' | '가상계좌' | '미선택',
+  client_key: string,
+  amount: number,
+  productName: string,
+  customerName: string,
+): Promise<void> {
+  return loadTossPayments(client_key)
+    .then((tossPayments) => {
+      return tossPayments.requestPayment(paymentType, {
+        amount,
+        orderId: `${dayjs().format('YYYYMMDDHHmmssSSS')}${nanoid(6)}`,
+        orderName: `${productName}`,
+        customerName,
+        successUrl: `${getCustomerWebHost()}/payment/success`,
+        failUrl: `${getCustomerWebHost()}/payment/fail`,
+      });
+    })
+    .catch((err) => {
+      console.error('Error - loadTossPayments');
+      console.error(err);
+    });
+}
+
 export function OrderPaymentForm(): JSX.Element | null {
   const { data: profile } = useProfile();
-  const { data: customer } = useCustomerInfo(profile?.id);
   const orderPrepareData = useKkshowOrderStore((s) => s.order);
 
   const methods = useForm<CreateOrderForm>({
@@ -84,7 +111,6 @@ export function OrderPaymentForm(): JSX.Element | null {
           ? {
               ...oi.support,
               broadcasterId: oi.support?.broadcasterId || null,
-              nickname: customer?.nickname || '',
             }
           : undefined,
       })),

--- a/libs/components-web-kkshow/src/lib/payment/Payment.tsx
+++ b/libs/components-web-kkshow/src/lib/payment/Payment.tsx
@@ -3,15 +3,11 @@ import SectionWithTitle from '@project-lc/components-layout/SectionWithTitle';
 import { useDefaultMileageSetting } from '@project-lc/hooks';
 import { CreateOrderForm } from '@project-lc/shared-types';
 import { useKkshowOrderStore } from '@project-lc/stores';
-import { getCustomerWebHost } from '@project-lc/utils';
 import { getLocaleNumber } from '@project-lc/utils-frontend';
-import { loadTossPayments } from '@tosspayments/payment-sdk';
-import dayjs from 'dayjs';
-import { nanoid } from 'nanoid';
-import { useFormContext } from 'react-hook-form';
 import { useMemo } from 'react';
-import { TermBox } from './TermBox';
+import { useFormContext } from 'react-hook-form';
 import { KkshowSubNavbarHeight } from '../KkshowSubNavbar';
+import { TermBox } from './TermBox';
 
 export function getOrderPrice(
   originalPrice: number,
@@ -22,31 +18,6 @@ export function getOrderPrice(
 ): number {
   return originalPrice + shippingCost - discount - mileageDiscount - couponDiscount;
 }
-
-export async function doPayment(
-  paymentType: '카드' | '계좌이체' | '가상계좌' | '미선택',
-  client_key: string,
-  amount: number,
-  productName: string,
-  customerName: string,
-): Promise<void> {
-  return loadTossPayments(client_key)
-    .then((tossPayments) => {
-      return tossPayments.requestPayment(paymentType, {
-        amount,
-        orderId: `${dayjs().format('YYYYMMDDHHmmssSSS')}${nanoid(6)}`,
-        orderName: `${productName}`,
-        customerName,
-        successUrl: `${getCustomerWebHost()}/payment/success`,
-        failUrl: `${getCustomerWebHost()}/payment/fail`,
-      });
-    })
-    .catch((err) => {
-      console.error('Error - loadTossPayments');
-      console.error(err);
-    });
-}
-
 export function MileageBenefit({
   productPrice,
   mileage,

--- a/libs/components-web-kkshow/src/lib/payment/Payment.tsx
+++ b/libs/components-web-kkshow/src/lib/payment/Payment.tsx
@@ -196,6 +196,7 @@ export function PaymentBox(): JSX.Element {
       <Center>
         <Button
           type="submit"
+          form="order-payment-form"
           size="lg"
           colorScheme="blue"
           isFullWidth

--- a/libs/nest-modules-order/src/lib/order.service.ts
+++ b/libs/nest-modules-order/src/lib/order.service.ts
@@ -408,17 +408,15 @@ export class OrderService {
           broadcasterId: x.support.broadcasterId,
           productName: x.goodsName,
           purchaseNum,
-          nickname: nonMemberOrderFlag
-            ? setting?.fanNick || '비회원'
-            : x.support.nickname,
+          nickname: x.support?.nickname || setting?.fanNick || '익명의구매자',
           message: giftFlag
             ? `[방송인에게 선물!] ${x.support.message}`
-            : x.support.message,
+            : x.support.message || '',
           ttsSetting: setting?.ttsSetting || TtsSetting.full,
           level: setting?.levelCutOffPoint < purchaseNum ? '2' : '1',
-          nonMemberOrderFlag,
           giftFlag,
           liveShoppingId: x.support.liveShoppingId,
+          simpleMessageFlag: !x.support?.nickname, // 닉네임이 없는 경우 간단 메시지 송출 + 랭킹반영X
         };
       });
     // orderItems를 구매메시지 데이터로 전환한 배열의 각 송출 overlay 채널을 조회
@@ -444,7 +442,7 @@ export class OrderService {
           email: purchase.roomName,
           level: purchase.level,
           liveShoppingId: purchase.liveShoppingId,
-          loginFlag: !purchase.nonMemberOrderFlag,
+          loginFlag: !nonMemberOrderFlag,
           message: purchase.message,
           nickname: purchase.nickname,
           productName: purchase.productName,

--- a/libs/nest-modules-order/src/lib/order.service.ts
+++ b/libs/nest-modules-order/src/lib/order.service.ts
@@ -442,7 +442,7 @@ export class OrderService {
           email: purchase.roomName,
           level: purchase.level,
           liveShoppingId: purchase.liveShoppingId,
-          loginFlag: !nonMemberOrderFlag,
+          loginFlag: !purchase.simpleMessageFlag,
           message: purchase.message,
           nickname: purchase.nickname,
           productName: purchase.productName,

--- a/libs/nest-modules-overlay/src/overlay/overlay.controller.ts
+++ b/libs/nest-modules-overlay/src/overlay/overlay.controller.ts
@@ -67,11 +67,12 @@ export class OverlayController {
   // API -> 마이크로서비스 -> Overlay 구매메시지 핸들러
   @MessagePattern('liveshopping:overlay:purchase-msg')
   public async handlePurchaseMsg(@Payload() purchase: PurchaseMessage): Promise<void> {
-    if (purchase.nonMemberOrderFlag)
-      return this.overlayService.handlePurchaseMessageNonMember(
+    if (purchase.simpleMessageFlag) {
+      return this.overlayService.handleSimplePurchaseMessage(
         purchase,
         this.overlayMessageGateway.server,
       );
+    }
     return this.overlayService.handlePurchaseMessage(
       purchase,
       this.overlayMessageGateway.server,

--- a/libs/nest-modules-overlay/src/overlay/overlay.message.gateway.ts
+++ b/libs/nest-modules-overlay/src/overlay/overlay.message.gateway.ts
@@ -68,7 +68,7 @@ export class OverlayMessageGateway
    */
   @SubscribeMessage('get non client purchase message from admin')
   getNonClientMessage(@MessageBody() data: PurchaseMessage): void {
-    this.overlayService.handlePurchaseMessageNonMember(data, this.server);
+    this.overlayService.handleSimplePurchaseMessage(data, this.server);
   }
 
   // 하단 응원메세지 복구

--- a/libs/nest-modules-overlay/src/overlay/overlay.service.ts
+++ b/libs/nest-modules-overlay/src/overlay/overlay.service.ts
@@ -187,7 +187,7 @@ export class OverlayService {
   }
 
   /** 구매 메시지(비회원) 송출 핸들러 (overlay client 화면으로 송출 이벤트 전달) */
-  public async handlePurchaseMessageNonMember(
+  public async handleSimplePurchaseMessage(
     purchase: PurchaseMessage,
     socketServer: Server,
   ): Promise<void> {

--- a/libs/prisma-orm/prisma/schema.prisma
+++ b/libs/prisma-orm/prisma/schema.prisma
@@ -777,7 +777,7 @@ model LiveShoppingPurchaseMessage {
   price              Int // 구매금액
   phoneCallEventFlag Boolean      @default(false) // 전화 이벤트 참여 여부 
   giftFlag           Boolean      @default(false) // 스트리머����� 선물하기 여부
-  loginFlag          Boolean      @default(true) // 회원 | 비회원 구분 \
+  loginFlag          Boolean      @default(true) // 구매메시지 기본송출 여부 (true: 기본메시지송출, false: 간략메시지 송출)
   broadcaster        Broadcaster  @relation(fields: [broadcasterEmail], references: [email])
   broadcasterEmail   String // 스트리머의 아이디 
   createDate         DateTime     @default(now()) // 작성일자

--- a/libs/prisma-orm/prisma/seedData/kkshowSubNav.ts
+++ b/libs/prisma-orm/prisma/seedData/kkshowSubNav.ts
@@ -10,8 +10,8 @@ export const createKkshowSubNavDummy = async (prisma: PrismaClient): Promise<voi
       },
       {
         index: 2,
-        link: 'https://naver.com',
-        name: '네이버',
+        link: '/goods/4',
+        name: '4번상품',
       },
       {
         index: 3,

--- a/libs/shared-types/src/lib/overlay-controller/overlay-controller-types.ts
+++ b/libs/shared-types/src/lib/overlay-controller/overlay-controller-types.ts
@@ -3,7 +3,10 @@ import { PurchaseMessage } from '../overlay/overlay-types';
 export interface PurchaseMessageWithLoginFlag extends Omit<PurchaseMessage, 'roomName'> {
   /** broadcaster email */
   email: string;
-  /** 메세지 작성자 로그인 여부 */
+  /**
+   * 220822 이후 이 필드의 새로운 의미 -> 구매메시지 기본송출 여부 (true: 기본메시지송출, false: 간략메시지 송출)
+   *
+   * ~~메세지 작성자 로그인 여부~~ */
   loginFlag: boolean;
   /** 메세지 작성자 스트리머에게 선물하기 여부 */
   giftFlag: boolean;

--- a/libs/shared-types/src/lib/overlay/overlay-types.ts
+++ b/libs/shared-types/src/lib/overlay/overlay-types.ts
@@ -59,8 +59,8 @@ export interface PurchaseMessage {
   purchaseNum: number;
   /** tts 세팅 */
   ttsSetting: TtsSetting;
-  /** 비회원 메시지 여부 */
-  nonMemberOrderFlag?: boolean;
+  /** 간략 메시지(닉네임을 알 수 없는 익명메시지) 여부 */
+  simpleMessageFlag?: boolean;
   /** 선물 구매 여부 */
   giftFlag?: boolean;
 }


### PR DESCRIPTION
# 일감 개요

### 문제점

1. 회원가입을 했지만 닉네임을 설정하지 않은 경우 ‘’(공백)으로 응원메시지와 구매랭킹이 뜬다.

### 해결방법

1. 닉네임이 등록되지 않은 경우 응원메시지 및 구매랭킹에 포함시키지 않는다. (비회원 구매로 간주) = 후원 메시지 입력시 닉네임을 입력받으므로, 비회원 메시지 구분을 “비회원 주문인지 아닌지” 로 판단하지 않고 닉네임/메시지가 있는지 없는지로 판단하도록 수정

# 할일

**비회원주문인지 여부가 아닌, 닉네임/메시지가 작성되었는 지 여부에 따라 메시지 유형을 구분하도록 수정**

- 닉네임X, 메시지X의 경우
    - [x]  팬닉(설정안된경우 '알수없는구매자’) +‘간소화’ 송출
- 닉네임O, 메시지X의 경우
    - [x]  빈 메시지로 ‘기본’ 송출
- 닉네임X, 메시지O의 경우
    - [x]  팬닉(설정안된경우 '알수없는구매자’) +‘간소화’ 송출
- 닉네임O, 메시지O의 경우
    - [x]  ‘기본’ 송출

# 테스트케이스

- [ ]  **비회원주문인지 여부가 아닌, 닉네임/메시지가 작성되었는 지 여부에 따라 메시지 유형이 올바르게 구분된다.**
    - 닉네임X, 메시지X의 경우
        - [ ]  팬닉(설정안된경우 '알수없는구매자’) +‘간소화’ 송출
    - 닉네임O, 메시지X의 경우
        - [ ]  빈 메시지로 ‘기본’ 송출
    - 닉네임X, 메시지O의 경우
        - [ ]  팬닉(설정안된경우 '알수없는구매자’) +‘간소화’ 송출
    - 닉네임O, 메시지O의 경우
        - [ ]  ‘기본’ 송출