### PR TITLE
[크크쇼] 첫 입력주소 자동 기본배송지

### DIFF
--- a/libs/components-web-kkshow/src/lib/payment/DeliveryAddressList.tsx
+++ b/libs/components-web-kkshow/src/lib/payment/DeliveryAddressList.tsx
@@ -13,6 +13,7 @@ import { CustomerAddress } from '@prisma/client';
 import { CreateOrderForm } from '@project-lc/shared-types';
 import { useKkshowOrderStore } from '@project-lc/stores';
 import { useFormContext } from 'react-hook-form';
+import { CustomerAddressCreateButton } from '../address/CustomerAddressCreateDialog';
 import CustomerAddressList from '../address/CustomerAddressList';
 
 type DeliveryListProps = {
@@ -23,13 +24,14 @@ type DeliveryListProps = {
 export function DeliveryAddressList({ onClose, isOpen }: DeliveryListProps): JSX.Element {
   const { handleAddressType } = useKkshowOrderStore();
   const handleAddressSelect = (data: CustomerAddress): void => {
-    const phone1 = data.phone?.slice(0, 3);
-    const phone2 = data.phone?.slice(3, 7);
-    const phone3 = data.phone?.slice(7, 12);
+    const phoneData = (data.phone || '').match(/(\d+)/g);
+    if (phoneData && phoneData.length === 3) {
+      const [phone1, phone2, phone3] = phoneData;
+      setValue('recipientPhone1', phone1 || '');
+      setValue('recipientPhone2', phone2 || '');
+      setValue('recipientPhone3', phone3 || '');
+    }
     setValue('recipientName', data.recipient || '');
-    setValue('recipientPhone1', phone1 || '');
-    setValue('recipientPhone2', phone2 || '');
-    setValue('recipientPhone3', phone3 || '');
     setValue('recipientPostalCode', data.postalCode || '');
     setValue('recipientAddress', data.address || '');
     setValue('recipientDetailAddress', data.detailAddress || '');
@@ -51,6 +53,7 @@ export function DeliveryAddressList({ onClose, isOpen }: DeliveryListProps): JSX
         <ModalCloseButton />
         <ModalHeader>배송지목록</ModalHeader>
         <ModalBody>
+          <CustomerAddressCreateButton />
           <Center>
             <CustomerAddressList
               editable={false}

--- a/libs/components-web-kkshow/src/lib/payment/DeliveryAddressList.tsx
+++ b/libs/components-web-kkshow/src/lib/payment/DeliveryAddressList.tsx
@@ -23,19 +23,33 @@ type DeliveryListProps = {
 
 export function DeliveryAddressList({ onClose, isOpen }: DeliveryListProps): JSX.Element {
   const { handleAddressType } = useKkshowOrderStore();
+  const { setValue } = useFormContext<CreateOrderForm>();
   const handleAddressSelect = (data: CustomerAddress): void => {
-    const phoneData = (data.phone || '').match(/(\d+)/g);
-    if (phoneData && phoneData.length === 3) {
-      const [phone1, phone2, phone3] = phoneData;
-      setValue('recipientPhone1', phone1 || '');
-      setValue('recipientPhone2', phone2 || '');
-      setValue('recipientPhone3', phone3 || '');
+    const phoneData = data.phone || '';
+    if (/(\d+)-(\d+)-(\d+)/g.test(phoneData)) {
+      const _phoneData = (data.phone || '').match(/(\d+)/g);
+      if (_phoneData && _phoneData.length === 3) {
+        const [phone1, phone2, phone3] = _phoneData;
+        setValue('recipientPhone1', phone1 || '', { shouldValidate: true });
+        setValue('recipientPhone2', phone2 || '', { shouldValidate: true });
+        setValue('recipientPhone3', phone3 || '', { shouldValidate: true });
+      }
     }
-    setValue('recipientName', data.recipient || '');
-    setValue('recipientPostalCode', data.postalCode || '');
-    setValue('recipientAddress', data.address || '');
-    setValue('recipientDetailAddress', data.detailAddress || '');
-    setValue('memo', data.memo || '');
+    if (/\d+$/g.test(phoneData)) {
+      const phone1 = phoneData.slice(0, 3);
+      const phone2 = phoneData.slice(3, 7);
+      const phone3 = phoneData.slice(7, 11);
+      setValue('recipientPhone1', phone1 || '', { shouldValidate: true });
+      setValue('recipientPhone2', phone2 || '', { shouldValidate: true });
+      setValue('recipientPhone3', phone3 || '', { shouldValidate: true });
+    }
+    setValue('recipientName', data.recipient || '', { shouldValidate: true });
+    setValue('recipientPostalCode', data.postalCode || '', { shouldValidate: true });
+    setValue('recipientAddress', data.address || '', { shouldValidate: true });
+    setValue('recipientDetailAddress', data.detailAddress || '', {
+      shouldValidate: true,
+    });
+    setValue('memo', data.memo || '', { shouldValidate: true });
     if (data.isDefault) {
       handleAddressType('default');
     } else {
@@ -43,8 +57,6 @@ export function DeliveryAddressList({ onClose, isOpen }: DeliveryListProps): JSX
     }
     onClose();
   };
-
-  const { setValue } = useFormContext<CreateOrderForm>();
 
   return (
     <Modal onClose={onClose} isOpen={isOpen} isCentered size="sm">

--- a/libs/components-web-kkshow/src/lib/payment/OrderPaymentForm.tsx
+++ b/libs/components-web-kkshow/src/lib/payment/OrderPaymentForm.tsx
@@ -54,7 +54,7 @@ export function OrderPaymentForm(): JSX.Element | null {
 
   const { getValues, setValue } = methods;
 
-  const { data: defaultAddr } = useDefaultCustomerAddress();
+  const { data: defaultAddr } = useDefaultCustomerAddress(customer?.id);
   const { mutateAsync: createAddress } = useCustomerAddressMutation();
 
   // 로그인하여 소비자 정보가 있는경우 id등 기타 정보 저장
@@ -142,6 +142,7 @@ export function OrderPaymentForm(): JSX.Element | null {
         py={6}
         mb={{ base: 0, lg: 20 }}
         as="form"
+        id="order-payment-form"
         onSubmit={methods.handleSubmit(onSubmit)}
       >
         <GridItem colSpan={7}>

--- a/libs/components-web-kkshow/src/lib/payment/OrderPaymentForm.tsx
+++ b/libs/components-web-kkshow/src/lib/payment/OrderPaymentForm.tsx
@@ -49,6 +49,7 @@ export async function doPayment(
 
 export function OrderPaymentForm(): JSX.Element | null {
   const { data: profile } = useProfile();
+  const { data: customer } = useCustomerInfo(profile?.id);
   const orderPrepareData = useKkshowOrderStore((s) => s.order);
 
   const methods = useForm<CreateOrderForm>({

--- a/libs/components-web-kkshow/src/lib/payment/OrderPaymentForm.tsx
+++ b/libs/components-web-kkshow/src/lib/payment/OrderPaymentForm.tsx
@@ -1,6 +1,5 @@
 import { Grid, GridItem, Heading, Stack } from '@chakra-ui/react';
 import {
-  useCustomerAddress,
   useCustomerAddressMutation,
   useCustomerInfo,
   useDefaultCustomerAddress,

--- a/libs/components-web-kkshow/src/lib/payment/Payment.tsx
+++ b/libs/components-web-kkshow/src/lib/payment/Payment.tsx
@@ -224,6 +224,7 @@ export function PaymentBox(): JSX.Element {
       </Box>
       <Center>
         <Button
+          form="order-payment-form"
           type="submit"
           size="lg"
           colorScheme="blue"

--- a/libs/components-web-kkshow/src/lib/payment/Payment.tsx
+++ b/libs/components-web-kkshow/src/lib/payment/Payment.tsx
@@ -197,7 +197,6 @@ export function PaymentBox(): JSX.Element {
         <Button
           form="order-payment-form"
           type="submit"
-          form="order-payment-form"
           size="lg"
           colorScheme="blue"
           isFullWidth

--- a/libs/hooks/src/lib/mutation/useCustomerAddressMutation.tsx
+++ b/libs/hooks/src/lib/mutation/useCustomerAddressMutation.tsx
@@ -20,8 +20,12 @@ export const useCustomerAddressMutation = (): UseMutationResult<
         .then((res) => res.data),
     {
       onSuccess: (resData) => {
-        queryClient.invalidateQueries(['CustomerAddress', resData.customerId]);
-        queryClient.invalidateQueries(['DefaultCustomerAddress', resData.customerId]);
+        queryClient.invalidateQueries(['CustomerAddress', resData.customerId], {
+          refetchInactive: true,
+        });
+        queryClient.invalidateQueries(['DefaultCustomerAddress', resData.customerId], {
+          refetchInactive: true,
+        });
       },
     },
   );


### PR DESCRIPTION
+ 배송지에서 폰번 올바르게 불러오지 못하는 현상 수정

# 문제점

처음 입력한 배송지가 자동으로 기본배송지로 설정되지 않아 마이페이지에서 구매마다 새로 입력하여야 함

배송지 입력은 마이페이지에서 가능하므로 자동으로 불러오도록 하려면 마이페이지로 이동해 등록해야하는 번거로움이 있음

라이브쇼핑시 1회성으로 사용하는 크크쇼 특성상 마이페이지를 들리거나 하도록 구성하는 것 보다 자동 처리가 더 편할 것

# 해결방법

1. 로그인한 경우 + 주소(배송지)가 하나도 없는 경우 + 직접입력한 주소가 기본배송지로 자동 등록되도록 구성.
2. 배송지 등록을 구매페이지에서 진행할 수 있도록 한다.

# 할일

- [ ]  로그인한 경우 + 주소(배송지)가 하나도 없는 경우 구매버튼 클릭시 직접입력한 주소가 기본배송지로 자동 등록되도록 구성.
- [ ]  “배송지목록에서 선택” 창에 배송지 등록 버튼/절차를 추가한다

### 추가 작업 사항

- [x]  배송지목록에서 폰번 올바르게 불러오지 못하는 현상 수정

# 테스트케이스

- [ ]  로그인한 경우 + 주소(배송지)가 하나도 없는 경우 구매버튼 클릭시 직접입력한 주소가 기본배송지로 자동 등록된다.
- [ ]  “배송지목록에서 선택” 창에 배송지 등록 버튼이 올바르게 추가되어있다
    - [ ]  해당 버튼을 통해 배송지를 등록할 수 있다
- [ ]  배송지목록에서 폰번을 올바르게 불러올 수 있다