### PR TITLE
feat: 쿠폰등록시 전체상품용 쿠폰은 상품 연결하지 않도록 구성

### DIFF
--- a/apps/admin/pages/customer/coupon/[couponId].tsx
+++ b/apps/admin/pages/customer/coupon/[couponId].tsx
@@ -236,7 +236,7 @@ export function CouponManage(): JSX.Element {
             <Heading size="lg">고객 목록</Heading>
             <Flex direction="column">
               <Button onClick={issueAllOnOpen} colorScheme="blue">
-                전체/선택 발급
+                선택된 고객 일괄 발급
               </Button>
             </Flex>
           </Flex>

--- a/libs/components-web-kkshow/src/lib/payment/Discount.tsx
+++ b/libs/components-web-kkshow/src/lib/payment/Discount.tsx
@@ -275,7 +275,7 @@ function CouponSelectDialog({
           return <Text>{amount}%</Text>;
         }
         // unit === 'W'
-        return <Text>{amount}원</Text>;
+        return <Text>{getLocaleNumber(amount)}원</Text>;
       },
     },
     {

--- a/libs/nest-modules-coupon/src/lib/coupon.controller.ts
+++ b/libs/nest-modules-coupon/src/lib/coupon.controller.ts
@@ -11,16 +11,16 @@ import {
 } from '@nestjs/common';
 import { CustomerCoupon } from '@prisma/client';
 import {
+  CacheClearKeys,
+  CustomerInfo,
   HttpCacheInterceptor,
   UserPayload,
-  CustomerInfo,
-  CacheClearKeys,
 } from '@project-lc/nest-core';
 import { JwtAuthGuard } from '@project-lc/nest-modules-authguard';
 import {
   CouponStatusDto,
-  CustomerCouponRes,
   CustomerCouponLogRes,
+  CustomerCouponRes,
 } from '@project-lc/shared-types';
 import { CouponLogService } from './coupon-log.service';
 import { CustomerCouponService } from './customer-coupon.service';

--- a/libs/nest-modules-coupon/src/lib/coupon.service.ts
+++ b/libs/nest-modules-coupon/src/lib/coupon.service.ts
@@ -12,7 +12,7 @@ export class CouponService {
   ) {}
 
   /** 쿠폰 상세조회 */
-  findCoupon(couponId: number): Promise<Coupon> {
+  public async findCoupon(couponId: number): Promise<Coupon> {
     return this.prismaService.coupon.findFirst({
       where: {
         id: couponId,
@@ -34,7 +34,7 @@ export class CouponService {
   }
 
   /** 쿠폰 목록 조회 */
-  findCoupons(): Promise<Coupon[]> {
+  public async findCoupons(): Promise<Coupon[]> {
     return this.prismaService.coupon.findMany({
       include: {
         goods: true,
@@ -43,13 +43,11 @@ export class CouponService {
   }
 
   /** 쿠폰 생성 */
-  async createCoupon(dto: CouponDto): Promise<Coupon> {
-    let goodsList;
+  public async createCoupon(dto: CouponDto): Promise<Coupon> {
+    let goodsList = [];
 
-    if (dto.applyType === 'allGoods') {
-      goodsList = await this.goodsService
-        .findAllConfirmedLcGoodsListWithCategory()
-        .then((item) => item.map((value) => ({ id: value.id })));
+    if (dto.applyType === 'selectedGoods') {
+      goodsList = dto.goods.map((item) => ({ id: item }));
     } else if (dto.applyType === 'exceptSelectedGoods') {
       goodsList = await this.goodsService
         .findAllConfirmedLcGoodsListWithCategory()
@@ -58,10 +56,7 @@ export class CouponService {
             .map((value) => !dto.goods.includes(value.id) && { id: value.id })
             .filter(Boolean),
         );
-    } else {
-      goodsList = dto.goods.map((item) => ({ id: item }));
     }
-
     return this.prismaService.coupon.create({
       data: {
         ...dto,
@@ -75,7 +70,7 @@ export class CouponService {
   }
 
   /** 특정 쿠폰 수정 */
-  updateCoupon(id: number, dto: CouponDto): Promise<Coupon> {
+  public async updateCoupon(id: number, dto: CouponDto): Promise<Coupon> {
     return this.prismaService.coupon.update({
       where: { id },
       data: { ...dto },
@@ -83,7 +78,7 @@ export class CouponService {
   }
 
   /** 특정 쿠폰 제거 */
-  deleteCoupon(couponId: number): Promise<Coupon> {
+  public async deleteCoupon(couponId: number): Promise<Coupon> {
     return this.prismaService.coupon.delete({
       where: { id: couponId },
     });

--- a/libs/shared-types/src/lib/dto/customerCoupon.dto.ts
+++ b/libs/shared-types/src/lib/dto/customerCoupon.dto.ts
@@ -1,5 +1,5 @@
-import { IsNumber, IsOptional, IsEnum, IsArray } from 'class-validator';
 import { CouponStatus } from '@prisma/client';
+import { IsArray, IsEnum, IsNumber, IsOptional } from 'class-validator';
 
 export class CouponStatusDto {
   @IsNumber()


### PR DESCRIPTION
# 문제점

전체 상품에 적용가능한 쿠폰이 생성시점의 전체 상품들에만 사용가능하고, 쿠폰 생성 시점 이후에 생성된 새로운 상품들에는 사용이 불가능하도록 처리되어 있음.

# 해결방법

- 전체상품에 사용가능한 쿠폰은 상품과 연결시키지 않고, 모든 상품 주문시 사용할 수 있도록 구성
    - [x]  최초 등록시 모든 상품연결
    - [ ]  ~~전체상품용 쿠폰의 경우 따로 처리하도록 구성 → 이미 구성되어 있음~~

# 할일

- [x]  전체상품에 적용가능한 쿠폰 등록시 상품연결하지 않도록 구성

# 테스트케이스 (개발)

비개발자가 테스트할 사항은 없음.

- [x]  전체 상품에 적용가능한 쿠폰 등록시 상품연결되지 않는다