### PR TITLE
feat: 소셜로그인시 프로필 사진 기본 등록 제거처리

### DIFF
--- a/libs/nest-modules-auth/src/social/social.service.ts
+++ b/libs/nest-modules-auth/src/social/social.service.ts
@@ -36,7 +36,7 @@ interface UserDataInterface {
   provider: string;
   email: string;
   name: string;
-  picture: string;
+  picture?: string;
   accessToken: string;
   refreshToken?: string;
 }

--- a/libs/nest-modules-auth/src/social/strategy/google.strategy.ts
+++ b/libs/nest-modules-auth/src/social/strategy/google.strategy.ts
@@ -39,6 +39,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, GOOGLE_PROVIDER) 
     refreshToken: string,
     profile: Profile,
   ): Promise<Seller | Broadcaster | Customer> {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { id, displayName, emails, photos } = profile;
 
     if (!emails[0].value) {
@@ -57,7 +58,8 @@ export class GoogleStrategy extends PassportStrategy(Strategy, GOOGLE_PROVIDER) 
       provider: GOOGLE_PROVIDER,
       email: emails[0].value,
       name: displayName,
-      picture: photos[0].value,
+      // 220822 주석처리 => 연관일감: [회원가입] 소셜로그인시 프로필사진 받아온 프로필사진으로 설정하지 않기 by dan
+      // picture: photos[0].value,
       accessToken,
       refreshToken,
     });

--- a/libs/nest-modules-auth/src/social/strategy/kakao.strategy.ts
+++ b/libs/nest-modules-auth/src/social/strategy/kakao.strategy.ts
@@ -33,6 +33,7 @@ export class KakaoStrategy extends PassportStrategy(Strategy, KAKAO_PROVIDER) {
     const { id, username, _json } = profile;
     const { kakao_account } = _json;
     const { email, profile: kakaoProfile } = kakao_account;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { is_default_image, profile_image_url } = kakaoProfile;
 
     if (!email) {
@@ -51,7 +52,8 @@ export class KakaoStrategy extends PassportStrategy(Strategy, KAKAO_PROVIDER) {
       provider: KAKAO_PROVIDER,
       email,
       name: username,
-      picture: is_default_image ? '' : profile_image_url,
+      // 220822 주석처리 => 연관일감: [회원가입] 소셜로그인시 프로필사진 받아온 프로필사진으로 설정하지 않기 by dan
+      // picture: is_default_image ? '' : profile_image_url,
       accessToken,
       refreshToken,
     });

--- a/libs/nest-modules-auth/src/social/strategy/naver.strategy.ts
+++ b/libs/nest-modules-auth/src/social/strategy/naver.strategy.ts
@@ -31,6 +31,7 @@ export class NaverStrategy extends PassportStrategy(Strategy, NAVER_PROVIDER) {
     refreshToken: null,
     profile: Profile,
   ): Promise<Seller | Broadcaster | Customer> {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { email, nickname, profile_image, id } = profile._json;
 
     if (!email) {
@@ -49,7 +50,8 @@ export class NaverStrategy extends PassportStrategy(Strategy, NAVER_PROVIDER) {
       provider: NAVER_PROVIDER,
       email,
       name: nickname,
-      picture: profile_image,
+      // 220822 주석처리 => 연관일감: [회원가입] 소셜로그인시 프로필사진 받아온 프로필사진으로 설정하지 않기 by dan
+      // picture: profile_image,
       accessToken,
       refreshToken,
     });


### PR DESCRIPTION
# 문제점

소셜로그인시 정보 제공 동의를 받지만 사적인 프로필사진을 크크쇼 프로필사진으로 등록하는 것은 이상하다

# 해결방법/할일

- [x]  소셜로그인시 제공받는 프로필사진 정보를 크크쇼 프로필사진으로 설정하지 않도록 한다.

# 테스트케이스

- [ ]  소셜로그인시 프로필사진이 자동으로 설정되지 않는다.
    - [ ]  카카오
    - [ ]  네이버
    - [ ]  구글