### PR TITLE
fix: 오버레이URL 올바르게 복사되도록 수정

### DIFF
--- a/libs/components-web-bc/src/lib/OverlayUrlCard.tsx
+++ b/libs/components-web-bc/src/lib/OverlayUrlCard.tsx
@@ -1,5 +1,6 @@
 import { Button, Flex, Input, Text, useToast } from '@chakra-ui/react';
 import { useProfile } from '@project-lc/hooks';
+import { getOverlayHost } from '@project-lc/utils';
 import { useState } from 'react';
 
 export interface UrlCardProps {
@@ -56,7 +57,7 @@ export function OverlayUrlCard(): JSX.Element {
 
   // 10초간 overlayUrl을 보여주는 함수
   const handleShowOverlayUrl = (): void => {
-    const overlayUrl = `https://live.크크쇼.com${profileData?.overlayUrl}` || '';
+    const overlayUrl = `${getOverlayHost()}${profileData?.overlayUrl}` || '';
     setOverlayUrlValue(overlayUrl);
 
     // 클립보드 복사


### PR DESCRIPTION
- 문제 상황
    - 한글 도메인인 경우 브라우저에서 변환해 주지만 프릭샷에서는 정상적으로 작동하지 않는 것으로 보인다.
- 해결 방안
    - ‘라이브 쇼핑 URL 복사’시 한글 도메인이 아닌 변환된 URL을 복사 하도록 한다.
        - ex)
            - `크크쇼.com` X
            - `xn--hp4b17xa.com` O

# 할일

- [x]  라이브쇼핑 URL 복사 한글 → 영문으로 수정

# 테스트케이스

- [x]  라이브쇼핑 URL이 영어로 올바르게 복사된다