### PR TITLE
[성능개선] 이미지 불러오는 데에 시간이 많이 걸림

### DIFF
--- a/apps/web-kkshow/next.config.js
+++ b/apps/web-kkshow/next.config.js
@@ -13,11 +13,11 @@ const nextConfig = {
   images: {
     domains: [
       'project-lc-dev-test.s3.ap-northeast-2.amazonaws.com',
+      'lc-project.s3.ap-northeast-2.amazonaws.com',
       'whiletrue.firstmall.kr',
       'k-kmarket.com',
       // 테스트용 랜덤 사진 사이트. 프로덕션에는 필요 없음.
       // by @hwasurr
-      'lc-project.s3.ap-northeast-2.amazonaws.com',
       'picsum.photos',
     ],
   },

--- a/apps/web-kkshow/next.config.js
+++ b/apps/web-kkshow/next.config.js
@@ -19,6 +19,8 @@ const nextConfig = {
       // 테스트용 랜덤 사진 사이트. 프로덕션에는 필요 없음.
       // by @hwasurr
       'picsum.photos',
+      'i.ibb.co',
+      'phinf.pstatic.net',
     ],
   },
 };

--- a/libs/components-core/src/lib/ChakraNextImage.tsx
+++ b/libs/components-core/src/lib/ChakraNextImage.tsx
@@ -1,6 +1,29 @@
-import { chakra } from '@chakra-ui/react';
+import { chakra, forwardRef } from '@chakra-ui/react';
 import Image from 'next/image';
+import { ComponentProps } from 'react';
 
-export const ChakraNextImage = chakra(Image, {
-  shouldForwardProp: (prop) => ['width', 'height', 'src', 'alt', 'layout'].includes(prop),
+export const ChakraNextImageBase = chakra(Image, {
+  shouldForwardProp: (prop) =>
+    [
+      'width',
+      'height',
+      'src',
+      'alt',
+      'layout',
+      'quality',
+      'sizes',
+      'loader',
+      'priority',
+      'placeholder',
+      'objectFit',
+      'objectPosition',
+      'blurDataURL',
+      'lazyBoundray',
+      'lazyRoot',
+    ].includes(prop),
 });
+
+export const ChakraNextImage = forwardRef<
+  ComponentProps<typeof ChakraNextImageBase>,
+  typeof ChakraNextImageBase
+>((props, ref) => <ChakraNextImageBase {...props} ref={ref} />);

--- a/libs/components-shared/src/lib/goods-review/ReviewList.tsx
+++ b/libs/components-shared/src/lib/goods-review/ReviewList.tsx
@@ -14,7 +14,6 @@ import {
   Center,
   Divider,
   Flex,
-  Image,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -24,6 +23,7 @@ import {
   Text,
   useDisclosure,
 } from '@chakra-ui/react';
+import { ChakraNextImage } from '@project-lc/components-core/ChakraNextImage';
 import StarRating from '@project-lc/components-core/StarRating';
 import {
   useGoodsById,
@@ -234,17 +234,17 @@ export function ReviewDetail({
 
         <Flex gap={1} my={2} flexWrap="wrap">
           {review.images.slice(0, 5).map((i, idx) => (
-            <Image
-              rounded="md"
-              key={i.id}
-              h="90px"
-              w="90px"
-              objectFit="cover"
-              src={i.imageUrl}
-              draggable={false}
-              cursor="pointer"
-              onClick={() => handleImageClick(idx)}
-            />
+            <button key={i.id} onClick={() => handleImageClick(idx)} type="button">
+              <ChakraNextImage
+                rounded="md"
+                height="90px"
+                width="90px"
+                objectFit="cover"
+                src={i.imageUrl}
+                draggable={false}
+                cursor="pointer"
+              />
+            </button>
           ))}
         </Flex>
         <Box>
@@ -318,8 +318,9 @@ export function ReviewDetail({
             {selectedImageIdx !== null && (
               <Box pos="relative">
                 <AspectRatio maxH={600} maxW={600} textAlign="center">
-                  <Image
-                    w="100%"
+                  <ChakraNextImage
+                    layout="fill"
+                    width="100%"
                     src={review.images[selectedImageIdx].imageUrl}
                     objectFit="cover"
                   />

--- a/libs/components-shared/src/lib/goods/GoodsDisplay2.tsx
+++ b/libs/components-shared/src/lib/goods/GoodsDisplay2.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Badge, Box, Flex, Image, Link, Text } from '@chakra-ui/react';
+import { Avatar, Badge, Box, Flex, Link, Text } from '@chakra-ui/react';
 import {
   Goods,
   GoodsImages,
@@ -7,6 +7,7 @@ import {
   Seller,
   SellerShop,
 } from '@prisma/client';
+import { ChakraNextImage } from '@project-lc/components-core/ChakraNextImage';
 import NextLink from 'next/link';
 import { OrderStatusBadge } from '../order/OrderStatusBadge';
 
@@ -62,7 +63,7 @@ export function GoodsDisplay2({
   return (
     <Flex gap={2}>
       {goods.imageSrc && (
-        <Image
+        <ChakraNextImage
           rounded="md"
           src={goods.imageSrc}
           width={imageSize}

--- a/libs/components-web-kkshow/src/lib/EventPopup.tsx
+++ b/libs/components-web-kkshow/src/lib/EventPopup.tsx
@@ -1,7 +1,7 @@
 import {
+  Box,
   Button,
   Checkbox,
-  Image,
   LinkBox,
   LinkOverlay,
   Modal,
@@ -12,6 +12,7 @@ import {
   useBoolean,
   useDisclosure,
 } from '@chakra-ui/react';
+import { ChakraNextImage } from '@project-lc/components-core/ChakraNextImage';
 import { useProfile } from '@project-lc/hooks';
 import { getKkshowWebHost } from '@project-lc/utils';
 import { deleteCookie, getCookie, setCookie } from '@project-lc/utils-frontend';
@@ -65,10 +66,16 @@ export function EventPopup(): JSX.Element {
           <LinkBox>
             <NextLink href={`${getKkshowWebHost()}/signup`} passHref>
               <LinkOverlay>
-                <Image
-                  src={s3.getSavedObjectUrl(KKSHOW_OPEN_EVENT_IMAGE_KEY)}
-                  borderTopRadius="md"
-                />
+                <Box h={[300, 400, 500]} pos="relative">
+                  <ChakraNextImage
+                    layout="fill"
+                    quality={100}
+                    objectFit="fill"
+                    priority
+                    src={s3.getSavedObjectUrl(KKSHOW_OPEN_EVENT_IMAGE_KEY)}
+                    borderTopRadius="md"
+                  />
+                </Box>
               </LinkOverlay>
             </NextLink>
           </LinkBox>

--- a/libs/components-web-kkshow/src/lib/GoodsDisplay.tsx
+++ b/libs/components-web-kkshow/src/lib/GoodsDisplay.tsx
@@ -10,6 +10,7 @@ import {
   LinkOverlay,
   Text,
 } from '@chakra-ui/react';
+import { ChakraNextImage } from '@project-lc/components-core/ChakraNextImage';
 import MotionBox from '@project-lc/components-core/MotionBox';
 import { KkshowShoppingTabGoodsData } from '@project-lc/shared-types';
 import { getDiscountedRate, getLocaleNumber } from '@project-lc/utils-frontend';
@@ -99,23 +100,20 @@ export const GoodsDisplayImage = ({
 }: GoodsDisplayImageProps): JSX.Element => (
   <AspectRatio ratio={ratio}>
     <Box
-      position="relative"
       maxWidth={{ base: 'unset', md: 340 }}
       borderRadius={rest.borderRadius || 'xl'}
       {...rest}
     >
-      <motion.img
-        style={{
-          shadow: hasShadow ? 'md' : 'none',
-          width: '100%',
-          height: '100%',
-          objectFit: 'cover',
-        }}
-        alt={alt}
-        src={src}
-        draggable={false}
-        {...imageProps}
-      />
+      <motion.div {...imageProps}>
+        <ChakraNextImage
+          layout="fill"
+          shadow={hasShadow ? 'md' : 'none'}
+          objectFit="cover"
+          alt={alt}
+          src={src}
+          draggable={false}
+        />
+      </motion.div>
 
       {withArrowIcon && <GoodsDisplayArrowIcon />}
     </Box>
@@ -169,9 +167,8 @@ export function GoodsDisplay({
           src={goods.imageUrl}
           ratio={ratio}
           borderBottomRadius={variant === 'card' ? 'none' : undefined}
-          imageProps={{
-            variants: { hover: { scale: 1.05 } },
-          }}
+          // 이미지 컴포넌트를 motion.img에서 ChakraNextImage로 변경이후, hover시 이미지 사라지는 현상으로 임시 제거
+          // imageProps={{ variants: { hover: { scale: 1.05 } } }}
         />
 
         <GoodsDisplayContainer

--- a/libs/components-web-kkshow/src/lib/goods/GoodsViewMeta.tsx
+++ b/libs/components-web-kkshow/src/lib/goods/GoodsViewMeta.tsx
@@ -15,6 +15,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react';
 import { Goods, GoodsStatus } from '@prisma/client';
+import { ChakraNextImage } from '@project-lc/components-core/ChakraNextImage';
 import { GoodsStatusBadge } from '@project-lc/components-shared/GoodsStatusBadge';
 import ShippingGroupSets from '@project-lc/components-shared/shipping/ShippingGroupSets';
 import { useGoodsById, useLiveShoppingNowOnLive } from '@project-lc/hooks';
@@ -147,7 +148,7 @@ export function GoodsViewImages({
             key={i.id}
             src={i.image}
             alt={goodsName + i.id}
-            maxW="45px"
+            width="45px"
             mb={2}
             rounded="md"
             onMouseEnter={() => setSelectedImageIdx(idx)}
@@ -155,7 +156,8 @@ export function GoodsViewImages({
         ))}
       </Box>
       <AspectRatio ratio={1 / 1} w="100%" rounded="md">
-        <Image
+        <ChakraNextImage
+          layout="fill"
           draggable={false}
           src={images[selectedImageIdx].image}
           alt={goodsName}

--- a/libs/components-web-kkshow/src/lib/main/carousel/KkshowMainCarouselContents.tsx
+++ b/libs/components-web-kkshow/src/lib/main/carousel/KkshowMainCarouselContents.tsx
@@ -1,17 +1,11 @@
-import {
-  AspectRatio,
-  Box,
-  BoxProps,
-  Image,
-  LinkBox,
-  LinkOverlay,
-} from '@chakra-ui/react';
+import { AspectRatio, Box, BoxProps, LinkBox, LinkOverlay } from '@chakra-ui/react';
 import { KkshowMainCarouselItem } from '@project-lc/shared-types';
 import { EmbededVideo } from '@project-lc/components-shared/EmbededVideo';
 import { memo, useCallback } from 'react';
 import Link from 'next/link';
 import { YouTubePlayer } from 'youtube-player/dist/types';
 import { useSwiper } from 'swiper/react';
+import { ChakraNextImage } from '@project-lc/components-core/ChakraNextImage';
 
 export interface KkshowMainCarouselContentsProps {
   item: KkshowMainCarouselItem;
@@ -53,7 +47,16 @@ export function KkshowMainCarouselContents({
           <LinkBox rounded="xl">
             <Link href={item.productLinkUrl} passHref>
               <LinkOverlay isExternal={item.productLinkUrl.includes('http')}>
-                <Image src={item.imageUrl} rounded="xl" w="100%" h="100%" />
+                <ChakraNextImage
+                  layout="fill"
+                  objectFit="contain"
+                  src={item.imageUrl}
+                  rounded="xl"
+                  priority
+                  quality={100}
+                  width="100%"
+                  height="100%"
+                />
               </LinkOverlay>
             </Link>
           </LinkBox>
@@ -68,7 +71,16 @@ export function KkshowMainCarouselContents({
           <LinkBox rounded="xl">
             <Link href={item.linkUrl || '#'} passHref>
               <LinkOverlay isExternal={!!(item.linkUrl && item.linkUrl.includes('http'))}>
-                <Image src={item.imageUrl} rounded="xl" w="100%" h="100%" />
+                <ChakraNextImage
+                  layout="fill"
+                  objectFit="contain"
+                  src={item.imageUrl}
+                  rounded="xl"
+                  priority
+                  quality={100}
+                  width="100%"
+                  height="100%"
+                />
               </LinkOverlay>
             </Link>
           </LinkBox>

--- a/libs/components-web-kkshow/src/lib/shopping/ShoppingCarousel.tsx
+++ b/libs/components-web-kkshow/src/lib/shopping/ShoppingCarousel.tsx
@@ -1,4 +1,5 @@
-import { Flex, Image, useBreakpointValue } from '@chakra-ui/react';
+import { Flex, useBreakpointValue } from '@chakra-ui/react';
+import { ChakraNextImage } from '@project-lc/components-core/ChakraNextImage';
 import { useKkshowShopping } from '@project-lc/hooks';
 import { KkshowShoppingTabCarouselItem } from '@project-lc/shared-types';
 import Link from 'next/link';
@@ -30,6 +31,8 @@ export function ShoppingCarousel(): JSX.Element {
             <SwiperSlide
               style={{
                 margin: '0 auto',
+                width: '100%',
+                height: '100%',
                 maxWidth: 1000,
                 maxHeight: 500,
               }}
@@ -62,13 +65,17 @@ const ShoppingCarouselItem = ({
       onSlideNext={onSlideNext}
       onSlidePrev={onSlidePrev}
     >
-      <Link href={linkUrl}>
-        <Image
-          src={imageUrl}
-          w={{ base: 'unset', lg: 1000 }}
-          h={{ base: 'unset', lg: 500 }}
-          objectFit="contain"
-        />
+      <Link href={linkUrl} passHref>
+        <a>
+          <ChakraNextImage
+            layout="intrinsic"
+            width="1000px"
+            height="500px"
+            quality={100}
+            src={imageUrl}
+            objectFit="contain"
+          />
+        </a>
       </Link>
     </SwiperSlideItem>
   );

--- a/libs/components-web-kkshow/src/lib/shopping/ShoppingCategories.tsx
+++ b/libs/components-web-kkshow/src/lib/shopping/ShoppingCategories.tsx
@@ -59,8 +59,8 @@ export function ShoppingCategories(): JSX.Element | null {
                   _groupHover={{ shadow: 'lg', transform: 'translateY(2px)' }}
                   _groupActive={{ shadow: 'lg', transform: 'translateY(2px)' }}
                 />
-                <Link href={`shopping/category/${category.categoryCode}`} passHref>
-                  <LinkOverlay href={`shopping/category/${category.categoryCode}`}>
+                <Link href={`/shopping/category/${category.categoryCode}`} passHref>
+                  <LinkOverlay href={`/shopping/category/${category.categoryCode}`}>
                     <Text fontSize={['xs', 'sm', 'md']} noOfLines={2} textAlign="center">
                       {category.name}
                     </Text>

--- a/libs/components-web-kkshow/src/lib/shopping/ShoppingGoodsOfTheWeek.tsx
+++ b/libs/components-web-kkshow/src/lib/shopping/ShoppingGoodsOfTheWeek.tsx
@@ -1,4 +1,5 @@
-import { Box, Flex, Heading, Image, LinkBox, LinkOverlay } from '@chakra-ui/react';
+import { Box, Flex, Heading, LinkBox, LinkOverlay } from '@chakra-ui/react';
+import { ChakraNextImage } from '@project-lc/components-core/ChakraNextImage';
 import FadeUp from '@project-lc/components-layout/motion/FadeUp';
 import SlideCustom from '@project-lc/components-layout/motion/SlideCustom';
 import { useKkshowShopping } from '@project-lc/hooks';
@@ -92,9 +93,11 @@ export function ShoppingGoodsOfTheWeek(): JSX.Element {
             data.goodsOfTheWeek.map((item) => (
               <SwiperSlide key={item.name} style={{ width: '75%', maxWidth: 340 }}>
                 {({ isActive }) => (
-                  <Image
+                  <ChakraNextImage
+                    layout="intrinsic"
                     objectFit="cover"
-                    h={{ base: 240, md: 340 }}
+                    height={340}
+                    width={340}
                     src={item.imageUrl}
                     alt={item.name}
                     transform={isActive ? 'scale(1)' : 'scale(0.8)'}

--- a/libs/prisma-orm/prisma/seedData/kkshowShoppingTab.ts
+++ b/libs/prisma-orm/prisma/seedData/kkshowShoppingTab.ts
@@ -210,7 +210,8 @@ export const kkshowShoppingTabDummyData = {
       linkUrl: 'https://k-kmarket.com/board/view?id=goods_review&seq=2',
       contents:
         '티비에서 방송하는걸 본적 있던 예스닭강정\n\n\n\n이번에 라이브커머스로 소개되자마자 예전 기억이 떠오르면서 구매하게 됐습니다\n\n\n\n\n\n일단 기본적으로 닭강정입니다\n\n\n\n네, 실패할수가 없다는 말이죠\n\n\n\n다만 뼈있는 닭강정이 아니라 순살 닭강정입니다\n\n\n\n네, 먹기가 편하다는거죠\n\n\n\n기본적으로 닭강정들은 먹을때 따로 뎁히지 않고 차갑게 된 상태에서 먹는게 국룰입니다\n\n\n\n다만 예스닭강정의 경우 순살 닭강정이다 보니 차갑게 먹는것보다 전자레인지에 살짝 뎁히는편이 더 좋았습니다\n\n\n\n1분은 좀 과했고, 30초정도가 딱 좋았네요\n\n\n\n세일즈포인트중 하나가 공기층이 같이 있어서 부들부들한 식감이었는데, 30초 뎁히니까 딱 부드러우면서 쫄깃하고 달콤한 닭강정 최적의 맛이 나왔습니다\n\n\n\n블랙닭강정의 경우는 일단 신기해서 같이 시켜봤는데요.\n\n\n\n일단 생각하는 맛은 아닙니다.\n\n\n\n춘장이 들어가있기는 한데, 그렇다고 짜장맛은 아니구요\n\n\n\n기본적인 닭강정맛에서 매운맛을 조금 더 덜어내고, 달짝한 맛이 추가됐습니다\n\n\n\n그리고 춘장이 들어가서 소스가 일반 닭강정보다 약간 꾸덕한 느낌이 듭니다. 춘장맛은 일부러 찾으려고 하지 않으면 잘 느껴지지는 않고, 꾸덕함과 달짝한 맛이 더 추가됐다고 생각하시면 되겠습니다\n\n\n\n그리고 먹는다고 이빨이 까매지지는 않았습니다\n\n\n\n색다른 닭강정이 먹고 싶다면 한번쯤 도전해볼만 합니다. 기본 닭강정에서 지나치게 바뀌진 않으면서 다른맛이 납니다\n\n\n\n\n\n결론 - 닭강정은 항상 맛있다. 존..맛 ',
-      imageUrl: 'https://i.ibb.co/Qbm6Lyp/Kakao-Talk-20211221-194813657.jpg',
+      imageUrl:
+        'https://k-kmarket.com/data/board/goods_review/761167a21b74945284840126978ac0611424122.jpg',
       createDate: '2021-12-21',
     },
     {
@@ -219,7 +220,7 @@ export const kkshowShoppingTabDummyData = {
       linkUrl: 'https://k-kmarket.com/board/view?id=goods_review&seq=4',
       contents: '배송이 잘못왔는데 대처가 너무 만족스럽습니다.',
       imageUrl:
-        'https://phinf.pstatic.net/checkout.phinf/20220123_210/1642904591443WBJrD_JPEG/review-attachment-7eab1102-c0fb-4276-8eb5-bad83ff536b6.jpeg?type=w640',
+        'https://k-kmarket.com/data/board/goods_review/761167a21b74945284840126978ac0611424122.jpg',
       createDate: '2022-01-23',
     },
   ],

--- a/libs/prisma-orm/prisma/seedData/kkshowShoppingTab.ts
+++ b/libs/prisma-orm/prisma/seedData/kkshowShoppingTab.ts
@@ -210,8 +210,7 @@ export const kkshowShoppingTabDummyData = {
       linkUrl: 'https://k-kmarket.com/board/view?id=goods_review&seq=2',
       contents:
         '티비에서 방송하는걸 본적 있던 예스닭강정\n\n\n\n이번에 라이브커머스로 소개되자마자 예전 기억이 떠오르면서 구매하게 됐습니다\n\n\n\n\n\n일단 기본적으로 닭강정입니다\n\n\n\n네, 실패할수가 없다는 말이죠\n\n\n\n다만 뼈있는 닭강정이 아니라 순살 닭강정입니다\n\n\n\n네, 먹기가 편하다는거죠\n\n\n\n기본적으로 닭강정들은 먹을때 따로 뎁히지 않고 차갑게 된 상태에서 먹는게 국룰입니다\n\n\n\n다만 예스닭강정의 경우 순살 닭강정이다 보니 차갑게 먹는것보다 전자레인지에 살짝 뎁히는편이 더 좋았습니다\n\n\n\n1분은 좀 과했고, 30초정도가 딱 좋았네요\n\n\n\n세일즈포인트중 하나가 공기층이 같이 있어서 부들부들한 식감이었는데, 30초 뎁히니까 딱 부드러우면서 쫄깃하고 달콤한 닭강정 최적의 맛이 나왔습니다\n\n\n\n블랙닭강정의 경우는 일단 신기해서 같이 시켜봤는데요.\n\n\n\n일단 생각하는 맛은 아닙니다.\n\n\n\n춘장이 들어가있기는 한데, 그렇다고 짜장맛은 아니구요\n\n\n\n기본적인 닭강정맛에서 매운맛을 조금 더 덜어내고, 달짝한 맛이 추가됐습니다\n\n\n\n그리고 춘장이 들어가서 소스가 일반 닭강정보다 약간 꾸덕한 느낌이 듭니다. 춘장맛은 일부러 찾으려고 하지 않으면 잘 느껴지지는 않고, 꾸덕함과 달짝한 맛이 더 추가됐다고 생각하시면 되겠습니다\n\n\n\n그리고 먹는다고 이빨이 까매지지는 않았습니다\n\n\n\n색다른 닭강정이 먹고 싶다면 한번쯤 도전해볼만 합니다. 기본 닭강정에서 지나치게 바뀌진 않으면서 다른맛이 납니다\n\n\n\n\n\n결론 - 닭강정은 항상 맛있다. 존..맛 ',
-      imageUrl:
-        'https://k-kmarket.com/data/board/goods_review/761167a21b74945284840126978ac0611424122.jpg',
+      imageUrl: 'https://i.ibb.co/Qbm6Lyp/Kakao-Talk-20211221-194813657.jpg',
       createDate: '2021-12-21',
     },
     {
@@ -220,7 +219,7 @@ export const kkshowShoppingTabDummyData = {
       linkUrl: 'https://k-kmarket.com/board/view?id=goods_review&seq=4',
       contents: '배송이 잘못왔는데 대처가 너무 만족스럽습니다.',
       imageUrl:
-        'https://k-kmarket.com/data/board/goods_review/761167a21b74945284840126978ac0611424122.jpg',
+        'https://phinf.pstatic.net/checkout.phinf/20220123_210/1642904591443WBJrD_JPEG/review-attachment-7eab1102-c0fb-4276-8eb5-bad83ff536b6.jpeg?type=w640',
       createDate: '2022-01-23',
     },
   ],


### PR DESCRIPTION
### 문제점

네트워크 성능을 제한한 채 페이지 로딩시, 빠르게 화면을 확인할 수 없음

+느리다는 제보가 있음

### 개선 방법

1. chakra Image 컴포넌트 → next/image 로 변경하면 빨라지려나>?
2. 이미지가 화면에 안보일 때 레이지로딩 적용
3. (크크쇼 메인화면 twitch/youtube 임베드 불러오는 데에 시간이 많이 걸릴 수도)

# 할일

- [x]  next/image 학습 / 조사
    - 내용
        
        Nextjs 의 Image Optimization 을 위한 컴포넌트.
        
        - **Required Props**
            - src: 정적 이미지 (statically imported image) 또는 이미지 URL (path string, can be external URL or internal path depending on loader) extenralURL을 사용한다면, next.config.js 에 domains 에 명시해야 한다.
            - width, height: `layout` 속성에 따라 성격이 달라지는 속성으로, 이미지의 너비(width)와 높이(height)를 표현
                - `layout=intrinsic`(default) or `layout=fixed`: rendered width/height in pixels. how large the image appears.
                - `layout=responsive` or `layout=fill`: original width/height in pixels. only affect the aspect ratio.
                - `layout=fill` 인 경우, width/height 속성은 옵셔널이다.
        - **Optional Props**
            - layout
                - intrinsic: 컨테이너의 width에 맞춰지기 위해 줄어듦, maxWidth가 설정되어있고 width:100% 가 설정되어 있는 상태라고 생각하면 편하다.
                - fixed
                - responsive
                    - 부모엘리먼트가 display:block 여야 한다.
                - fill
                    - 부모엘리먼트가 position: relative 여야 한다.
            - loader
            - sizes
                - 다양한 breakpoint에서 이미지의 너비에 대한 정보를 제공하는 문자열. sizes 값은 layout=responsive 또는 layout=fill 인 경우 성능에 큰 영향을 미친다. layout=intrinsic, layout=fixed 인 경우 sizes 속성값은 무시된다.
                - sizes 속성의 이미지 성능 최적화와 관련된 중요한 두 목적
                    - sizes 속성값은 브라우저에 의해 어떤 사이즈의 이미지를 다운로드할 것인지 결정하는 데에 사용된다.
                    브라우저가 다운로드할 이미지를 선택할 때 이전 이미지의 크기를 모르기 때문에, 뷰포트보다 크거나 같은 크기의 이미지를 선택한다. sizes 속성은 브라우저에게 full screen 보다 이미지가 작다고 알릴 수 있게 한다. sizes 속성을 지정하지 않으면 100vw가 기본값으로 지정되어 있다.
                    - sizes 속성값은 구문분석되고 자동 생성된 srcset 값을 잘라내는 데에 사용된다. 만약 sizes 속성이 뷰포트 너비의 백분율을 나타내는 50vw 와 같은 값을 포함하고 있다면, srcset은 너무 작아서 필요하지 않은 값은 포함하지 않도록 잘려진다.
            - quality
                - 최적화된 이미지의 품질. 1 ~ 100 사이의 값을 가지고, 100이 최상 품질의 이미지를 의미함. 기본값은 75
            - priority
                - boolean, 만약 true 로 지정된 경우, 해당 이미지는 우선순위가 높다고 고려되며, lazy loading이 비활성화 되고 preload 된다. 페이지의 가장 큰 엘리먼트(LCP Element)에 priority 속성을 지
            - placeholder
                - 이미지가 로딩되는 동안 표시될 placeholder 에 대한 설정을 지정하는 속성. blur, empty 두 값이 가능.
                    - blur: blurDataURL을 placeholder 이미지로 사용함. 만약 src에 사용된 이미지가 static import 이미지 오브젝트인 경우, 자동으로 blurDataURL이 생성되고, 그렇지 않은 경우 blurDataURL을 입력해야만 한다.
                    - empty: 불러오는 동안 빈 공간이 보여진다.
        - **Advanced Props**
            - style
                - 다른 React 태그들과 마찬가지로 inline-css를 적용할 수 있음. 그러나, layout 속성에 따른 스타일이 우선적용됨.
            - objectFit
                - layout = fill 인 경우에만 유효한 속성. 이미지가 부모 컨테이너 안에서 어떻게 맞출지를 지정한다. CSS object-fit 속성과 같은 속성이다.
            - objectPosition
                - layout = fill 인 경우에만 유효한 속성. 이미지가 부모 컨테이너 안에서 어떻게 위치할지를 지정한다. CSS object-position 속성과 같은 속성이다.
            - onLoadingComplete
                - 이미지 로딩에 성공하고 동시에 placeholder가 제거될 때 한번 호출되는 콜백함수
            - blurDataURL
                - placeholder = blur인 경우에만 유효한 속성. 이미지 src를 성공적으로 로딩하기 전에 placeholder로 사용될 이미지의 DataURL을 입력받는다. 이 속성은 base64-encoded 문자열이어야만 한다. 이 이미지는 확대되고 흐려지므로 성능을 위해 아주 작은 이미지를 권장한다.
            - lazyBoundary
                - 이미지와 뷰포트의 교차를 감지하여 이미지의 lazy loading을 트리거하기 위한 속성으로, 바운딩박스 역할을 하는 문자열. margin 속성과 같은 값을 가짐. 기본값은 200px
            - lazyRoot
                - 스크롤 가능한 부모 엘리먼트의 리액트 ref.
- [x]  크크쇼 메인화면 Image 컴포넌트 next/image 컴포넌트로 구성
- [x]  크크마켓
- [x]  크크마켓 - 카테고리
- [x]  상품상세
- [x]  크크쇼 - 마이페이지 - 리뷰


# 테스트케이스

- [ ]  이벤트 팝업 이미지가 올바르게 보인다
- [ ]  크크쇼 페이지 이미지가 올바르게 보인다
- [ ]  크크마켓 페이지 이미지가 올바르게 보인다
    - [ ]  크크마켓 - 카테고리 페이지 이미지가 올바르게 보인다
- [ ]  상품상세 페이지 이미지가 올바르게 보인다
- [ ]  크크쇼-마이페이지-리뷰 이미지가 올바르게보인다