### PR TITLE
improve : [크크쇼] 상품 마우스 올렸을때 이미지 효과 되돌리기

### DIFF
--- a/apps/web-kkshow/pages/index.tsx
+++ b/apps/web-kkshow/pages/index.tsx
@@ -1,8 +1,5 @@
 import { Box } from '@chakra-ui/react';
-import {
-  ChuseokDeliveryPopup,
-  SignupEventPopup,
-} from '@project-lc/components-web-kkshow/EventPopup';
+import { SignupEventPopup } from '@project-lc/components-web-kkshow/EventPopup';
 import { KkshowLayout } from '@project-lc/components-web-kkshow/KkshowLayout';
 import { KkshowMainBestBroadcaster } from '@project-lc/components-web-kkshow/main/KkshowMainBestBroadcaster';
 import { KkshowMainBestLive } from '@project-lc/components-web-kkshow/main/KkshowMainBestLive';
@@ -69,8 +66,6 @@ export default function Index(): JSX.Element {
 
       {/* 신규가입 이벤트 팝업 */}
       <SignupEventPopup />
-      {/* 추석 배송 안내 팝업 */}
-      <ChuseokDeliveryPopup />
 
       <KkshowLayout>
         <KkshowMainCarousel />

--- a/libs/components-core/src/lib/ChakraNextImage.tsx
+++ b/libs/components-core/src/lib/ChakraNextImage.tsx
@@ -20,6 +20,7 @@ export const ChakraNextImageBase = chakra(Image, {
       'blurDataURL',
       'lazyBoundray',
       'lazyRoot',
+      'style', // 대부분 스타일 적용은 chakra style props로 전달하므로, 스타일 적용 위한 style prop은 NextImage 컴포넌트로 전달
     ].includes(prop),
 });
 

--- a/libs/components-web-kkshow/src/lib/EventPopup.tsx
+++ b/libs/components-web-kkshow/src/lib/EventPopup.tsx
@@ -20,7 +20,6 @@ import { useProfile } from '@project-lc/hooks';
 import { getKkshowWebHost } from '@project-lc/utils';
 import { deleteCookie, getCookie, setCookie } from '@project-lc/utils-frontend';
 import { s3 } from '@project-lc/utils-s3';
-import dayjs from 'dayjs';
 import NextLink from 'next/link';
 import { useEffect } from 'react';
 
@@ -34,27 +33,6 @@ export function SignupEventPopup(): JSX.Element {
       s3ImageKey={KKSHOW_OPEN_EVENT_IMAGE_KEY}
       cookieKey={EVENT_POPUP_COOKIE}
       href={`${getKkshowWebHost()}/signup`}
-    />
-  );
-}
-
-const DELIVERY_IMAGE_KEY = 'public/delivery_popup.jpg';
-const DELIVERY_POPUP_COOKIE = 'kkshow-dv';
-/** 추석배송 이벤트 팝업 */
-export function ChuseokDeliveryPopup(): JSX.Element {
-  const endDateOfChuseokHoliday = '2022-9-12';
-  const todayIsAfterChuseokHoliday = dayjs().isAfter(endDateOfChuseokHoliday, 'day');
-  if (todayIsAfterChuseokHoliday) {
-    // 9월 13일부터 안뜸
-    return <></>;
-  }
-  return (
-    <EventPopup
-      s3ImageKey={DELIVERY_IMAGE_KEY}
-      cookieKey={DELIVERY_POPUP_COOKIE}
-      modalSize="5xl"
-      imageHeight={483}
-      imageFit={{ base: 'cover', md: 'fill' }}
     />
   );
 }

--- a/libs/components-web-kkshow/src/lib/GoodsDisplay.tsx
+++ b/libs/components-web-kkshow/src/lib/GoodsDisplay.tsx
@@ -6,16 +6,13 @@ import {
   Heading,
   HeadingProps,
   Icon,
-  LinkBox,
-  LinkOverlay,
   Text,
+  useBoolean,
 } from '@chakra-ui/react';
 import { ChakraNextImage } from '@project-lc/components-core/ChakraNextImage';
-import MotionBox from '@project-lc/components-core/MotionBox';
 import { KkshowShoppingTabGoodsData } from '@project-lc/shared-types';
 import { getDiscountedRate, getLocaleNumber } from '@project-lc/utils-frontend';
-import { HTMLMotionProps, motion } from 'framer-motion';
-import Link from 'next/link';
+import NextLink from 'next/link';
 import { useMemo } from 'react';
 
 export interface GoodsDisplayDetailProps {
@@ -87,7 +84,7 @@ interface GoodsDisplayImageProps extends BoxProps {
   alt?: string;
   hasShadow?: boolean;
   withArrowIcon?: boolean;
-  imageProps?: HTMLMotionProps<'img'>;
+  mouseEnter?: boolean;
 }
 export const GoodsDisplayImage = ({
   src,
@@ -95,16 +92,16 @@ export const GoodsDisplayImage = ({
   ratio = 1,
   hasShadow,
   withArrowIcon = true,
-  imageProps,
+  mouseEnter = false,
   ...rest
-}: GoodsDisplayImageProps): JSX.Element => (
-  <AspectRatio ratio={ratio}>
-    <Box
-      maxWidth={{ base: 'unset', md: 340 }}
-      borderRadius={rest.borderRadius || 'xl'}
-      {...rest}
-    >
-      <motion.div {...imageProps}>
+}: GoodsDisplayImageProps): JSX.Element => {
+  return (
+    <AspectRatio ratio={ratio}>
+      <Box
+        maxWidth={{ base: 'unset', md: 340 }}
+        borderRadius={rest.borderRadius || 'xl'}
+        {...rest}
+      >
         <ChakraNextImage
           layout="fill"
           shadow={hasShadow ? 'md' : 'none'}
@@ -112,13 +109,17 @@ export const GoodsDisplayImage = ({
           alt={alt}
           src={src}
           draggable={false}
+          style={{
+            transition: 'all 0.5s ease',
+            transform: mouseEnter ? 'scale(1.05)' : undefined,
+          }}
         />
-      </motion.div>
 
-      {withArrowIcon && <GoodsDisplayArrowIcon />}
-    </Box>
-  </AspectRatio>
-);
+        {withArrowIcon && <GoodsDisplayArrowIcon />}
+      </Box>
+    </AspectRatio>
+  );
+};
 
 export interface GoodsDisplayProps extends GoodsDisplayDetailProps {
   goods: KkshowShoppingTabGoodsData;
@@ -159,30 +160,27 @@ export function GoodsDisplay({
     return <Box {...props} />;
   };
 
+  const [mouseEnter, { on, off }] = useBoolean();
+
   return (
-    <LinkBox w="100%">
-      <MotionBox whileHover="hover">
+    <NextLink href={goods.linkUrl}>
+      <Box cursor="pointer" onMouseEnter={on} onMouseLeave={off}>
         <GoodsDisplayImage
           alt={goods.name}
           src={goods.imageUrl}
           ratio={ratio}
           borderBottomRadius={variant === 'card' ? 'none' : undefined}
-          // 이미지 컴포넌트를 motion.img에서 ChakraNextImage로 변경이후, hover시 이미지 사라지는 현상으로 임시 제거
-          // imageProps={{ variants: { hover: { scale: 1.05 } } }}
+          mouseEnter={mouseEnter}
         />
 
         <GoodsDisplayContainer
           p={2}
           color={variant === 'card' ? 'blackAlpha.900' : undefined}
         >
-          <Link href={goods.linkUrl} passHref>
-            <LinkOverlay href={goods.linkUrl}>
-              <GoodsDisplayDetail goods={goods} {...detailProps} />
-            </LinkOverlay>
-          </Link>
+          <GoodsDisplayDetail goods={goods} {...detailProps} />
         </GoodsDisplayContainer>
-      </MotionBox>
-    </LinkBox>
+      </Box>
+    </NextLink>
   );
 }
 

--- a/libs/components-web-kkshow/src/lib/GoodsDisplay.tsx
+++ b/libs/components-web-kkshow/src/lib/GoodsDisplay.tsx
@@ -111,7 +111,7 @@ export const GoodsDisplayImage = ({
           draggable={false}
           style={{
             transition: 'all 0.5s ease',
-            transform: mouseEnter ? 'scale(1.05)' : undefined,
+            transform: mouseEnter ? 'scale(1.1)' : undefined,
           }}
         />
 

--- a/libs/components-web-kkshow/src/lib/GoodsReviewDisplay.tsx
+++ b/libs/components-web-kkshow/src/lib/GoodsReviewDisplay.tsx
@@ -1,13 +1,4 @@
-import {
-  Box,
-  BoxProps,
-  Flex,
-  Heading,
-  LinkBox,
-  LinkOverlay,
-  Text,
-} from '@chakra-ui/react';
-import MotionBox from '@project-lc/components-core/MotionBox';
+import { Box, BoxProps, Flex, Heading, Text, useBoolean } from '@chakra-ui/react';
 import { StarRating } from '@project-lc/components-core/StarRating';
 import { KkshowShoppingTabReviewData } from '@project-lc/shared-types';
 import dayjs from 'dayjs';
@@ -37,16 +28,15 @@ export function GoodsReviewDisplay({
       );
     return <Box {...props} />;
   };
+  const [mouseEnter, { on, off }] = useBoolean();
   return (
-    <MotionBox whileHover="hover">
-      <LinkBox>
+    <Link href={review.linkUrl} passHref>
+      <Box cursor="pointer" onMouseEnter={on} onMouseLeave={off}>
         <GoodsDisplayImage
           src={review.imageUrl}
           alt={review.title}
           withArrowIcon={false}
-          // imageProps={{
-          //   variants: { hover: { scale: 1.05 } },
-          // }}
+          mouseEnter={mouseEnter}
         />
         <GoodsReviewDisplayContainer
           maxH={150}
@@ -60,19 +50,17 @@ export function GoodsReviewDisplay({
             <StarRating rating={review.rating} />
             <Text fontSize="xs">{dayjs(review.createDate).format('YYYY.MM.DD')}</Text>
           </Flex>
-          <Link href={review.linkUrl} passHref>
-            <LinkOverlay href={review.linkUrl}>
-              <Heading mb={3} fontSize="md">
-                {review.title}
-              </Heading>
-            </LinkOverlay>
-          </Link>
+
+          <Heading mb={3} fontSize="md">
+            {review.title}
+          </Heading>
+
           <Text fontSize="xs" noOfLines={3}>
             {review.contents}
           </Text>
         </GoodsReviewDisplayContainer>
-      </LinkBox>
-    </MotionBox>
+      </Box>
+    </Link>
   );
 }
 

--- a/libs/components-web-kkshow/src/lib/promotion-page/PromotionPageGoodsDisplay.tsx
+++ b/libs/components-web-kkshow/src/lib/promotion-page/PromotionPageGoodsDisplay.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/no-array-index-key */
-import { Badge, Box, Flex, LinkBox, LinkOverlay, Text } from '@chakra-ui/react';
-import MotionBox from '@project-lc/components-core/MotionBox';
+import { Badge, Box, Flex, Text, useBoolean } from '@chakra-ui/react';
 import RedLinedText from '@project-lc/components-core/RedLinedText';
 
 import { PromotionPagePromotionGoods } from '@project-lc/shared-types';
@@ -26,39 +25,33 @@ export function PromotinoPageGoodsDisplay({
   item,
   isLive,
 }: PromotinoPageGoodsDisplayProps): JSX.Element | null {
+  const [mouseEnter, { on, off }] = useBoolean();
+
   const defaultOpt = item.goods.options.find((x) => x.default_option === 'y');
   if (!defaultOpt) return null;
 
   const isDiscounted = defaultOpt.consumer_price > defaultOpt.price;
 
   return (
-    <LinkBox pos="relative">
-      <MotionBox whileHover="hover">
+    <NextLink href={`/goods/${item.goods.id}?bc=${broadcasterId}`} passHref>
+      <Box cursor="pointer" onMouseEnter={on} onMouseLeave={off}>
         <GoodsDisplayImage
           border={isLive ? '2px solid red' : undefined}
           alt={item.goods.goods_name}
           src={item.goods.image.find((i) => i.image)?.image || ''}
           ratio={1}
-          imageProps={
-            {
-              // variants: { hover: { scale: 1.05 } },
-            }
-          }
+          mouseEnter={mouseEnter}
         />
 
         <Box py={2} px={1}>
-          <NextLink href={`/goods/${item.goods.id}?bc=${broadcasterId}`} passHref>
-            <LinkOverlay>
-              <Text noOfLines={2} fontSize={['sm', 'md']}>
-                {isLive && (
-                  <Badge variant="solid" colorScheme="red" mr={1}>
-                    LIVE
-                  </Badge>
-                )}
-                {item.goods.goods_name}
-              </Text>
-            </LinkOverlay>
-          </NextLink>
+          <Text noOfLines={2} fontSize={['sm', 'md']}>
+            {isLive && (
+              <Badge variant="solid" colorScheme="red" mr={1}>
+                LIVE
+              </Badge>
+            )}
+            {item.goods.goods_name}
+          </Text>
           <Text
             color="GrayText"
             fontSize="sm"
@@ -90,8 +83,8 @@ export function PromotinoPageGoodsDisplay({
             </Flex>
           </Box>
         </Box>
-      </MotionBox>
-    </LinkBox>
+      </Box>
+    </NextLink>
   );
 }
 

--- a/libs/components-web-kkshow/src/lib/search/GoodsCard.tsx
+++ b/libs/components-web-kkshow/src/lib/search/GoodsCard.tsx
@@ -1,30 +1,22 @@
-import { LinkBox, LinkOverlay, Stack, Text } from '@chakra-ui/react';
-import MotionBox from '@project-lc/components-core/MotionBox';
+import { Box, Stack, Text, useBoolean } from '@chakra-ui/react';
 import { SearchResultItem } from '@project-lc/shared-types';
 import NextLink from 'next/link';
 import { GoodsDisplayImage } from '../GoodsDisplay';
 
-/** 검색결과 - 상품아이템 => 쇼핑탭에서 작성한 상품컴포넌트와 비슷할듯하다 => 확인 후 수정필요
+/** 검색결과 - 상품아이템
  */
 export function GoodsCard({ item }: { item: SearchResultItem }): JSX.Element {
+  const [mouseEnter, { on, off }] = useBoolean();
   return (
-    <MotionBox whileHover="hover">
-      <LinkBox>
-        <NextLink href={item.linkUrl} passHref>
-          <LinkOverlay isExternal={item.linkUrl.includes('http')}>
-            <Stack>
-              <GoodsDisplayImage
-                rounded="xl"
-                src={item.imageUrl}
-                imageProps={{ variants: { hover: { scale: 1.1 } } }}
-              />
-              <Text fontFamily="Gmarket Sans" textAlign="center">
-                {item.title}
-              </Text>
-            </Stack>
-          </LinkOverlay>
-        </NextLink>
-      </LinkBox>
-    </MotionBox>
+    <NextLink href={item.linkUrl} passHref>
+      <Box cursor="pointer" onMouseEnter={on} onMouseLeave={off}>
+        <Stack>
+          <GoodsDisplayImage rounded="xl" src={item.imageUrl} mouseEnter={mouseEnter} />
+          <Text fontFamily="Gmarket Sans" textAlign="center">
+            {item.title}
+          </Text>
+        </Stack>
+      </Box>
+    </NextLink>
   );
 }


### PR DESCRIPTION
상품에 마우스를 올렸을 때 이미지가 확대대는 효과 되돌리기 위해 
해당 효과가 필요한 컴포넌트에만 framer motion 제거하고, mouseEnter이벤트 발생 시 NextImage의 style을 변경하도록 함

**기타 수정사항**
- 추석이벤트 팝업 컴포넌트 제거함

**테스트케이스**

- [ ]  크크마켓 메인페이지 상품에 마우스를 올렸을 때 이미지가 확대대는 효과가 나타난다
- [ ]  크크마켓 메인페이지 하단 리뷰에 마우스 올렸을 때 이미지가 확대대는 효과가 나타난다
- [ ]  크크쇼 방송인 상품홍보페이지 상품에 마우스를 올렸을 때 이미지가 확대대는 효과가 나타난다
- [ ]  크크쇼 검색페이지 상품에 마우스를 올렸을 때 이미지가 확대대는 효과가 나타난다