### PR TITLE
fix: 라이브쇼핑 특가 설정 없는 경우 특가 표시하지않도록 수정

### DIFF
--- a/libs/components-web-kkshow/src/lib/goods/GoodsViewMeta.tsx
+++ b/libs/components-web-kkshow/src/lib/goods/GoodsViewMeta.tsx
@@ -253,7 +253,6 @@ export function GoodsViewPriceTag({
         nowOnliveLsListBySelectedBc.data[0] &&
         nowOnliveLsListBySelectedBc.data[0].liveShoppingSpecialPrices.length > 0
       ) {
-        specialPriceInfo.hasLiveShoppingSpecialPrice = true;
         const specialPriceArr =
           nowOnliveLsListBySelectedBc.data[0].liveShoppingSpecialPrices.map((spData) =>
             Number(spData.specialPrice),
@@ -265,6 +264,11 @@ export function GoodsViewPriceTag({
           Number(defaultOption.consumer_price),
           Number(specialPriceInfo.cheapestPrice),
         );
+
+        // 라이브특가 정보가 존재하고, 최저가가 기존옵션가보다 작은경우 특가가 존재한다고 판단함
+        specialPriceInfo.hasLiveShoppingSpecialPrice =
+          !!specialPriceInfo.cheapestPrice &&
+          specialPriceInfo.cheapestPrice < Number(defaultOption.price);
       }
 
       return specialPriceInfo;
@@ -314,25 +318,23 @@ export function GoodsViewPriceTag({
       </GridItem>
 
       {/* 라이브 특가가 존재하는 경우 표시 */}
-      {hasLiveShoppingSpecialPrice &&
-        cheapestPrice &&
-        cheapestPrice < Number(defaultOption.price) && (
-          <>
-            <GridItem>
-              <Flex alignItems="center" height="100%">
-                <Text fontWeight="extrabold">LIVE특가</Text>
-              </Flex>
-            </GridItem>
-            <GridItem>
-              <Flex gap={1} flexWrap="wrap" alignItems="center">
-                <Text id="special-cheapest-price" fontWeight="extrabold" fontSize="2xl">
-                  {getLocaleNumber(cheapestPrice)}원
-                </Text>
-                <DiscountRateText discountRate={specialPriceDiscountRate} />
-              </Flex>
-            </GridItem>
-          </>
-        )}
+      {hasLiveShoppingSpecialPrice && (
+        <>
+          <GridItem>
+            <Flex alignItems="center" height="100%">
+              <Text fontWeight="extrabold">LIVE특가</Text>
+            </Flex>
+          </GridItem>
+          <GridItem>
+            <Flex gap={1} flexWrap="wrap" alignItems="center">
+              <Text id="special-cheapest-price" fontWeight="extrabold" fontSize="2xl">
+                {getLocaleNumber(cheapestPrice)}원
+              </Text>
+              <DiscountRateText discountRate={specialPriceDiscountRate} />
+            </Flex>
+          </GridItem>
+        </>
+      )}
 
       {shippingGroup && (
         <>

--- a/libs/components-web-kkshow/src/lib/goods/GoodsViewMeta.tsx
+++ b/libs/components-web-kkshow/src/lib/goods/GoodsViewMeta.tsx
@@ -243,21 +243,24 @@ export function GoodsViewPriceTag({
         specialPriceDiscountRate: string;
       } = {
         hasLiveShoppingSpecialPrice: false,
-        cheapestPrice: null,
+        cheapestPrice: Number(defaultOption?.price),
         specialPriceDiscountRate: '',
       };
 
       if (
         selectedBc &&
         nowOnliveLsListBySelectedBc.data &&
-        nowOnliveLsListBySelectedBc.data[0]
+        nowOnliveLsListBySelectedBc.data[0] &&
+        nowOnliveLsListBySelectedBc.data[0].liveShoppingSpecialPrices.length > 0
       ) {
         specialPriceInfo.hasLiveShoppingSpecialPrice = true;
         const specialPriceArr =
           nowOnliveLsListBySelectedBc.data[0].liveShoppingSpecialPrices.map((spData) =>
             Number(spData.specialPrice),
           );
-        specialPriceInfo.cheapestPrice = Math.min(...specialPriceArr);
+        specialPriceInfo.cheapestPrice = Math.min(
+          ...specialPriceArr.concat(Number(defaultOption.price)),
+        );
         specialPriceInfo.specialPriceDiscountRate = getDiscountedRate(
           Number(defaultOption.consumer_price),
           Number(specialPriceInfo.cheapestPrice),
@@ -265,7 +268,12 @@ export function GoodsViewPriceTag({
       }
 
       return specialPriceInfo;
-    }, [selectedBc, nowOnliveLsListBySelectedBc.data, defaultOption.consumer_price]);
+    }, [
+      defaultOption.price,
+      defaultOption.consumer_price,
+      selectedBc,
+      nowOnliveLsListBySelectedBc.data,
+    ]);
 
   return (
     <Grid
@@ -306,23 +314,25 @@ export function GoodsViewPriceTag({
       </GridItem>
 
       {/* 라이브 특가가 존재하는 경우 표시 */}
-      {hasLiveShoppingSpecialPrice && (
-        <>
-          <GridItem>
-            <Flex alignItems="center" height="100%">
-              <Text fontWeight="extrabold">LIVE특가</Text>
-            </Flex>
-          </GridItem>
-          <GridItem>
-            <Flex gap={1} flexWrap="wrap" alignItems="center">
-              <Text id="special-cheapest-price" fontWeight="extrabold" fontSize="2xl">
-                {getLocaleNumber(cheapestPrice)}원
-              </Text>
-              <DiscountRateText discountRate={specialPriceDiscountRate} />
-            </Flex>
-          </GridItem>
-        </>
-      )}
+      {hasLiveShoppingSpecialPrice &&
+        cheapestPrice &&
+        cheapestPrice < Number(defaultOption.price) && (
+          <>
+            <GridItem>
+              <Flex alignItems="center" height="100%">
+                <Text fontWeight="extrabold">LIVE특가</Text>
+              </Flex>
+            </GridItem>
+            <GridItem>
+              <Flex gap={1} flexWrap="wrap" alignItems="center">
+                <Text id="special-cheapest-price" fontWeight="extrabold" fontSize="2xl">
+                  {getLocaleNumber(cheapestPrice)}원
+                </Text>
+                <DiscountRateText discountRate={specialPriceDiscountRate} />
+              </Flex>
+            </GridItem>
+          </>
+        )}
 
       {shippingGroup && (
         <>


### PR DESCRIPTION
# 문제점

- 라이브특가가설정되지 않아도 후원 방송인 선택시 LIVE특가가 보여져, 빈배열을 Math.min(…) 하여 Infinity 값으로 특가가 계산됨

# 해결방법, 할일

- [x]  특가가설정되지 않은 경우 LIVE특가를 계산하지 않고 보이지 않도록 수정

# 테스트케이스

- [x]  특가가설정되지 않은 경우 LIVE특가를 계산하지 않고 보이지 않는다.