### PR TITLE
improve : [오버레이] 중간금액 - 뉴스테마 송출 시 하단 메시지 속도 조절

### DIFF
--- a/apps/overlay/src/assets/layout.css
+++ b/apps/overlay/src/assets/layout.css
@@ -205,7 +205,7 @@ body {
 }
 
 .bottom-timer.urgent {
-  color: #ac0000;
+  color: #ff4d4d;
 }
 
 .bottom-timer span {
@@ -829,6 +829,9 @@ span.objective-value {
   padding-left: 1000px;
   display: inline-block;
   white-space: nowrap;
+}
+
+.animation-marquee {
   -webkit-animation-name: marquee;
   -webkit-animation-timing-function: linear;
   -moz-animation-name: marquee;
@@ -840,6 +843,7 @@ span.objective-value {
   animation-name: marquee;
   animation-timing-function: linear;
 }
+
 @-webkit-keyframes marquee {
   from {
     -webkit-transform: translate(0%);

--- a/apps/overlay/src/assets/layout.css
+++ b/apps/overlay/src/assets/layout.css
@@ -831,24 +831,14 @@ span.objective-value {
   white-space: nowrap;
   -webkit-animation-name: marquee;
   -webkit-animation-timing-function: linear;
-  -webkit-animation-duration: 10s;
-  -webkit-animation-iteration-count: infinite;
   -moz-animation-name: marquee;
   -moz-animation-timing-function: linear;
-  -moz-animation-duration: 10s;
-  -moz-animation-iteration-count: infinite;
   -ms-animation-name: marquee;
   -ms-animation-timing-function: linear;
-  -ms-animation-duration: 10s;
-  -ms-animation-iteration-count: infinite;
   -o-animation-name: marquee;
   -o-animation-timing-function: linear;
-  -o-animation-duration: 10s;
-  -o-animation-iteration-count: infinite;
   animation-name: marquee;
   animation-timing-function: linear;
-  animation-duration: 10s;
-  animation-iteration-count: infinite;
 }
 @-webkit-keyframes marquee {
   from {

--- a/apps/overlay/src/lib/overlayClient.js
+++ b/apps/overlay/src/lib/overlayClient.js
@@ -554,21 +554,27 @@ socket.on('get objective message', async (data) => {
     `,
   );
   $('.news-banner').show();
-  $('.bottom-area-text').text(`${data.users} 구매 감사합니다!`);
+  $('.bottom-area-text').text(`구매 감사합니다! ${data.users} 구매 감사합니다!`);
 
   $('.bottom-area-right').css({ opacity: 1 });
   $('.bottom-area-text').css({ opacity: 1 });
 
-  // .bottom-area-text 의 너비 (px)
+  // .bottom-area-text 의 너비 (px단위)
   const userNicknamesWidth = $('.bottom-area-text').width();
-  // 초당 보여질 너비 (px)
-  const displayPixelPerSec = 250;
-  // 0 -> -100% 이동하는 애니메이션을 몇초동안 보여줄것인지 (animationDuration 설정 css 상으로는 기존 10s)
-  const animationDurationInSec = Math.floor(userNicknamesWidth / displayPixelPerSec);
-  $('.bottom-area-text').css({ animationDuration: `${animationDurationInSec}s` });
-  // onaminationEnd => hide(). removeAnimationEndEvent
-
-  // animationIterationCount 설정 현재 infinite => 한번만
+  // 초당 이동할 거리 (px단위) => 속도를 빠르게 하려면 초당이동거리를 증가시키면 됨
+  const movingPixelPerSec = 150;
+  // 0 -> -100% 이동하는 애니메이션(marquee)을 몇 초동안 보여줄것인지 (animationDuration 설정 css 상으로는 기존 10s)
+  const animationDurationInSec = Math.floor(userNicknamesWidth / movingPixelPerSec);
+  const keyframeName = 'marquee'; // layout.css 에 작성되어 있음;
+  const easingFunction = 'linear';
+  const duration = `${Math.max(animationDurationInSec, 10)}s`; // 최소 10초
+  $('.bottom-area-text').css({
+    animation: `${keyframeName} ${easingFunction} ${duration}`,
+  });
+  // 구매자 닉네임 보여주는 애니메이션 종료 후 하단띠 숨기기
+  $('.bottom-area-text').on('animationend', () => {
+    hideBottomAreaText();
+  });
 
   // 중간금액 알림 tts를 위한 이벤트
   socket.emit('send objective notification signal', data);
@@ -660,12 +666,18 @@ socket.on('get bottom fever message', (data) => {
 //   bottomMessages = data;
 // });
 
+/** 하단 띠 숨기기(& 애니메이션 해제) */
+function hideBottomAreaText() {
+  $('.bottom-area-text').text('');
+  $('.bottom-area-right').css({ opacity: 0 });
+  $('.bottom-area-text').css({ animation: null });
+  $('.bottom-area-right-fever-wrapper').hide();
+}
+
 // 하단 띠 배너 영역 토글
 socket.on('handle bottom area to client', () => {
   if ($('.bottom-area-right').css('opacity') === '1') {
-    $('.bottom-area-text').text('');
-    $('.bottom-area-right').css({ opacity: 0 });
-    $('.bottom-area-right-fever-wrapper').hide();
+    hideBottomAreaText();
   } else {
     $('.bottom-area-right').css({ opacity: 1 }).fadeIn(2000);
   }

--- a/apps/overlay/src/lib/overlayClient.js
+++ b/apps/overlay/src/lib/overlayClient.js
@@ -554,7 +554,7 @@ socket.on('get objective message', async (data) => {
     `,
   );
   $('.news-banner').show();
-  $('.bottom-area-text').text(`구매 감사합니다! ${data.users} 구매 감사합니다!`);
+  $('.bottom-area-text').text(`${data.users} 구매 감사합니다!`);
 
   $('.bottom-area-right').css({ opacity: 1 });
   $('.bottom-area-text').css({ opacity: 1 });
@@ -565,16 +565,13 @@ socket.on('get objective message', async (data) => {
   const movingPixelPerSec = 150;
   // 0 -> -100% 이동하는 애니메이션(marquee)을 몇 초동안 보여줄것인지 (animationDuration 설정 css 상으로는 기존 10s)
   const animationDurationInSec = Math.floor(userNicknamesWidth / movingPixelPerSec);
-  const keyframeName = 'marquee'; // layout.css 에 작성되어 있음;
-  const easingFunction = 'linear';
   const duration = `${Math.max(animationDurationInSec, 10)}s`; // 최소 10초
-  $('.bottom-area-text').css({
-    animation: `${keyframeName} ${easingFunction} ${duration}`,
-  });
-  // 구매자 닉네임 보여주는 애니메이션 종료 후 하단띠 숨기기
-  $('.bottom-area-text').on('animationend', () => {
-    hideBottomAreaText();
-  });
+  $('.bottom-area-text')
+    .addClass('animation-marquee')
+    .css({ animationDuration: `${duration}` })
+    .on('animationend', () => {
+      hideBottomAreaText();
+    }); // 구매자 닉네임 보여주는 애니메이션 종료 후 하단띠 숨기기
 
   // 중간금액 알림 tts를 위한 이벤트
   socket.emit('send objective notification signal', data);
@@ -668,9 +665,11 @@ socket.on('get bottom fever message', (data) => {
 
 /** 하단 띠 숨기기(& 애니메이션 해제) */
 function hideBottomAreaText() {
-  $('.bottom-area-text').text('');
   $('.bottom-area-right').css({ opacity: 0 });
-  $('.bottom-area-text').css({ animation: null });
+  $('.bottom-area-text')
+    .text('')
+    .css({ animationDuration: '' })
+    .removeClass('animation-marquee');
   $('.bottom-area-right-fever-wrapper').hide();
 }
 

--- a/apps/overlay/src/lib/overlayClient.js
+++ b/apps/overlay/src/lib/overlayClient.js
@@ -555,8 +555,20 @@ socket.on('get objective message', async (data) => {
   );
   $('.news-banner').show();
   $('.bottom-area-text').text(`${data.users} 구매 감사합니다!`);
+
   $('.bottom-area-right').css({ opacity: 1 });
   $('.bottom-area-text').css({ opacity: 1 });
+
+  // .bottom-area-text 의 너비 (px)
+  const userNicknamesWidth = $('.bottom-area-text').width();
+  // 초당 보여질 너비 (px)
+  const displayPixelPerSec = 250;
+  // 0 -> -100% 이동하는 애니메이션을 몇초동안 보여줄것인지 (animationDuration 설정 css 상으로는 기존 10s)
+  const animationDurationInSec = Math.floor(userNicknamesWidth / displayPixelPerSec);
+  $('.bottom-area-text').css({ animationDuration: `${animationDurationInSec}s` });
+  // onaminationEnd => hide(). removeAnimationEndEvent
+
+  // animationIterationCount 설정 현재 infinite => 한번만
 
   // 중간금액 알림 tts를 위한 이벤트
   socket.emit('send objective notification signal', data);


### PR DESCRIPTION
- 중간금액 뉴스속보 메세지 송출시 표시되는 하단메시지(구매자들 닉네임) 속도 고정함 - 초당 150px 이동

**테스트케이스**

(송출 프로그램obs을 켜서 오버레이 브라우저 띄운 상태로 테스트함. 브라우저에서 오버레이 접속하여 테스트시 유저 동작없이 play()를 할 수 없다는 오류가 간헐적으로 발생하여 소리가 나지 않음. 이에 대한 해결방법은 아직 찾지 못함)

- “하단메시지 없이 & 뉴스속보 소리 없이” 뉴스메시지만 전송하고 싶은 경우 테마선택 위 ‘뉴스메시지 전송' 기능을 사용하면 됨

- [ ]  뉴스테마 송출시 구매자가 많아도 하단메시지 속도가 고정되어 있다
- [ ]  하단메시지가 1회 돌고나면 자동으로 사라진다
- [ ]  하단메시지가  표시되는 중 화면제어 부분의 ‘하단띠토글' 버튼을 누르면 하단메시지를 숨길 수 있다
- [ ]  다른 중간금액 뉴스속보 알림 시 하단메시지 애니메이션이 다시 동작한다