### PR TITLE
fix(common) : resetPassword 페이지 폼 전송버튼 추가

### DIFF
--- a/libs/components-shared/src/lib/PasswordChangeForm.tsx
+++ b/libs/components-shared/src/lib/PasswordChangeForm.tsx
@@ -50,7 +50,7 @@ export function PasswordChangeForm(props: PasswordChangeFormProps): JSX.Element 
           title: `새 비밀번호 등록 실패`,
           status: 'error',
         });
-        onCancel();
+        if (onCancel) onCancel();
       })
       .finally(() => {
         reset();

--- a/libs/components-shared/src/lib/ResetPasswordForm.tsx
+++ b/libs/components-shared/src/lib/ResetPasswordForm.tsx
@@ -252,11 +252,19 @@ export function ResetPasswordForm(): JSX.Element {
 
       {/* step 2 : 비밀번호 재설정 */}
       {step === 2 && (
-        <PasswordChangeForm
-          email={getValues('email')}
-          onCancel={moveToStepZero}
-          onConfirm={() => router.push('/login')}
-        />
+        <Box>
+          <PasswordChangeForm
+            email={getValues('email')}
+            onCancel={moveToStepZero}
+            onConfirm={() => router.push('/login')}
+          />
+          <Stack direction="row">
+            <Button onClick={moveToStepZero}>취소</Button>
+            <Button colorScheme="blue" type="submit" form="password-change-form">
+              비밀번호 변경
+            </Button>
+          </Stack>
+        </Box>
       )}
     </CenterBox>
   );


### PR DESCRIPTION
비밀번호 재설정 페이지에서 사용하는 비밀번호 입력폼은 다른 컴포넌트(PasswordChangeDialog)에서도 사용중임
다른 컴포넌트에는 sumit 버튼이 있으나 비밀번호 재설정페이지에는 해당 버튼이 없어서 비밀번호 재설정을 할 수 없었음
submit 버튼을 추가하여 비밀번호 재설정페이지에서도 비밀번호를 변경할 수 있도록 수정함

- [ ] 소비자, 판매자, 방송인센터 비밀번호재설정페이지 (/resetPassword) 에 비밀번호 변경 버튼이 존재한다. 해당 버튼을 눌러 비밀번호를 재설정 할 수 있다