### PR TITLE
improve : [크크쇼] 마이페이지 혜택관리 개선사항

### DIFF
--- a/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponApplyGoodsList.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponApplyGoodsList.tsx
@@ -82,10 +82,10 @@ export function CouponApplicableGoodsListDialog({
         {DiscountApplyTypeBadge(coupon.applyType)}
       </Button>
 
-      <Modal isOpen={isOpen} onClose={onClose}>
+      <Modal isOpen={isOpen} onClose={onClose} isCentered>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader fontSize="md">적용 가능한 상품 목록</ModalHeader>
+          <ModalHeader fontSize="md">{coupon.name} - 적용 가능한 상품 목록</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
             <CouponApplicableGoodsList goodsList={coupon.goods} />

--- a/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponApplyGoodsList.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponApplyGoodsList.tsx
@@ -1,0 +1,54 @@
+import { Grid, GridItem, Image, Link } from '@chakra-ui/react';
+import { Goods, GoodsImages } from '@prisma/client';
+import { CustomerCouponRes } from '@project-lc/shared-types';
+import NextLink from 'next/link';
+
+export interface CustomerCouponApplyGoodsListProps {
+  goodsList: CustomerCouponRes['coupon']['goods'];
+}
+export function CustomerCouponApplyGoodsList({
+  goodsList,
+}: CustomerCouponApplyGoodsListProps): JSX.Element {
+  return (
+    <Grid
+      gridTemplateColumns="repeat(6, 1fr)"
+      fontSize={{ base: 'sm', md: 'md' }}
+      rowGap={1}
+      maxHeight="120px"
+      overflowY="auto"
+    >
+      {goodsList.map((goods) => (
+        <CouponApplyGoodsLink key={goods.id} {...goods} />
+      ))}
+    </Grid>
+  );
+}
+
+export default CustomerCouponApplyGoodsList;
+
+function CouponApplyGoodsLink({
+  id,
+  goods_name,
+  image,
+}: {
+  id: Goods['id'];
+  goods_name: Goods['goods_name'];
+  image: GoodsImages[];
+}): JSX.Element {
+  return (
+    <>
+      <GridItem display="flex" alignItems="center">
+        <Image
+          boxSize="35px"
+          objectFit="cover"
+          src={image[0] ? image[0].image : undefined}
+        />
+      </GridItem>
+      <GridItem colSpan={5}>
+        <NextLink passHref href={`/goods/${id}`}>
+          <Link fontSize="sm">{goods_name}</Link>
+        </NextLink>
+      </GridItem>
+    </>
+  );
+}

--- a/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponApplyGoodsList.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponApplyGoodsList.tsx
@@ -16,7 +16,7 @@ import {
 import { Goods, GoodsImages } from '@prisma/client';
 import { DiscountApplyTypeBadge } from '@project-lc/components-shared/CouponBadge';
 import { CustomerCouponRes } from '@project-lc/shared-types';
-import NextLink from 'next/link';
+import { getKkshowWebHost } from '@project-lc/utils';
 
 export interface CouponApplicableGoodsListProps {
   goodsList: CustomerCouponRes['coupon']['goods'];
@@ -62,9 +62,9 @@ function ApplicableGoodsLink({
         />
       </GridItem>
       <GridItem colSpan={5}>
-        <NextLink passHref href={`/goods/${id}`}>
-          <Link fontSize="sm">{goods_name}</Link>
-        </NextLink>
+        <Link fontSize="sm" href={`${getKkshowWebHost()}/goods/${id}`} isExternal>
+          {goods_name}
+        </Link>
       </GridItem>
     </>
   );

--- a/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponApplyGoodsList.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponApplyGoodsList.tsx
@@ -1,20 +1,22 @@
-import { Grid, GridItem, Image, Link } from '@chakra-ui/react';
+import { Grid, GridItem, GridProps, Image, Link } from '@chakra-ui/react';
 import { Goods, GoodsImages } from '@prisma/client';
 import { CustomerCouponRes } from '@project-lc/shared-types';
 import NextLink from 'next/link';
 
 export interface CouponApplicableGoodsListProps {
   goodsList: CustomerCouponRes['coupon']['goods'];
+  maxHeight?: GridProps['maxHeight'];
 }
 export function CouponApplicableGoodsList({
   goodsList,
+  maxHeight,
 }: CouponApplicableGoodsListProps): JSX.Element {
   return (
     <Grid
       gridTemplateColumns="repeat(6, 1fr)"
       fontSize={{ base: 'sm', md: 'md' }}
       rowGap={1}
-      maxHeight="120px"
+      maxHeight={maxHeight}
       overflowY="auto"
     >
       {goodsList.map((goods) => (

--- a/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponApplyGoodsList.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponApplyGoodsList.tsx
@@ -1,5 +1,20 @@
-import { Grid, GridItem, GridProps, Image, Link } from '@chakra-ui/react';
+import {
+  Button,
+  Grid,
+  GridItem,
+  GridProps,
+  Image,
+  Link,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  useDisclosure,
+} from '@chakra-ui/react';
 import { Goods, GoodsImages } from '@prisma/client';
+import { DiscountApplyTypeBadge } from '@project-lc/components-shared/CouponBadge';
 import { CustomerCouponRes } from '@project-lc/shared-types';
 import NextLink from 'next/link';
 
@@ -51,6 +66,32 @@ function ApplicableGoodsLink({
           <Link fontSize="sm">{goods_name}</Link>
         </NextLink>
       </GridItem>
+    </>
+  );
+}
+
+export function CouponApplicableGoodsListDialog({
+  coupon,
+}: {
+  coupon: CustomerCouponRes['coupon'];
+}): JSX.Element {
+  const { isOpen, onClose, onOpen } = useDisclosure();
+  return (
+    <>
+      <Button variant="unstyled" onClick={onOpen}>
+        {DiscountApplyTypeBadge(coupon.applyType)}
+      </Button>
+
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader fontSize="md">적용 가능한 상품 목록</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <CouponApplicableGoodsList goodsList={coupon.goods} />
+          </ModalBody>
+        </ModalContent>
+      </Modal>
     </>
   );
 }

--- a/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponApplyGoodsList.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponApplyGoodsList.tsx
@@ -3,12 +3,12 @@ import { Goods, GoodsImages } from '@prisma/client';
 import { CustomerCouponRes } from '@project-lc/shared-types';
 import NextLink from 'next/link';
 
-export interface CustomerCouponApplyGoodsListProps {
+export interface CouponApplicableGoodsListProps {
   goodsList: CustomerCouponRes['coupon']['goods'];
 }
-export function CustomerCouponApplyGoodsList({
+export function CouponApplicableGoodsList({
   goodsList,
-}: CustomerCouponApplyGoodsListProps): JSX.Element {
+}: CouponApplicableGoodsListProps): JSX.Element {
   return (
     <Grid
       gridTemplateColumns="repeat(6, 1fr)"
@@ -18,15 +18,15 @@ export function CustomerCouponApplyGoodsList({
       overflowY="auto"
     >
       {goodsList.map((goods) => (
-        <CouponApplyGoodsLink key={goods.id} {...goods} />
+        <ApplicableGoodsLink key={goods.id} {...goods} />
       ))}
     </Grid>
   );
 }
 
-export default CustomerCouponApplyGoodsList;
+export default CouponApplicableGoodsList;
 
-function CouponApplyGoodsLink({
+function ApplicableGoodsLink({
   id,
   goods_name,
   image,

--- a/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponDetailDialog.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponDetailDialog.tsx
@@ -79,6 +79,7 @@ export function CustomerCouponDetailDialog({
 
                       <CouponApplicableGoodsList
                         goodsList={customerCoupon.coupon.goods}
+                        maxHeight="150px"
                       />
                     </GridItem>
                   )}

--- a/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponDetailDialog.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponDetailDialog.tsx
@@ -17,6 +17,7 @@ import {
 } from '@project-lc/components-shared/CouponBadge';
 import { CustomerCouponRes } from '@project-lc/shared-types';
 import dayjs from 'dayjs';
+import CustomerCouponApplyGoodsList from './CustomerCouponApplyGoodsList';
 
 type CustomerCouponDetailDialogProps = {
   isOpen: boolean;
@@ -70,6 +71,17 @@ export function CustomerCouponDetailDialog({
                   <GridItem colSpan={3} textAlign="right">
                     {DiscountApplyTypeBadge(customerCoupon.coupon.applyType)}
                   </GridItem>
+
+                  {/* 특정상품에만 적용가능한 쿠폰인 경우에만 표시 */}
+                  {customerCoupon.coupon.applyType === 'selectedGoods' && (
+                    <GridItem colSpan={4}>
+                      <Text>적용 가능한 상품 목록</Text>
+
+                      <CustomerCouponApplyGoodsList
+                        goodsList={customerCoupon.coupon.goods}
+                      />
+                    </GridItem>
+                  )}
 
                   <GridItem>
                     <Text>최소주문액</Text>

--- a/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponDetailDialog.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponDetailDialog.tsx
@@ -17,7 +17,7 @@ import {
 } from '@project-lc/components-shared/CouponBadge';
 import { CustomerCouponRes } from '@project-lc/shared-types';
 import dayjs from 'dayjs';
-import CustomerCouponApplyGoodsList from './CustomerCouponApplyGoodsList';
+import CouponApplicableGoodsList from './CustomerCouponApplyGoodsList';
 
 type CustomerCouponDetailDialogProps = {
   isOpen: boolean;
@@ -77,7 +77,7 @@ export function CustomerCouponDetailDialog({
                     <GridItem colSpan={4}>
                       <Text>적용 가능한 상품 목록</Text>
 
-                      <CustomerCouponApplyGoodsList
+                      <CouponApplicableGoodsList
                         goodsList={customerCoupon.coupon.goods}
                       />
                     </GridItem>

--- a/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponList.tsx
+++ b/libs/components-web-kkshow/src/lib/mypage/benefits/CustomerCouponList.tsx
@@ -9,6 +9,7 @@ import { useCustomerCouponList } from '@project-lc/hooks';
 import { CustomerCouponRes } from '@project-lc/shared-types';
 import dayjs from 'dayjs';
 import { useMemo, useState } from 'react';
+import { CouponApplicableGoodsListDialog } from './CustomerCouponApplyGoodsList';
 import { CustomerCouponDetailDialog } from './CustomerCouponDetailDialog';
 
 /** 소비자 쿠폰 중 사용가능한 상태(사용하지 않음, 사용기간 지나지 않음)의 쿠폰만 필터링하는 훅 */
@@ -72,7 +73,13 @@ export function CustomerCouponList(): JSX.Element {
       headerName: '적용대상',
       width: 100,
       sortable: false,
-      renderCell: ({ row }) => DiscountApplyTypeBadge(row.coupon.applyType),
+      renderCell: ({ row }) => {
+        if (row.coupon.applyType !== 'selectedGoods') {
+          return DiscountApplyTypeBadge(row.coupon.applyType);
+        }
+        // '선택상품' 인 경우에만 버튼으로 감싸서 렌더링
+        return <CouponApplicableGoodsListDialog coupon={row.coupon} />;
+      },
     },
     {
       field: 'endDate',

--- a/libs/nest-modules-coupon/src/lib/customer-coupon.service.ts
+++ b/libs/nest-modules-coupon/src/lib/customer-coupon.service.ts
@@ -32,7 +32,15 @@ export class CustomerCouponService {
           },
         },
         coupon: {
-          include: { goods: { select: { id: true } } },
+          include: {
+            goods: {
+              select: {
+                id: true,
+                goods_name: true,
+                image: { take: 1, orderBy: { cut_number: 'asc' } },
+              },
+            },
+          },
         },
       },
     });

--- a/libs/shared-types/src/lib/res-types/coupon.res.ts
+++ b/libs/shared-types/src/lib/res-types/coupon.res.ts
@@ -1,10 +1,23 @@
-import { CustomerCoupon, Coupon, Customer, CustomerCouponLog } from '@prisma/client';
+import {
+  CustomerCoupon,
+  Coupon,
+  Customer,
+  CustomerCouponLog,
+  Goods,
+  GoodsImages,
+} from '@prisma/client';
 
 type CustomerCouponCustomer = Pick<Customer, 'nickname' | 'email'>;
 
 export interface CustomerCouponRes extends CustomerCoupon {
   customer: CustomerCouponCustomer;
-  coupon: Coupon & { goods: { id: number }[] }; // 쿠폰적용가능 혹은 쿠폰적용불가 상품 id[]
+  coupon: Coupon & {
+    goods: {
+      id: Goods['id']; // 쿠폰적용가능 혹은 쿠폰적용불가 상품 id
+      goods_name: Goods['goods_name'];
+      image: GoodsImages[]; // 연결된 상품 이미지 중 take 1
+    }[];
+  };
 }
 
 export interface CustomerCouponLogRes extends CustomerCouponLog {


### PR DESCRIPTION
크크쇼>쇼핑>혜택관리
쿠폰 적용대상이 선택 상품인 경우 선택상품 or 상세정보 클릭 시 적용 대상인 상품을 볼 수 있는 팝업창이 뜬다.
상품이미지 + 상품명 + 상품링크
상품 클릭 시 해당 상품 페이지로 이동

**테스트케이스**
- [ ]  보유쿠폰목록에서 적용대상이 ‘선택상품’인 경우 ‘선택상품' 글자를 누르면 적용대상 상품 목록을 볼 수 있는 팝업창이 뜬다
- [ ]  적용대상이 ‘선택상품'인 쿠폰의 상세정보 팝업창에서 해당 쿠폰을 적용할 수 있는 상품목록을 확인할 수 있다
- [ ]  적용할 수 있는 상품목록 클릭시 해당 상품 상세페이지로 이동한다