### PR TITLE
feat: 출고 상태 배송중/배송완료로 일괄 변경 처리

### DIFF
--- a/apps/admin/pages/customer/coupon/[couponId].tsx
+++ b/apps/admin/pages/customer/coupon/[couponId].tsx
@@ -254,9 +254,7 @@ export function CouponManage(): JSX.Element {
               }}
               selectionModel={manyCustomerCouponIssue}
               checkboxSelection
-              components={{
-                Toolbar: GridToolbar,
-              }}
+              components={{ Toolbar: GridToolbar }}
             />
           )}
 

--- a/libs/components-admin/src/lib/AdminOrderExportList.tsx
+++ b/libs/components-admin/src/lib/AdminOrderExportList.tsx
@@ -1,13 +1,42 @@
-import { Box, Link, Text } from '@chakra-ui/react';
-import { GridColumns, GridRowData, GridRowId, GridToolbar } from '@material-ui/data-grid';
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  ButtonProps,
+  Link,
+  Text,
+  useButtonGroup,
+  useDisclosure,
+  useToast,
+} from '@chakra-ui/react';
+import {
+  GridColumns,
+  GridRowData,
+  GridRowId,
+  GridSelectionModel,
+  GridToolbar,
+} from '@material-ui/data-grid';
 import { OrderProcessStep } from '@prisma/client';
 import { ChakraDataGrid } from '@project-lc/components-core/ChakraDataGrid';
+import {
+  ConfirmDialog,
+  ConfirmDialogProps,
+} from '@project-lc/components-core/ConfirmDialog';
 import { OrderStatusBadge } from '@project-lc/components-shared/order/OrderStatusBadge';
-import { useExports } from '@project-lc/hooks';
-import { convertkkshowOrderStatusToString } from '@project-lc/shared-types';
+import {
+  useDelieveryDoneManyMutation,
+  useDelieveryStartManyMutation,
+  useExports,
+} from '@project-lc/hooks';
+import {
+  convertkkshowOrderStatusToString,
+  ExportListItem,
+} from '@project-lc/shared-types';
+import { useAdminOrderExportListStore } from '@project-lc/stores';
 import dayjs from 'dayjs';
 import NextLink from 'next/link';
 import { useEffect, useRef, useState } from 'react';
+import { FaTruck } from 'react-icons/fa';
 
 const columns: GridColumns = [
   {
@@ -99,24 +128,216 @@ export function AdminOrderExportList(): JSX.Element {
       data?.totalCount ? data.totalCount : prevRowCountState,
     );
   }, [data, setRowCountState]);
+
+  // * 출고 선택
+  const { selectedItems, onSelectedItemsChange, setSelectedExports } =
+    useAdminOrderExportListStore();
+  const _onSelectedItemsChange = (m: GridSelectionModel): void => {
+    onSelectedItemsChange(m);
+    const targets = data?.edges
+      .filter((x) => m.includes(x.id))
+      .filter((x) => !!x.exportCode);
+    if (targets) setSelectedExports(targets);
+  };
+
   return (
-    <ChakraDataGrid
-      components={{ Toolbar: GridToolbar }}
-      columns={columns}
-      page={page}
-      rowsPerPageOptions={rowsPerPageOptions.current}
-      onPageSizeChange={(newPageSize) => setPageSize(newPageSize)}
-      rows={data?.edges || []}
-      minH={500}
-      autoHeight
-      loading={isLoading}
-      disableSelectionOnClick
-      pageSize={pageSize}
-      pagination
-      rowCount={rowCountState}
-      density="compact"
-      paginationMode="server"
-      onPageChange={handlePageChange}
-    />
+    <>
+      <Box>
+        <ButtonGroup size="sm" isDisabled={!(selectedItems.length > 0)}>
+          <DeliveryStartManyConfirmDialogButton />
+          <DeliveryDoneManyConfirmDialogButton />
+        </ButtonGroup>
+      </Box>
+      <ChakraDataGrid
+        components={{ Toolbar: GridToolbar }}
+        columns={columns}
+        page={page}
+        rowsPerPageOptions={rowsPerPageOptions.current}
+        onPageSizeChange={(newPageSize) => setPageSize(newPageSize)}
+        rows={data?.edges || []}
+        minH={500}
+        autoHeight
+        loading={isLoading}
+        disableSelectionOnClick
+        pageSize={pageSize}
+        pagination
+        rowCount={rowCountState}
+        density="compact"
+        paginationMode="server"
+        onPageChange={handlePageChange}
+        checkboxSelection
+        onSelectionModelChange={_onSelectedItemsChange}
+        selectionModel={selectedItems}
+      />
+    </>
+  );
+}
+
+type DeliveryStartManyConfirmDialogProps = Pick<
+  ConfirmDialogProps,
+  'onClose' | 'isOpen'
+> & {
+  targets: ExportListItem[];
+};
+function DeliveryStartManyConfirmDialog({
+  isOpen,
+  onClose,
+  targets,
+}: DeliveryStartManyConfirmDialogProps): JSX.Element {
+  const toast = useToast();
+  const resetSelectedExports = useAdminOrderExportListStore(
+    (s) => s.resetSelectedExports,
+  );
+  const deliveryStartMany = useDelieveryStartManyMutation();
+  const onDeliveryStartMany = async (): Promise<void> => {
+    if (targets.length <= 0)
+      toast({
+        status: 'warning',
+        title: '선택된 출고중 배송중처리할 수 있는 출고(배송중상태의 출고)가 없습니다.',
+      });
+    else {
+      deliveryStartMany
+        .mutateAsync({
+          deliveryDTOs: targets.map((exp) => ({
+            exportCode: exp.exportCode as string,
+            status: 'shipping',
+          })),
+        })
+        .then(() => {
+          resetSelectedExports();
+          toast({ status: 'success', title: '일괄 배송중 처리 성공' });
+        })
+        .catch((err) => {
+          toast({
+            status: 'error',
+            title: '일괄 배송중 처리 실패',
+            description: err.response?.data?.message,
+          });
+        });
+    }
+  };
+  return (
+    <ConfirmDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title="일괄배송중처리"
+      onConfirm={onDeliveryStartMany}
+    >
+      선택된 모든 출고의 상태를 배송중으로 상태를 변경할까요?
+    </ConfirmDialog>
+  );
+}
+
+function DeliveryStartManyConfirmDialogButton(props: ButtonProps): JSX.Element {
+  const btnGrpProps = useButtonGroup();
+  // 다중 배송중처리
+  const deliveryStartDialog = useDisclosure();
+  const selectedExports = useAdminOrderExportListStore((s) => s.selectedExports);
+  const targets = selectedExports.filter((exp) =>
+    ['exportDone', 'partialExportDone'].includes(exp.status),
+  );
+
+  return (
+    <>
+      <Button
+        {...btnGrpProps}
+        {...props}
+        isDisabled={targets.length <= 0 || btnGrpProps.isDisabled || props.isDisabled}
+        leftIcon={<FaTruck />}
+        colorScheme="purple"
+        onClick={deliveryStartDialog.onOpen}
+      >
+        일괄배송중처리
+      </Button>
+      <DeliveryStartManyConfirmDialog
+        isOpen={deliveryStartDialog.isOpen}
+        onClose={deliveryStartDialog.onClose}
+        targets={targets}
+      />
+    </>
+  );
+}
+
+type DeliveryDoneManyConfirmDialogProps = Pick<
+  ConfirmDialogProps,
+  'onClose' | 'isOpen'
+> & {
+  targets: ExportListItem[];
+};
+function DeliveryDoneManyConfirmDialog({
+  isOpen,
+  onClose,
+  targets,
+}: DeliveryDoneManyConfirmDialogProps): JSX.Element {
+  const toast = useToast();
+  const resetSelectedExports = useAdminOrderExportListStore(
+    (s) => s.resetSelectedExports,
+  );
+  const deliveryDoneMany = useDelieveryDoneManyMutation();
+  const onDeliveryDoneMany = async (): Promise<void> => {
+    if (targets.length <= 0)
+      toast({
+        status: 'warning',
+        title: '선택된 출고중 배송완료처리할 수 있는 출고(배송중상태의 출고)가 없습니다.',
+      });
+    else {
+      deliveryDoneMany
+        .mutateAsync({
+          deliveryDTOs: targets.map((exp) => ({
+            exportCode: exp.exportCode as string,
+            status: 'shippingDone',
+          })),
+        })
+        .then(() => {
+          resetSelectedExports();
+          toast({ status: 'success', title: '일괄 배송완료 처리 성공' });
+        })
+        .catch((err) => {
+          toast({
+            status: 'error',
+            title: '일괄 배송완료 처리 실패',
+            description: err.response?.data?.message,
+          });
+        });
+    }
+  };
+  return (
+    <ConfirmDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title="일괄배송중처리"
+      onConfirm={onDeliveryDoneMany}
+    >
+      선택된 모든 출고의 상태를 배송완료로 상태를 변경할까요?
+    </ConfirmDialog>
+  );
+}
+
+function DeliveryDoneManyConfirmDialogButton(props: ButtonProps): JSX.Element {
+  const btnGrpProps = useButtonGroup();
+  // 다중 배송중처리
+  const deliveryDoneDialog = useDisclosure();
+  const selectedExports = useAdminOrderExportListStore((s) => s.selectedExports);
+  const targets = selectedExports.filter((exp) =>
+    ['shipping', 'partialShipping'].includes(exp.status),
+  );
+  return (
+    <>
+      <Button
+        {...btnGrpProps}
+        {...props}
+        leftIcon={<FaTruck />}
+        colorScheme="messenger"
+        isDisabled={targets.length <= 0 || btnGrpProps.isDisabled || props.isDisabled}
+        onClick={deliveryDoneDialog.onOpen}
+      >
+        일괄배송완료처리
+      </Button>
+      <DeliveryDoneManyConfirmDialog
+        isOpen={deliveryDoneDialog.isOpen}
+        onClose={deliveryDoneDialog.onClose}
+        targets={targets}
+      />
+    </>
   );
 }

--- a/libs/components-admin/src/lib/AdminOrderExportList.tsx
+++ b/libs/components-admin/src/lib/AdminOrderExportList.tsx
@@ -305,7 +305,7 @@ function DeliveryDoneManyConfirmDialog({
     <ConfirmDialog
       isOpen={isOpen}
       onClose={onClose}
-      title="일괄배송중처리"
+      title="일괄배송완료처리"
       onConfirm={onDeliveryDoneMany}
     >
       선택된 모든 출고의 상태를 배송완료로 상태를 변경할까요?

--- a/libs/hooks/src/lib/mutation/useDelieveryMutation.tsx
+++ b/libs/hooks/src/lib/mutation/useDelieveryMutation.tsx
@@ -1,5 +1,5 @@
 import { Export } from '@prisma/client';
-import { DeliveryDto } from '@project-lc/shared-types';
+import { DeliveryDto, DeliveryManyDto } from '@project-lc/shared-types';
 import { AxiosError } from 'axios';
 import { useQueryClient, useMutation, UseMutationResult } from 'react-query';
 import axios from '../../axios';
@@ -19,7 +19,32 @@ export const useDelieveryStartMutation = (): UseMutationResult<
       onSuccess: (data) => {
         queryClient.invalidateQueries('OrderDetail');
         queryClient.invalidateQueries('getAdminOrder', { refetchInactive: true });
-        queryClient.invalidateQueries('AdminOrderList');
+        queryClient.invalidateQueries('AdminOrderList', { refetchInactive: true });
+        queryClient.invalidateQueries('Exports');
+        queryClient.invalidateQueries(['Exports'], { refetchInactive: true });
+      },
+    },
+  );
+};
+
+export type useDelieveryMutationManyRes = Export[];
+/** 배송중처리 - 일괄처리 요청 */
+export const useDelieveryStartManyMutation = (): UseMutationResult<
+  useDelieveryMutationManyRes,
+  AxiosError,
+  DeliveryManyDto
+> => {
+  const queryClient = useQueryClient();
+  return useMutation<useDelieveryMutationManyRes, AxiosError, DeliveryManyDto>(
+    (dto: DeliveryManyDto) =>
+      axios
+        .post<useDelieveryMutationManyRes>('/delivery/start/many', dto)
+        .then((res) => res.data),
+    {
+      onSuccess: (data) => {
+        queryClient.invalidateQueries('OrderDetail');
+        queryClient.invalidateQueries('getAdminOrder', { refetchInactive: true });
+        queryClient.invalidateQueries('AdminOrderList', { refetchInactive: true });
         queryClient.invalidateQueries('Exports');
         queryClient.invalidateQueries(['Exports'], { refetchInactive: true });
       },
@@ -41,7 +66,32 @@ export const useDelieveryDoneMutation = (): UseMutationResult<
       onSuccess: (data) => {
         queryClient.invalidateQueries('OrderDetail');
         queryClient.invalidateQueries('getAdminOrder', { refetchInactive: true });
-        queryClient.invalidateQueries('AdminOrderList');
+        queryClient.invalidateQueries('AdminOrderList', { refetchInactive: true });
+        queryClient.invalidateQueries('Exports');
+        queryClient.invalidateQueries(['Exports'], { refetchInactive: true });
+      },
+    },
+  );
+};
+
+export type useDelieveryDoneManyRes = Export[];
+/** 배송완료처리 - 일괄처리 요청 */
+export const useDelieveryDoneManyMutation = (): UseMutationResult<
+  useDelieveryDoneManyRes,
+  AxiosError,
+  DeliveryManyDto
+> => {
+  const queryClient = useQueryClient();
+  return useMutation<useDelieveryDoneManyRes, AxiosError, DeliveryManyDto>(
+    (dto: DeliveryManyDto) =>
+      axios
+        .post<useDelieveryDoneManyRes>('/delivery/done/many', dto)
+        .then((res) => res.data),
+    {
+      onSuccess: (data) => {
+        queryClient.invalidateQueries('OrderDetail');
+        queryClient.invalidateQueries('getAdminOrder', { refetchInactive: true });
+        queryClient.invalidateQueries('AdminOrderList', { refetchInactive: true });
         queryClient.invalidateQueries('Exports');
         queryClient.invalidateQueries(['Exports'], { refetchInactive: true });
       },

--- a/libs/nest-modules-delivery/src/lib/delivery.controller.ts
+++ b/libs/nest-modules-delivery/src/lib/delivery.controller.ts
@@ -8,7 +8,7 @@ import {
 } from '@nestjs/common';
 import { CacheClearKeys, HttpCacheInterceptor } from '@project-lc/nest-core';
 import { JwtAuthGuard } from '@project-lc/nest-modules-authguard';
-import { DeliveryDto } from '@project-lc/shared-types';
+import { DeliveryDto, DeliveryManyDto } from '@project-lc/shared-types';
 import { DeliveryService } from './delivery.service';
 
 @UseGuards(JwtAuthGuard)
@@ -25,10 +25,24 @@ export class DeliveryController {
     return this.deliveryService.deliveryStart(dto);
   }
 
+  @Post('start/many')
+  public async deliveryStartMany(
+    @Body(new ValidationPipe({ transform: true })) dto: DeliveryManyDto,
+  ): Promise<unknown> {
+    return this.deliveryService.deliveryStartMany(dto.deliveryDTOs);
+  }
+
   @Post('done')
   public async deliveryDone(
     @Body(new ValidationPipe({ transform: true })) dto: DeliveryDto,
   ): Promise<unknown> {
     return this.deliveryService.deliveryDone(dto);
+  }
+
+  @Post('done/many')
+  public async deliveryDoneMany(
+    @Body(new ValidationPipe({ transform: true })) dto: DeliveryManyDto,
+  ): Promise<unknown> {
+    return this.deliveryService.deliveryDoneMany(dto.deliveryDTOs);
   }
 }

--- a/libs/nest-modules-delivery/src/lib/delivery.service.ts
+++ b/libs/nest-modules-delivery/src/lib/delivery.service.ts
@@ -88,9 +88,19 @@ export class DeliveryService {
     return this.handleDelivery(dto);
   }
 
+  /** 배송시작 이벤트 핸들러 - 일괄처리 */
+  public async deliveryStartMany(dto: DeliveryDto[]): Promise<Export[]> {
+    return Promise.all(dto.map((deliveryDto) => this.handleDelivery(deliveryDto)));
+  }
+
   /** 배송완료 이벤트 핸들러 */
   public async deliveryDone(dto: DeliveryDto): Promise<Export> {
     // 향후 Noti 알림처리 등 handleDelivery와 독립적인 작업을 여기에 추가할 수 있을 것.
     return this.handleDelivery(dto);
+  }
+
+  /** 배송완료 이벤트 핸들러 - 일괄처리 */
+  public async deliveryDoneMany(dto: DeliveryDto[]): Promise<Export[]> {
+    return Promise.all(dto.map((deliveryDto) => this.handleDelivery(deliveryDto)));
   }
 }

--- a/libs/shared-types/src/lib/dto/delivery.dto.ts
+++ b/libs/shared-types/src/lib/dto/delivery.dto.ts
@@ -1,5 +1,6 @@
 import { OrderProcessStep } from '@prisma/client';
-import { IsIn, IsNotEmpty, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsArray, IsIn, IsNotEmpty, IsString, ValidateNested } from 'class-validator';
 
 export class DeliveryDto {
   @IsNotEmpty()
@@ -14,4 +15,11 @@ export class DeliveryDto {
     OrderProcessStep.partialShippingDone,
   ])
   status: OrderProcessStep;
+}
+
+export class DeliveryManyDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => DeliveryDto)
+  deliveryDTOs: DeliveryDto[];
 }

--- a/libs/stores/src/index.ts
+++ b/libs/stores/src/index.ts
@@ -1,3 +1,4 @@
+export * from './lib/adminOrderExportListStore';
 export * from './lib/adminReturnFilterStore';
 export * from './lib/adminSignupListStore';
 export * from './lib/cartStore';

--- a/libs/stores/src/lib/adminOrderExportListStore.tsx
+++ b/libs/stores/src/lib/adminOrderExportListStore.tsx
@@ -1,0 +1,25 @@
+import { GridSelectionModel } from '@material-ui/data-grid';
+import { ExportListItem } from '@project-lc/shared-types';
+import create from 'zustand';
+
+export interface AdminOrderExportListStore {
+  selectedItems: GridSelectionModel;
+  onSelectedItemsChange: (newSelectedItems: GridSelectionModel) => void;
+  selectedExports: ExportListItem[];
+  setSelectedExports: (_selectedExports: ExportListItem[]) => void;
+  resetSelectedExports: () => void;
+}
+
+export const useAdminOrderExportListStore = create<AdminOrderExportListStore>((set) => ({
+  selectedItems: [],
+  onSelectedItemsChange: (newV) => {
+    set({ selectedItems: newV });
+  },
+  selectedExports: [],
+  setSelectedExports: (selectedExports) => {
+    set({ selectedExports });
+  },
+  resetSelectedExports: () => {
+    set({ selectedExports: [], selectedItems: [] });
+  },
+}));


### PR DESCRIPTION
# 요구사항

여러개의 출고 목록을 한번에 배송중 배송 완료 등으로 변경할 수 있다. 

# 할일

- Front
- [x]  출고목록 선택가능하도록 구성
- [x]  선택된 목록에 대해 배송중 처리
    - [x]  선택된 목록에 배송중으로 처리가능한 상태의 출고가 없는 경우 버튼 비활성화 (출고완료, 부분출고완료 상태의 출고)
- [x]  선택된 목록에 대해 배송완료 처리
    - [x]  선택된 목록에 배송완료로 처리가능한 상태의 출고가 없는 경우 버튼 비활성화 (배송중, 부분배송중 상태의 출고)
- [x]  배송중/배송완료 확인 다이얼로그
- API
- [x]  일괄배송중처리
- [x]  일괄배송완료처리

# 테트케이스

- [ ]  출고목록에서 특정 출고를 선택할 수 있다
- [ ]  선택된 목록에 배송중으로 처리가능한 상태의 출고가 없는 경우 버튼 비활성화 (출고완료, 부분출고완료 상태의 출고) 된다
- [ ]  선택된 목록에 배송완료로 처리가능한 상태의 출고가 없는 경우 버튼 비활성화 (배송중, 부분배송중 상태의 출고) 된다
- [ ]  일괄배송중처리가 올바르게 진행된다
- [ ]  일괄배송완료처리가 올바르게 진행된다