### PR TITLE
feat: 관리자 주문목록/주문상세 선물 여부 조회 기능

### DIFF
--- a/apps/admin/pages/order/list/[orderId].tsx
+++ b/apps/admin/pages/order/list/[orderId].tsx
@@ -114,6 +114,12 @@ export function OrderDetail(): JSX.Element {
               <Text>{data.ordererEmail}</Text>
             </Flex>
             <Flex justifyContent="space-between">
+              <Text>선물주문여부</Text>
+              <Text color={data.giftFlag ? 'red.500' : 'unset'}>
+                {data.giftFlag ? '이 주문은 선물 주문입니다' : 'X'}
+              </Text>
+            </Flex>
+            <Flex justifyContent="space-between">
               <Text>단계</Text>
               <Flex>
                 {!isEdit ? (
@@ -251,7 +257,14 @@ export function OrderDetail(): JSX.Element {
             </Box>
             <Flex justifyContent="space-between">
               <Text>수령인 이름</Text>
-              <Text>{data.recipientName}</Text>
+              <Text>
+                {data.giftFlag ? (
+                  <Text as="span" color="red.500">
+                    {'[선물주문!] 아래 배송지는 방송인 선물 수령지입니다. => '}
+                  </Text>
+                ) : null}
+                {data.recipientName}
+              </Text>
             </Flex>
             <Flex justifyContent="space-between">
               <Text>수령인 연락처</Text>

--- a/libs/components-admin/src/lib/AdminOrderList.tsx
+++ b/libs/components-admin/src/lib/AdminOrderList.tsx
@@ -66,13 +66,15 @@ const columns: GridColumns = [
     valueGetter: ({ row }) => {
       const _row = row as OrderListRes['orders'][number];
       const oiIncludesSupports = _row.orderItems.filter((x) => !!x.support);
+      const gitftOrderStr = _row.giftFlag ? '[선물]' : '';
       if (oiIncludesSupports.length > 1) {
-        return `${`${
+        return `${gitftOrderStr} ${`${
           oiIncludesSupports[0]?.support?.broadcaster?.userNickname || ''
         } 외 ${oiIncludesSupports.length - 1}`}명`;
       }
       return oiIncludesSupports[0]?.support
-        ? oiIncludesSupports[0]?.support?.broadcaster?.userNickname || ''
+        ? `${gitftOrderStr} ${oiIncludesSupports[0]?.support?.broadcaster?.userNickname}` ||
+            ''
         : '후원X';
     },
   },


### PR DESCRIPTION
# 문제사항

관리자가 주문목록/주문상세페이지에서 주문이 선물 주문인지 여부를 판단할 수 없다.

- 관리자 주문목록, 주문상세
    - 선물여부 보여지도록 구성

# 할일

- [ ]  관리자 주문목록 선물여부 추가
- [ ]  관리자 주문상세 선물여부 추가

# 테스트케이스

- [ ]  관리자 주문목록에서 선물주문인 경우 선물 여부를 확인할 수 있다
- [ ]  관리자 주문상세에서 선물주문인 경우 선물 여부를 확인할 수 있다