### PR TITLE
fix: 네이버 로그인 최신 개발 가이드에 따르도록 수정

### DIFF
--- a/libs/nest-modules-auth/src/social/social.service.ts
+++ b/libs/nest-modules-auth/src/social/social.service.ts
@@ -187,7 +187,6 @@ export class SocialService {
         email,
         userName: name,
         overlayUrl: `/${email}`,
-        userNickname: nickname || null,
         avatar: picture || null,
         password: null,
         socialAccounts: {

--- a/libs/nest-modules-auth/src/social/social.service.ts
+++ b/libs/nest-modules-auth/src/social/social.service.ts
@@ -36,6 +36,7 @@ interface UserDataInterface {
   provider: string;
   email: string;
   name: string;
+  nickname?: string;
   picture?: string;
   accessToken: string;
   refreshToken?: string;

--- a/libs/nest-modules-auth/src/social/social.service.ts
+++ b/libs/nest-modules-auth/src/social/social.service.ts
@@ -172,7 +172,7 @@ export class SocialService {
   private async createBroadcasterSocialAccountRecord(
     userData: UserDataInterface,
   ): Promise<Broadcaster> {
-    const { id, email, name, picture, ...rest } = userData;
+    const { id, email, name, picture, nickname, ...rest } = userData;
     const socialAccountCreateInput = {
       serviceId: id,
       profileImage: picture,
@@ -182,15 +182,12 @@ export class SocialService {
 
     const createdBroadcaster = await this.prisma.broadcaster.upsert({
       where: { email },
-      update: {
-        socialAccounts: {
-          create: socialAccountCreateInput,
-        },
-      },
+      update: { socialAccounts: { create: socialAccountCreateInput } },
       create: {
         email,
         userName: name,
         overlayUrl: `/${email}`,
+        userNickname: nickname || null,
         avatar: picture || null,
         password: null,
         socialAccounts: {
@@ -243,7 +240,7 @@ export class SocialService {
   private async createCustomerSocialAccountRecrod(
     userData: UserDataInterface,
   ): Promise<Customer> {
-    const { id, email, name, picture, ...rest } = userData;
+    const { id, email, name, picture, nickname, ...rest } = userData;
     const socialAccountCreateInput = {
       serviceId: id,
       profileImage: picture,
@@ -257,6 +254,7 @@ export class SocialService {
       create: {
         email,
         name,
+        nickname,
         password: null,
         socialAccounts: { create: socialAccountCreateInput },
       },
@@ -325,7 +323,8 @@ export class SocialService {
   private async createSellerSocialAccountRecord(
     sellerData: UserDataInterface,
   ): Promise<Seller> {
-    const { id, email, name, picture, ...rest } = sellerData;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { id, email, name, picture, nickname, ...rest } = sellerData;
     const socialAccountCreateInput = {
       serviceId: id,
       profileImage: picture,

--- a/libs/nest-modules-auth/src/social/strategy/naver.strategy.ts
+++ b/libs/nest-modules-auth/src/social/strategy/naver.strategy.ts
@@ -15,8 +15,8 @@ import { Customer, Seller } from '.prisma/client';
 import { SocialService } from '../social.service';
 
 type NaverAuthorizationParams = {
-  /** 재동의 요청의 경우 'reprompt'로 전송해야 함 */
-  auth_type?: 'reprompt';
+  /** 재동의 요청의 경우 'reprompt'로 전송해야 함. 매번 로그인부터 다시 시작한다면 'reauthenticate' */
+  auth_type?: 'reprompt' | 'reauthenticate';
 };
 /** snakecase -> camelcase 변경 타입 ex) auth_type -> authType */
 type SnakeToCamel<S extends string> = S extends `${infer T}_${infer U}`

--- a/libs/nest-modules-auth/src/social/strategy/naver.strategy.ts
+++ b/libs/nest-modules-auth/src/social/strategy/naver.strategy.ts
@@ -14,6 +14,18 @@ import OAuth2Strategy, {
 import { Customer, Seller } from '.prisma/client';
 import { SocialService } from '../social.service';
 
+type NaverAuthorizationParams = {
+  /** 재동의 요청의 경우 'reprompt'로 전송해야 함 */
+  auth_type?: 'reprompt';
+};
+/** snakecase -> camelcase 변경 타입 ex) auth_type -> authType */
+type SnakeToCamel<S extends string> = S extends `${infer T}_${infer U}`
+  ? `${T}${Capitalize<SnakeToCamel<U>>}`
+  : S;
+type NaverAuthorizationParamOptions = {
+  [K in keyof NaverAuthorizationParams as SnakeToCamel<K>]: NaverAuthorizationParams[K];
+};
+
 export type NaverSocialProfile = {
   provider: 'naver';
   /** 동일인 식별 정보: 동일인 식별 정보는 네이버 아이디마다 고유하게 발급되는 값입니다. */
@@ -60,9 +72,8 @@ class NaverStrategyBase extends OAuth2Strategy {
     this.name = NAVER_PROVIDER;
   }
 
-  authorizationParams(options: any): object {
-    if (options.authType) return { auth_type: options.authType };
-    return {};
+  authorizationParams(options: NaverAuthorizationParamOptions): object {
+    return { auth_type: options.authType, ...options };
   }
 
   userProfile(accessToken: string, done: (err?: Error, profile?: any) => void): void {

--- a/libs/nest-modules-auth/src/social/strategy/naver.strategy.ts
+++ b/libs/nest-modules-auth/src/social/strategy/naver.strategy.ts
@@ -6,13 +6,106 @@ import { UserType } from '@project-lc/shared-types';
 import { getApiHost } from '@project-lc/utils';
 import { getUserTypeFromRequest } from '@project-lc/utils-backend';
 import { Request } from 'express';
-import { Profile, Strategy } from 'passport-naver';
+import OAuth2Strategy, {
+  InternalOAuthError,
+  StrategyOptions,
+  VerifyFunction,
+} from 'passport-oauth2';
 import { Customer, Seller } from '.prisma/client';
 import { SocialService } from '../social.service';
 
+export type NaverSocialProfile = {
+  provider: 'naver';
+  /** 동일인 식별 정보: 동일인 식별 정보는 네이버 아이디마다 고유하게 발급되는 값입니다. */
+  id: string;
+  /** 사용자 별명 */
+  nickname?: string;
+  /** 사용자 프로필 사진 URL */
+  profileImage?: string;
+  /** 사용자 연령대 */
+  age?: string;
+  /** 사용자 성별 F:여성, M:남성,U:확인불가 */
+  gender?: string;
+  /** 사용자 메일 주소 */
+  email?: string;
+  /** 휴대전화번호 */
+  mobile?: string;
+  /** 사용자이름 (실명) */
+  name?: string;
+  /** 사용자 생일(MM-DD형식) */
+  birthDay?: string;
+  /** 출생연도 */
+  birthYear?: string;
+  _raw: string;
+  _json: string;
+};
+
 const NAVER_PROVIDER = 'naver';
+const _authorizationURL = 'https://nid.naver.com/oauth2.0/authorize';
+const _tokenURL = 'https://nid.naver.com/oauth2.0/token';
+/**
+ * https://developers.naver.com/docs/login/devguide/devguide.md
+ */
+class NaverStrategyBase extends OAuth2Strategy {
+  public _profileURL = 'https://openapi.naver.com/v1/nid/me';
+  constructor(options: Partial<StrategyOptions>, verify: VerifyFunction) {
+    super(
+      {
+        ...(options as StrategyOptions),
+        authorizationURL: options.authorizationURL || _authorizationURL,
+        tokenURL: options.tokenURL || _tokenURL,
+      },
+      verify,
+    );
+    this.name = NAVER_PROVIDER;
+  }
+
+  authorizationParams(options: any): object {
+    if (options.authType) return { auth_type: options.authType };
+    return {};
+  }
+
+  userProfile(accessToken: string, done: (err?: Error, profile?: any) => void): void {
+    this._oauth2.get(this._profileURL, accessToken, (err: any, responseJson: string) => {
+      if (err) {
+        return done(
+          new InternalOAuthError('네이버로부터 UserProfile을 가져오지 못함.', err),
+        );
+      }
+
+      try {
+        const body = JSON.parse(responseJson);
+        const { response, resultcode } = body;
+        if (resultcode !== '00') {
+          return done(new InternalOAuthError('네이버로부터 00이 아닌 응답을 받음', err));
+        }
+        const profile: NaverSocialProfile = {
+          provider: NAVER_PROVIDER,
+          id: response.id,
+          name: response.name,
+          email: response.email,
+          nickname: response.nickname,
+          profileImage: response.profile_image,
+          age: response.age,
+          gender: response.gender,
+          mobile: response.mobile,
+          birthDay: response.birthday,
+          birthYear: response.birthyear,
+          _raw: responseJson,
+          _json: body,
+        };
+        return done(null, profile);
+      } catch (_err) {
+        return done(
+          new InternalOAuthError('네이버로부터 전달받은 profile 파싱 중 에러', _err),
+        );
+      }
+    });
+  }
+}
+
 @Injectable()
-export class NaverStrategy extends PassportStrategy(Strategy, NAVER_PROVIDER) {
+export class NaverStrategy extends PassportStrategy(NaverStrategyBase, NAVER_PROVIDER) {
   constructor(
     private configService: ConfigService,
     private readonly socialService: SocialService,
@@ -29,10 +122,10 @@ export class NaverStrategy extends PassportStrategy(Strategy, NAVER_PROVIDER) {
     req: Request,
     accessToken: string,
     refreshToken: null,
-    profile: Profile,
+    profile: NaverSocialProfile,
   ): Promise<Seller | Broadcaster | Customer> {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { email, nickname, profile_image, id } = profile._json;
+    const { email, nickname, id, name, profileImage } = profile;
 
     if (!email) {
       throw new ForbiddenException({
@@ -49,7 +142,8 @@ export class NaverStrategy extends PassportStrategy(Strategy, NAVER_PROVIDER) {
       id,
       provider: NAVER_PROVIDER,
       email,
-      name: nickname,
+      name,
+      nickname,
       // 220822 주석처리 => 연관일감: [회원가입] 소셜로그인시 프로필사진 받아온 프로필사진으로 설정하지 않기 by dan
       // picture: profile_image,
       accessToken,

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "passport-jwt": "^4.0.0",
     "passport-kakao": "^1.0.1",
     "passport-local": "^1.0.0",
-    "passport-naver": "^1.0.6",
     "prisma": "^3.11.0",
     "prisma-docs-generator": "^0.4.0",
     "react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12927,23 +12927,6 @@ passport-local@^1.0.0:
   dependencies:
     passport-strategy "1.x.x"
 
-passport-naver@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.npmjs.org/passport-naver/-/passport-naver-1.0.6.tgz"
-  integrity sha512-5XEbJesiPVshwE0cTDvbbJrOiYSJ9VFRJTctqiZL1Xip6qOi9n7d49UesOqavLT+Ry8C7aw3zdzbmWosqHcQ/Q==
-  dependencies:
-    passport-oauth "^1.0.0"
-    underscore "^1.8.3"
-
-passport-oauth1@1.x.x:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/passport-oauth1/-/passport-oauth1-1.2.0.tgz"
-  integrity sha512-Sv2YWodC6jN12M/OXwmR4BIXeeIHjjbwYTQw4kS6tHK4zYzSEpxBgSJJnknBjICA5cj0ju3FSnG1XmHgIhYnLg==
-  dependencies:
-    oauth "0.9.x"
-    passport-strategy "1.x.x"
-    utils-merge "1.x.x"
-
 passport-oauth2@1.x.x:
   version "1.6.1"
   resolved "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.6.1.tgz"
@@ -12963,14 +12946,6 @@ passport-oauth2@~1.1.2:
     oauth "0.9.x"
     passport-strategy "1.x.x"
     uid2 "0.0.x"
-
-passport-oauth@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/passport-oauth/-/passport-oauth-1.0.0.tgz"
-  integrity sha1-kK/2M4dUDwIImvKM2tOep/gNd98=
-  dependencies:
-    passport-oauth1 "1.x.x"
-    passport-oauth2 "1.x.x"
 
 passport-strategy@1.x.x, passport-strategy@^1.0.0:
   version "1.0.0"
@@ -15955,11 +15930,6 @@ unbox-primitive@^1.0.1:
     has-bigints "^1.0.1"
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
-
-underscore@^1.8.3:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.2.tgz#276cea1e8b9722a8dbed0100a407dda572125881"
-  integrity sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==
 
 undici@3.3.6:
   version "3.3.6"


### PR DESCRIPTION
- passport-naver는 6년전 모듈로, 업데이트되지 않고 있음.
- 몇 가지 필드명 변경사항에 대해 작업해두지 않음
- 이를 passport-oauth2를 통해 직접 구현하도록 구성

# 일감개요

사용자의 실명이 이름으로 설정되는 것이 올바를 것.

- 네이버에서는 제공되고 있다고 표시됨. 근데 이름 데이터가 전달되지 않는 것으로 확인됨 why?

# 문제점

사용하고 있는 passport 모듈 passport-naver 는 6년전 패키지로 네이버로그인API 최신 변경사항을 따르지 않고 있음

# 해결방법

최신 개발가이드에서 제공하는 oauth2 인증 방식대로 네이버 소셜 로그인 자체적으로 구현

### 작업진행로그

220824 14:00 ~ 15:00 (1)

# 테스트케이스

- [ ]  네이버로 로그인했을 때 사용자 이름이 네이버에서 설정된 실명으로 올바르게 설정된다
- [ ]  네이버로 로그인했을 때 사용자 닉네임이 네이버에서 설정된 닉으네임로바 르바게 설정된다