### PR TITLE
feat: 통신판매업신고번호 수정

### DIFF
--- a/libs/components-constants/src/lib/footerLinks.ts
+++ b/libs/components-constants/src/lib/footerLinks.ts
@@ -55,7 +55,7 @@ export const footerInfoArr = [
     },
   },
   { contents: '사업자등록번호 : 659-03-01549' },
-  { contents: '통신판매업신고 : 2019-부산금정-0581' },
+  { contents: '통신판매업신고 : 2022-부산연제-0281' },
   { contents: '대표이사 : 강동기' },
   { contents: '개인정보담당자 : 전민관' },
   { contents: '유선 전화번호 : 051-939-6309' },

--- a/libs/nest-modules-mail/src/lib/templates/createInactivateNoticeTemplate.ts
+++ b/libs/nest-modules-mail/src/lib/templates/createInactivateNoticeTemplate.ts
@@ -126,7 +126,7 @@ export const createPreInactivateNoticeTemplate = (targetDetails): string => `
                   </td>
                   <td style="padding:0 30px 30px 0;" width="580">
                     <p style="margin:0; word-break:keep-all; font-size:11px;">대표이사. 강동기  |  사업자등록번호. 659-03-01549 <br> 사업장소재지. 부산광역시 금정구 장전온천천로 51 (테라스파크) 313호<br>
-                      통신판매업신고번호. 2019-부산금정-0581  |  개인정보 관리책임자. 기획 및 경영지원팀장 전민관<br>ⓒ 2021 whiletrue. All Rights Reserved.
+                      통신판매업신고번호. 2022-부산연제-0281  |  개인정보 관리책임자. 기획 및 경영지원팀장 전민관<br>ⓒ 2021 whiletrue. All Rights Reserved.
                     </p>
                   </td>
                 </tr>
@@ -258,7 +258,7 @@ export const createInactivateNoticeTemplate = (targetDetails): string => `
                   </td>
                   <td style="padding:0 30px 30px 0;" width="580">
                     <p style="margin:0; word-break:keep-all; font-size:11px;">대표이사. 강동기  |  사업자등록번호. 659-03-01549 <br> 사업장소재지. 부산광역시 금정구 장전온천천로 51 (테라스파크) 313호<br>
-                      통신판매업신고번호. 2019-부산금정-0581  |  개인정보 관리책임자. 기획 및 경영지원팀장 전민관<br>ⓒ 2021 whiletrue. All Rights Reserved.
+                      통신판매업신고번호. 2022-부산연제-0281  |  개인정보 관리책임자. 기획 및 경영지원팀장 전민관<br>ⓒ 2021 whiletrue. All Rights Reserved.
                     </p>
                   </td>
                 </tr>


### PR DESCRIPTION
# 할일

- [x]  통신판매업 신고번호 수정
    
    기존 : 2019-부산금정-0581
    
    변경 : 2022-부산연제-0281
    

# 테스트케이스

- [ ]  올바르게 변경되었다
    - [ ]  판매자센터
    - [ ]  방송인센터
    - [ ]  크크쇼