### PR TITLE
improve: 홍보페이지 설명 이미지 크기 수정

### DIFF
--- a/libs/components-web-bc/src/lib/PromotionPageUrlCard.tsx
+++ b/libs/components-web-bc/src/lib/PromotionPageUrlCard.tsx
@@ -123,19 +123,17 @@ export function PromotionPageUrlInformationModal({
           <ModalCloseButton />
           <ModalBody>
             <Stack spacing={10}>
-              <Box>
+              <Text>
+                해당 페이지에서 판매가 발생하면 일정 수수료가 지급됩니다. <br />팬
+                여러분들이 볼 수 있는 공간 (방송국 정보란, 개인 SNS 등)에 해당 URL을
+                게시하고 상품을 홍보해보세요!
+              </Text>
+              <Box pos="relative" w="100%" h="600px">
                 <ChakraNextImage
-                  layout="responsive"
-                  width="1000"
-                  height="1000"
-                  objectFit="fill"
+                  layout="fill"
+                  objectFit="contain"
                   src={`${BASE_BANNER_IMAGE_S3_PATH}promotion-page-example.png`}
                 />
-                <Text>
-                  해당 페이지에서 판매가 발생하면 일정 수수료가 지급됩니다. <br />팬
-                  여러분들이 볼 수 있는 공간 (방송국 정보란, 개인 SNS 등)에 해당 URL을
-                  게시하고 상품을 홍보해보세요!
-                </Text>
               </Box>
 
               <Box>


### PR DESCRIPTION
- 상품 홍보 페이지 이미지 수정

→ 현재 구현된 상품 홍보페이지 이미지로 변경

# 할일

- [x]  예시이미지 크기 수정
- [x]  상품홍보페이지 예시 이미지를 실제 방송인 홍보페이지 이미지로 수정
    - [x]  s3 이미지 수정
        - [x]  dev → [https://project-lc-dev-test.s3.ap-northeast-2.amazonaws.com/public/promotion-page-example.png](https://project-lc-dev-test.s3.ap-northeast-2.amazonaws.com/public/promotion-page-example.png)
        - [x]  prod → [https://lc-project.s3.ap-northeast-2.amazonaws.com/public/promotion-page-example.png](https://lc-project.s3.ap-northeast-2.amazonaws.com/public/promotion-page-example.png)

# 테스트케이스

- [x]  이미지가 올바르게 보여진다