### PR TITLE
feat(overlay-controller): 전송된 시간 보여주기 추가

### DIFF
--- a/apps/overlay-controller/src/lib/admin.js
+++ b/apps/overlay-controller/src/lib/admin.js
@@ -347,6 +347,8 @@ $(document).ready(function ready() {
       date: selectedTime,
       streamerAndProduct,
     });
+    const sel = `현재 전송된 시작 시간: ${selectedTime}`;
+    $('#etc-control-start-time').text(sel);
   });
 
   $('#product-name-send-button').click(function startTimeSendButtonClickEvent() {
@@ -365,11 +367,15 @@ $(document).ready(function ready() {
   $('#end-time-send-button').click(function endTimeSendButtonClickEvent() {
     const selectedTime = $('#end-time-picker').val();
     socket.emit('get d-day', { roomName, date: selectedTime });
+    const sel = `현재 전송된 종료 시간: ${selectedTime}`;
+    $('#etc-control-end-time').text(sel);
   });
 
   $('#fever-time-send-button').click(function feverTimeSendButtonClickEvent() {
     const selectedTime = $('#fever-time-picker').val();
     socket.emit('get fever date from admin', { roomName, date: selectedTime });
+    const sel = `현재 전송된 피버 시간: ${selectedTime}`;
+    $('#etc-control-fever-time').text(sel);
   });
 
   $('#data-send-all').click(function dataSendAllButtonClickEvent() {

--- a/apps/overlay-controller/src/views/index.hbs
+++ b/apps/overlay-controller/src/views/index.hbs
@@ -413,18 +413,21 @@
             <button id='start-time-send-button' style='background-color: blue;'>
               시작 시간 전송
             </button>
+            <span id="etc-control-start-time"></span>
           </div>
           <div class='datetime-picker'>
             <input type='datetime-local' id='end-time-picker' />
             <button id='end-time-send-button' style='background-color: red;'>
               종료 시간 전송
             </button>
+            <span id="etc-control-end-time"></span>
           </div>
           <div class='datetime-picker'>
             <input type='datetime-local' id='fever-time-picker' />
             <button id='fever-time-send-button' style='background-color: purple;'>
               피버 시간 전송
             </button>
+            <span id="etc-control-fever-time"></span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
- 문제
    - 라이브 쇼핑 시작 및 종료 시간 설정이 제대로 되었는지 알수가 없음
- 해결 방안
    - 설정한 시간이 오른쪽에 뜨도록 한다.

# 할일

- [x]  설정한 시간이 오른쪽에 뜨도록 한다

# 테스트케이스

- [x]  시작시간이 올바르게 표시된다
- [x]  종료시간이 올바르게 표시된다
- [x]  피버시간이 올바르게 표시된다