### PR TITLE
hotfix : 크크쇼 메인 하단 베스트방송인 이미지 크기가 안맞는 현상 수정

### DIFF
--- a/libs/components-web-kkshow/src/lib/main/KkshowMainBestBroadcaster.tsx
+++ b/libs/components-web-kkshow/src/lib/main/KkshowMainBestBroadcaster.tsx
@@ -82,10 +82,8 @@ export function BestBroadcasterItem(props: BestBroadcasterItemProps): JSX.Elemen
       >
         <Avatar
           size="2xl"
-          width="100%"
-          height="100%"
-          maxW={{ base: 120, md: 160 }}
-          maxH={{ base: 120, md: 160 }}
+          width={{ base: 120, md: 160 }}
+          height={{ base: 120, md: 160 }}
           src={props.avatarUrl}
           cursor="pointer"
           border={isNowLive ? '2px solid red' : undefined}

--- a/libs/components-web-kkshow/src/lib/search/GoodsCard.tsx
+++ b/libs/components-web-kkshow/src/lib/search/GoodsCard.tsx
@@ -16,7 +16,7 @@ export function GoodsCard({ item }: { item: SearchResultItem }): JSX.Element {
               <GoodsDisplayImage
                 rounded="xl"
                 src={item.imageUrl}
-                imageProps={{ variants: { hover: { scale: 1.1 } } }}
+                // imageProps={{ variants: { hover: { scale: 1.1 } } }} // 이미지 컴포넌트를 motion.img에서 ChakraNextImage로 변경이후, hover시 이미지 사라지는 현상으로 임시 제거
               />
               <Text fontFamily="Gmarket Sans" textAlign="center">
                 {item.title}


### PR DESCRIPTION
- 정사각형 형태의 이미지가 아닌 경우 이상하게 표시됨 => Avatar 컴포넌트 width, height 고정
<img width="657" alt="스크린샷 2022-09-08 오전 10 23 31" src="https://user-images.githubusercontent.com/18395475/189012852-6ddf1c79-1073-4ce7-a1ed-a695cf7f18d8.png">

- 검색결과 상품이미지 마우스 올렸을때 이미지 하얗게 되는 현상 임시 수정