### PR TITLE
feat : 공지사항 링크 추가

### DIFF
--- a/apps/web-kkshow/pages/mypage/notice.tsx
+++ b/apps/web-kkshow/pages/mypage/notice.tsx
@@ -1,0 +1,14 @@
+import { MypageNoticeSection } from '@project-lc/components-shared/MypageNoticeSection';
+import CustomerMypageLayout from '@project-lc/components-web-kkshow/mypage/CustomerMypageLayout';
+
+const title = '공지사항';
+
+export function NoticeIndex(): JSX.Element {
+  return (
+    <CustomerMypageLayout title={title}>
+      <MypageNoticeSection />
+    </CustomerMypageLayout>
+  );
+}
+
+export default NoticeIndex;

--- a/libs/components-admin/src/lib/AdminNoticeDialog.tsx
+++ b/libs/components-admin/src/lib/AdminNoticeDialog.tsx
@@ -13,7 +13,10 @@ import {
   FormErrorMessage,
   Grid,
   GridItem,
+  HStack,
   Input,
+  Radio,
+  RadioGroup,
   useColorModeValue,
   useToast,
 } from '@chakra-ui/react';
@@ -25,6 +28,7 @@ import {
 import { useNoticeMutation } from '@project-lc/hooks';
 import { NoticePostDto } from '@project-lc/shared-types';
 import { useForm } from 'react-hook-form';
+import { useEffect } from 'react';
 
 export interface AdminNoticeDialogProps {
   isOpen: boolean;
@@ -38,7 +42,8 @@ export function AdminNoticeDialog({
   const {
     register,
     handleSubmit,
-    formState: { errors, isSubmitting },
+    reset,
+    formState: { errors, isSubmitting, isSubmitSuccessful },
   } = useForm<NoticePostDto>();
 
   const toast = useToast();
@@ -61,6 +66,12 @@ export function AdminNoticeDialog({
       onClose();
     }
   };
+
+  useEffect(() => {
+    if (isSubmitSuccessful) {
+      reset();
+    }
+  }, [isSubmitSuccessful, reset]);
 
   return (
     <Modal isOpen={isOpen} size="5xl" onClose={onClose}>
@@ -88,6 +99,33 @@ export function AdminNoticeDialog({
                 />
                 <FormErrorMessage ml={3} mt={0}>
                   {errors.title && errors.title.message}
+                </FormErrorMessage>
+              </FormControl>
+            </GridItem>
+            <GridItem {...useDialogHeaderConfig(useColorModeValue)}>
+              공지사항 대상
+            </GridItem>
+            <GridItem {...useDialogValueConfig(useColorModeValue)}>
+              <FormControl isInvalid={!!errors.target}>
+                <RadioGroup defaultValue="all">
+                  <HStack>
+                    <Radio value="all" {...register('target')}>
+                      전체
+                    </Radio>
+                    <Radio value="seller" {...register('target')}>
+                      판매자
+                    </Radio>
+                    <Radio value="broadcaster" {...register('target')}>
+                      방송인
+                    </Radio>
+                    <Radio value="customer" {...register('target')}>
+                      소비자
+                    </Radio>
+                  </HStack>
+                </RadioGroup>
+
+                <FormErrorMessage ml={3} mt={0}>
+                  {errors.target && errors.target.message}
                 </FormErrorMessage>
               </FormControl>
             </GridItem>

--- a/libs/components-admin/src/lib/AdminNoticeSection.tsx
+++ b/libs/components-admin/src/lib/AdminNoticeSection.tsx
@@ -9,7 +9,7 @@ import {
   useToast,
 } from '@chakra-ui/react';
 import { GridCellParams, GridColumns, GridRowData } from '@material-ui/data-grid';
-import { Notice } from '@prisma/client';
+import { Notice, NoticeTarget } from '@prisma/client';
 import { ChakraDataGrid } from '@project-lc/components-core/ChakraDataGrid';
 import {
   useDeleteNoticeMutation,
@@ -18,6 +18,13 @@ import {
 } from '@project-lc/hooks';
 import dayjs from 'dayjs';
 import { AdminNoticeDialog } from './AdminNoticeDialog';
+
+const noticeTargetKr: Record<NoticeTarget, string> = {
+  all: '전체',
+  seller: '판매자',
+  broadcaster: '방송인',
+  customer: '소비자',
+};
 
 const columns = (
   handleChange: any,
@@ -37,6 +44,12 @@ const columns = (
           />
         );
       },
+    },
+    {
+      field: 'target',
+      headerName: '대상',
+      minWidth: 80,
+      valueFormatter: ({ row }) => noticeTargetKr[row.target as NoticeTarget],
     },
     {
       field: 'title',

--- a/libs/components-admin/src/lib/AdminNoticeSection.tsx
+++ b/libs/components-admin/src/lib/AdminNoticeSection.tsx
@@ -32,6 +32,11 @@ const columns = (
 ): GridColumns => {
   return [
     {
+      field: 'id',
+      headerName: 'id',
+      width: 30,
+    },
+    {
       field: 'posting',
       headerName: '포스팅하기',
       minWidth: 120,
@@ -54,11 +59,11 @@ const columns = (
     {
       field: 'title',
       headerName: '제목',
-      minWidth: 800,
+      minWidth: 400,
     },
     {
       field: 'date',
-      headerName: '날짜',
+      headerName: '포스팅 한 날짜',
       valueFormatter: ({ row }) =>
         dayjs(row.postingDate as Date).format('YYYY/MM/DD HH:mm:ss'),
       minWidth: 200,
@@ -164,14 +169,14 @@ export function AdminNoticeSection(): JSX.Element {
         headerHeight={40}
         minHeight={100}
         autoHeight
-        hideFooter
+        // hideFooter
         density="compact"
         columns={columns(handleFlagChange, handleDelete)}
         rows={makeListRow(notices)}
         rowsPerPageOptions={[25, 50]}
         onCellClick={handleClick}
-        rowCount={5}
-        pageSize={5}
+        pageSize={25}
+        pagination
         disableColumnMenu
         disableColumnFilter
         disableSelectionOnClick

--- a/libs/components-constants/src/lib/footerLinks.ts
+++ b/libs/components-constants/src/lib/footerLinks.ts
@@ -15,7 +15,6 @@ export const commonFooterLinkList: FooterLinkListItem[] = [
       {
         title: '개인정보처리방침',
         href: '/privacy',
-        isBold: true,
       },
       {
         title: '이용약관',
@@ -29,6 +28,10 @@ export const commonFooterLinkList: FooterLinkListItem[] = [
       {
         title: 'FAQ',
         href: 'https://whiletrue.notion.site/FAQ-f182f90b7e984badb031a62ddd1bd00d',
+      },
+      {
+        title: '공지사항',
+        href: 'https://whiletrue.notion.site/624da834257946dd91c0c4bcb7d8ab67',
       },
     ],
   },

--- a/libs/components-constants/src/lib/footerLinks.ts
+++ b/libs/components-constants/src/lib/footerLinks.ts
@@ -15,6 +15,7 @@ export const commonFooterLinkList: FooterLinkListItem[] = [
       {
         title: '개인정보처리방침',
         href: '/privacy',
+        isBold: true,
       },
       {
         title: '이용약관',

--- a/libs/components-constants/src/lib/navigation.ts
+++ b/libs/components-constants/src/lib/navigation.ts
@@ -379,6 +379,11 @@ const customerMypageActivityChildrenNavLinks: Omit<MypageLink, 'icon'>[] = [
 /** 크크쇼 소비자 마이페이지 사이드바 - "정보" 하위 탭 */
 const customerMypageInfoChildrenNavLinks: MypageLink[] = [
   {
+    name: '공지사항',
+    href: '/mypage/notice',
+    checkIsActive: defaultIsActiveChecker,
+  },
+  {
     name: '회원 정보 수정',
     href: '/mypage/info',
     checkIsActive: defaultIsActiveChecker,

--- a/libs/components-shared/src/lib/MypageNoticeSection.tsx
+++ b/libs/components-shared/src/lib/MypageNoticeSection.tsx
@@ -53,12 +53,10 @@ export function MypageNoticeSection(): JSX.Element {
         headerHeight={40}
         minHeight={100}
         autoHeight
-        hideFooter
         density="compact"
         columns={columns}
         rows={makeListRow(notices)}
         rowsPerPageOptions={[25, 50]}
-        rowCount={5}
         pageSize={5}
         disableColumnMenu
         disableColumnFilter

--- a/libs/hooks/src/lib/queries/useNotice.tsx
+++ b/libs/hooks/src/lib/queries/useNotice.tsx
@@ -7,7 +7,9 @@ import { Notice } from '@prisma/client';
 import axios from '../../axios';
 
 export function getNotice(): Promise<Notice[]> {
-  return axios.get<Notice[]>('/notice').then((res) => res.data);
+  return axios
+    .get<Notice[]>('/notice', { params: { target: process.env.NEXT_PUBLIC_APP_TYPE } })
+    .then((res) => res.data);
 }
 
 export function getAdminNotice(): Promise<Notice[]> {

--- a/libs/nest-modules-notice/src/notice/notice.controller.ts
+++ b/libs/nest-modules-notice/src/notice/notice.controller.ts
@@ -8,11 +8,12 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  Query,
   UseGuards,
   UseInterceptors,
   ValidationPipe,
 } from '@nestjs/common';
-import { Notice } from '@prisma/client';
+import { Notice, NoticeTarget } from '@prisma/client';
 import { CacheClearKeys, HttpCacheInterceptor } from '@project-lc/nest-core';
 import { AdminGuard, JwtAuthGuard } from '@project-lc/nest-modules-authguard';
 import { NoticePatchDto, NoticePostDto } from '@project-lc/shared-types';
@@ -26,8 +27,8 @@ export class NoticeController {
 
   @Get()
   @CacheTTL(60 * 60 * 60) // 1시간
-  getNotice(): Promise<Notice[]> {
-    return this.noticeService.getNotices();
+  getNotice(@Query('target') target: NoticeTarget): Promise<Notice[]> {
+    return this.noticeService.getNotices(target);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/libs/nest-modules-notice/src/notice/notice.service.ts
+++ b/libs/nest-modules-notice/src/notice/notice.service.ts
@@ -13,14 +13,13 @@ export class NoticeService {
       where: { postingFlag: true, target: target ? { in: ['all', target] } : undefined },
       orderBy: [{ postingDate: 'desc' }],
     });
-
     return notice;
   }
 
   // 관리자용 공지사항 조건 미할당 조회
   public async getAdminNotices(): Promise<Notice[]> {
     const notice = await this.prisma.notice.findMany({
-      orderBy: [{ postingDate: 'desc' }],
+      orderBy: [{ id: 'desc' }],
     });
     return notice;
   }

--- a/libs/nest-modules-notice/src/notice/notice.service.ts
+++ b/libs/nest-modules-notice/src/notice/notice.service.ts
@@ -31,6 +31,7 @@ export class NoticeService {
       data: {
         title: dto.title,
         url: dto.url,
+        target: dto.target,
         postingDate: dayjs().toISOString(),
       },
     });

--- a/libs/nest-modules-notice/src/notice/notice.service.ts
+++ b/libs/nest-modules-notice/src/notice/notice.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Notice } from '@prisma/client';
+import { Notice, NoticeTarget } from '@prisma/client';
 import { PrismaService } from '@project-lc/prisma-orm';
 import { NoticePatchDto, NoticePostDto } from '@project-lc/shared-types';
 import dayjs from 'dayjs';
@@ -8,9 +8,9 @@ import dayjs from 'dayjs';
 export class NoticeService {
   constructor(private readonly prisma: PrismaService) {}
 
-  public async getNotices(): Promise<Notice[]> {
+  public async getNotices(target?: NoticeTarget): Promise<Notice[]> {
     const notice = await this.prisma.notice.findMany({
-      where: { postingFlag: true },
+      where: { postingFlag: true, target: target ? { in: ['all', target] } : undefined },
       orderBy: [{ postingDate: 'desc' }],
     });
 

--- a/libs/prisma-orm/prisma/migrations/20220830054342_/migration.sql
+++ b/libs/prisma-orm/prisma/migrations/20220830054342_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `Notice` ADD COLUMN `target` ENUM('all', 'seller', 'broadcaster', 'customer') NOT NULL DEFAULT 'all';

--- a/libs/prisma-orm/prisma/schema.prisma
+++ b/libs/prisma-orm/prisma/schema.prisma
@@ -838,11 +838,19 @@ model SellCommission {
 // 공지사항
 // -------------------------------------------------
 model Notice {
-  id          Int      @id @default(autoincrement())
+  id          Int          @id @default(autoincrement())
   title       String // 공지사항 글의 제목
   url         String // 공지사항 글의 notion URL
-  postingFlag Boolean  @default(false) // 공지사항 글 게시여부
-  postingDate DateTime @default(now()) // 공지사항 글 게시시간
+  postingFlag Boolean      @default(false) // 공지사항 글 게시여부
+  postingDate DateTime     @default(now()) // 공지사항 글 게시시간
+  target      NoticeTarget @default(all) // 공지사항 대상(전체, 판매자, 방송인, 구매자)
+}
+
+enum NoticeTarget {
+  all // 전체
+  seller // 판매자
+  broadcaster // 방송인
+  customer // 구매자
 }
 
 // 전자 결제 수수료 정보 (퍼스트몰의 fm_account_payment_fee와 유사함, 와일트루 정책에 따르기위해 따로 구현)

--- a/libs/shared-types/src/lib/dto/post.dto.ts
+++ b/libs/shared-types/src/lib/dto/post.dto.ts
@@ -1,4 +1,5 @@
-import { IsBoolean, IsNumber, IsString } from 'class-validator';
+import { NoticeTarget } from '@prisma/client';
+import { IsBoolean, IsNumber, IsString, IsEnum } from 'class-validator';
 
 export class NoticePostDto {
   @IsString()
@@ -6,6 +7,9 @@ export class NoticePostDto {
 
   @IsString()
   url: string;
+
+  @IsEnum(NoticeTarget)
+  target: NoticeTarget;
 }
 
 export class NoticePatchDto {


### PR DESCRIPTION
api
 - Notice 테이블에 target 컬럼 추가(전체, 판매자, 방송인, 소비자)
 - 공지사항 목록 조회시 appType에 따라 해당하는 type의 글만 조회하도록 수정함

소비자
- 마이페이지 공지사항 탭 추가, target='all' | 'customer'인 공지사항 목록 표시

공통
- 푸터링크에 노션 공지사항 페이지 링크 추가

**테스트케이스**
- [ ]  관리자에서 공지사항 등록시 대상(전체, 판매자, 방송인, 소비자)을 선택할 수 있다
- [ ]  공통 푸터에 공지사항 페이지 링크가 존재한다. 클릭시 노션 공지사항 공공페이지가 뜬다
- [ ]  방송인 마이페이지에는 공지사항 대상이 ‘전체', ‘방송인' 인 공지사항만 표시된다
- [ ]  판매자 마이페이지에는 공지사항 대상이 ‘전체', ‘판매자' 인 공지사항만 표시된다
- [ ]  소비자 마이페이지 사이드바에 공지사항 탭을 클릭하면 공지사항 목록이 표시된다
    - [ ]  소비자 마이페이지에는 공지사항 대상이 ‘전체', ’소비자' 인 공지사항만 표시된다