### PR TITLE
feat : [관리자] 외부상품으로 진행한 라이브쇼핑의 방송인 정산내역 생성

### DIFF
--- a/apps/admin/pages/broadcaster/settlement.tsx
+++ b/apps/admin/pages/broadcaster/settlement.tsx
@@ -2,6 +2,7 @@ import { Heading, Stack } from '@chakra-ui/react';
 import { AdminBcSettlementDoneList } from '@project-lc/components-admin/AdminBcSettlementDoneList';
 import { AdminPageLayout } from '@project-lc/components-admin/AdminPageLayout';
 import { BcSettlementTargetList } from '@project-lc/components-admin/BcSettlementTargetList';
+import { ExternalLiveShoppingBcSettlement } from '@project-lc/components-admin/ExternalLiveShoppingBcSettlement';
 
 export function BroadcasterSettlement(): JSX.Element {
   return (
@@ -10,6 +11,10 @@ export function BroadcasterSettlement(): JSX.Element {
         <Heading as="h3" size="lg">
           방송인 정산 처리
         </Heading>
+
+        {/* 외부상품 라이브쇼핑 판매건 정산내역 생성하기 */}
+        <ExternalLiveShoppingBcSettlement />
+
         {/* 정산 대상 */}
         <Heading as="h3" size="lg">
           정산 대상 목록

--- a/libs/components-admin/src/lib/ExternalLiveShoppingBcSettlement.tsx
+++ b/libs/components-admin/src/lib/ExternalLiveShoppingBcSettlement.tsx
@@ -186,12 +186,13 @@ function ExternalLiveShoppingBcSettlementForm(): JSX.Element {
           getOptionLabel={(option) => {
             if (!option) return '';
             const liveShoppingId = option.id;
-            const liveShoppingNamae = option?.liveShoppingName || '방송명 미정';
+            const liveShoppingName = option?.liveShoppingName || '방송명 미정';
+            const externalGoodsName = option?.externalGoods?.name || '상품 미정';
             const broadcasterId = option?.broadcaster.id || '방송인 미정';
             const broadcasterNickname =
               option?.broadcaster?.userNickname || '활동명 없음';
 
-            return `${liveShoppingNamae}( id: ${liveShoppingId} ), 방송인 : ${broadcasterNickname}( id: ${broadcasterId} ) `;
+            return `${liveShoppingName}( id: ${liveShoppingId} ) / 판매상품: ${externalGoodsName} / 방송인 : ${broadcasterNickname}( id: ${broadcasterId} ) `;
           }}
           onChange={(newV) => {
             if (newV) {

--- a/libs/components-admin/src/lib/ExternalLiveShoppingBcSettlement.tsx
+++ b/libs/components-admin/src/lib/ExternalLiveShoppingBcSettlement.tsx
@@ -1,0 +1,277 @@
+import {
+  Box,
+  Button,
+  Divider,
+  Input,
+  Link,
+  Radio,
+  RadioGroup,
+  Stack,
+  Text,
+  useDisclosure,
+  useToast,
+} from '@chakra-ui/react';
+import { LiveShoppingExternalGoods } from '@prisma/client';
+import { ChakraAutoComplete } from '@project-lc/components-core/ChakraAutoComplete';
+import { ConfirmDialog } from '@project-lc/components-core/ConfirmDialog';
+import {
+  useAdminLiveShoppingList,
+  useCreateSettlementBcWithExternalItem,
+} from '@project-lc/hooks';
+import {
+  CreateBcSettleHistoryWithExternalItemDto,
+  getLiveShoppingProgress,
+  LiveShoppingWithGoods,
+} from '@project-lc/shared-types';
+import { settlementHistoryStore } from '@project-lc/stores';
+import { getLocaleNumber } from '@project-lc/utils-frontend';
+import { useMemo } from 'react';
+import { FormProvider, useForm, useFormContext } from 'react-hook-form';
+import { calcSettleAmount } from './BcSettlementTargetList';
+
+type ExternalGoodsLiveBcSettlementFormData = {
+  liveShoppingId?: number;
+  broadcasterCommissionRate?: number;
+  settlementAmount?: number;
+  totalSalesAmount?: number;
+  externalGoods?: LiveShoppingExternalGoods;
+  broadcaster?: LiveShoppingWithGoods['broadcaster'];
+};
+
+export function ExternalLiveShoppingBcSettlement(): JSX.Element {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const toast = useToast();
+  const methods = useForm<ExternalGoodsLiveBcSettlementFormData>({
+    defaultValues: {
+      settlementAmount: 0,
+      totalSalesAmount: 0,
+    },
+  });
+  const roundStore = settlementHistoryStore();
+
+  const { mutateAsync } = useCreateSettlementBcWithExternalItem();
+  const onConfirm = async (): Promise<void> => {
+    const round = roundStore.selectedRound; // 'YYYY년MM월/1회차'
+    if (!round) {
+      throw new Error('회차를 설정해 주세요.');
+    }
+
+    const formData = methods.getValues();
+    if (!formData.liveShoppingId || !formData.broadcaster) {
+      throw new Error('정산할 라이브쇼핑을 선택해주세요');
+    }
+    if (!formData.totalSalesAmount || formData.totalSalesAmount <= 0) {
+      throw new Error('총 판매액을 입력해주세요. 0보다 큰 값이어야 합니다');
+    }
+
+    const settlementAmount = calcSettleAmount(
+      formData.totalSalesAmount,
+      formData.broadcasterCommissionRate || 0,
+    );
+
+    const dto: CreateBcSettleHistoryWithExternalItemDto = {
+      round,
+      liveShoppingId: formData.liveShoppingId,
+      broadcasterId: formData.broadcaster.id,
+      amount: settlementAmount,
+    };
+
+    mutateAsync(dto).then(() => {
+      resetFormData();
+      toast({ title: '정산내역 생성 성공', status: 'success' });
+    });
+  };
+
+  const onFail = async (e: any): Promise<void> => {
+    toast({ title: e.message, status: 'warning' });
+  };
+
+  const resetFormData = (): void => {
+    methods.setValue('liveShoppingId', undefined);
+    methods.setValue('broadcasterCommissionRate', undefined);
+    methods.setValue('externalGoods', undefined);
+    methods.setValue('broadcaster', undefined);
+    methods.setValue('totalSalesAmount', undefined);
+  };
+
+  const handleClose = (): void => {
+    resetFormData();
+    onClose();
+  };
+
+  return (
+    <Stack>
+      <Box>
+        <Button onClick={onOpen}>외부상품 라이브쇼핑 정산내역 생성하기</Button>
+        <Text color="grayText">
+          판매자의 네이버스토어 등에서 진행한 라이브쇼핑의 경우 아래 정산 대상 목록에
+          표시되지 않습니다
+        </Text>
+        <Text color="grayText">
+          외부판매처에서 진행한 라이브쇼핑건에 대한 정산내역을 방송인이 볼 수 있도록
+          하려면 <br />
+          외부상품 라이브쇼핑 정산내역 생성하기 버튼을 사용합니다
+        </Text>
+      </Box>
+
+      <FormProvider {...methods}>
+        <ConfirmDialog
+          isOpen={isOpen}
+          onClose={handleClose}
+          title="외부상품 라이브쇼핑 방송인 정산내역 생성"
+          onConfirm={onConfirm}
+          onFail={onFail}
+        >
+          <ExternalLiveShoppingBcSettlementForm />
+        </ConfirmDialog>
+      </FormProvider>
+    </Stack>
+  );
+}
+
+export default ExternalLiveShoppingBcSettlement;
+
+function ExternalLiveShoppingBcSettlementForm(): JSX.Element {
+  const roundStore = settlementHistoryStore();
+  const { data: adminLiveShoppingList } = useAdminLiveShoppingList({});
+  const { setValue, register, watch, getValues } =
+    useFormContext<ExternalGoodsLiveBcSettlementFormData>();
+
+  // 외부상품 진행 & 판매종료상태 & 방송인에 대한 정산내역 없는 라이브쇼핑 목록
+  const externalGoodsLiveShoppings = useMemo(() => {
+    if (!adminLiveShoppingList) return [];
+
+    return adminLiveShoppingList.filter((ls) => {
+      const withExternalGoods = !!ls.externalGoods;
+      const statusDone = getLiveShoppingProgress(ls) === '판매종료';
+      const noBcSettlement =
+        !ls.BroadcasterSettlementItems || ls.BroadcasterSettlementItems.length === 0;
+
+      return withExternalGoods && statusDone && noBcSettlement;
+    });
+  }, [adminLiveShoppingList]);
+
+  register('liveShoppingId', { required: true });
+  register('broadcasterCommissionRate', { required: true });
+  register('externalGoods', { required: true });
+  register('broadcaster', { required: true });
+  register('totalSalesAmount', {
+    required: true,
+    validate: (amount) => !!amount && amount > 0,
+  });
+  return (
+    <Stack spacing={4}>
+      {/* 회차선택 */}
+      <Stack>
+        <Text fontWeight="bold">회차 선택</Text>
+        <RadioGroup
+          value={roundStore.selectedRound}
+          onChange={(newV) => {
+            if (!newV) roundStore.resetRoundSelect();
+            roundStore.handleRoundSelect(newV);
+          }}
+        >
+          <Stack mt={4} direction="row" justifyContent="center">
+            <Radio value="1">1회차</Radio>
+            <Radio value="2">2회차</Radio>
+          </Stack>
+        </RadioGroup>
+      </Stack>
+      {/* 라이브쇼핑 선택(외부상품으로 진행한) */}
+      <Stack>
+        <Text fontWeight="bold">라이브쇼핑 선택</Text>
+        <ChakraAutoComplete
+          width="100%"
+          options={externalGoodsLiveShoppings}
+          getOptionLabel={(option) => {
+            if (!option) return '';
+            const liveShoppingId = option.id;
+            const liveShoppingNamae = option?.liveShoppingName || '방송명 미정';
+            const broadcasterId = option?.broadcaster.id || '방송인 미정';
+            const broadcasterNickname =
+              option?.broadcaster?.userNickname || '활동명 없음';
+
+            return `${liveShoppingNamae}( id: ${liveShoppingId} ), 방송인 : ${broadcasterNickname}( id: ${broadcasterId} ) `;
+          }}
+          onChange={(newV) => {
+            if (newV) {
+              setValue('liveShoppingId', newV.id);
+              setValue(
+                'broadcasterCommissionRate',
+                Number(newV?.broadcasterCommissionRate),
+              );
+              setValue('externalGoods', newV?.externalGoods || undefined);
+              setValue('broadcaster', newV?.broadcaster);
+            } else {
+              setValue('liveShoppingId', undefined);
+              setValue('broadcasterCommissionRate', undefined);
+              setValue('externalGoods', undefined);
+              setValue('broadcaster', undefined);
+            }
+          }}
+        />
+      </Stack>
+      {watch('liveShoppingId') && (
+        <Stack>
+          <Text>
+            - 판매상품 :
+            <Link isExternal href={getValues('externalGoods')?.linkUrl}>
+              <Text color="blue.500" as="span">
+                {getValues('externalGoods')?.name}
+              </Text>
+            </Link>
+          </Text>
+          <Text>
+            - 정산 대상 방송인 :
+            <Text color="red.400" as="span" fontWeight="bold">
+              {getValues('broadcaster')?.userNickname}
+            </Text>
+          </Text>
+          <Text>
+            - 방송인 수수료율 :
+            <Text color="red.400" as="span" fontWeight="bold">
+              {getValues('broadcasterCommissionRate')} %
+            </Text>
+          </Text>
+        </Stack>
+      )}
+
+      {watch('liveShoppingId') && (
+        <Stack>
+          <Stack direction="row">
+            <Text fontWeight="bold">총 판매액</Text>
+            <Text as="span" color="GrayText" ml={2}>
+              * 외부 판매 창구에서 확인한 총 판매액을 입력해주세요
+            </Text>
+          </Stack>
+
+          <Stack direction="row">
+            <Input
+              width="auto"
+              type="number"
+              {...register('totalSalesAmount', { valueAsNumber: true, required: true })}
+            />
+            <Text>{getLocaleNumber(watch('totalSalesAmount'))} 원</Text>
+          </Stack>
+
+          <Divider />
+
+          <Stack direction="row">
+            <Text fontWeight="bold">총 정산액</Text>
+            <Text as="span" color="GrayText" ml={2}>
+              * 총 판매액 x 방송인 수수료율
+            </Text>
+          </Stack>
+
+          <Text fontWeight="bold" fontSize="lg">
+            {calcSettleAmount(
+              watch('totalSalesAmount') || 0,
+              watch('broadcasterCommissionRate') || 0,
+            ).toLocaleString()}
+            원
+          </Text>
+        </Stack>
+      )}
+    </Stack>
+  );
+}

--- a/libs/components-core/src/lib/ChakraAutoComplete.tsx
+++ b/libs/components-core/src/lib/ChakraAutoComplete.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   CloseButton,
   FormControl,
+  FormControlProps,
   FormLabel,
   Heading,
   IconButton,
@@ -26,6 +27,7 @@ export interface ChakraAutoCompleteProps<T> {
   isDisabled?: boolean;
   getOptionLabel: (opt: T | null) => string;
   onChange: (newValue: T | null) => void;
+  width?: FormControlProps['width'];
 }
 export function ChakraAutoComplete<T = any>({
   label,
@@ -35,6 +37,7 @@ export function ChakraAutoComplete<T = any>({
   isDisabled,
   getOptionLabel,
   onChange,
+  width = '300px',
 }: ChakraAutoCompleteProps<T>): JSX.Element {
   const {
     getRootProps,
@@ -62,7 +65,7 @@ export function ChakraAutoComplete<T = any>({
   const backgroundColor = useColorModeValue('white', 'gray.700');
   const hoverListItemColor = useColorModeValue('gray.100', 'gray.600');
   return (
-    <FormControl width="300px">
+    <FormControl width={width}>
       <Box {...getRootProps()}>
         {label ? (
           <FormLabel {...getInputLabelProps()}>

--- a/libs/components-core/src/lib/ConfirmDialog.tsx
+++ b/libs/components-core/src/lib/ConfirmDialog.tsx
@@ -17,7 +17,7 @@ export interface ConfirmDialogProps
   isOpen: boolean;
   onClose: () => void;
   onConfirm: () => Promise<any>;
-  onFail?: () => Promise<any>;
+  onFail?: (e?: any) => Promise<any>;
   isLoading?: boolean;
   cancelString?: string;
   confirmString?: string;
@@ -40,7 +40,7 @@ export function ConfirmDialog({
     return onConfirm()
       .then(() => onClose())
       .catch((err) => {
-        if (onFail) return onFail();
+        if (onFail) return onFail(err);
         return console.log(err);
       });
   };

--- a/libs/components-web-bc/src/lib/BcSettlementHistory.tsx
+++ b/libs/components-web-bc/src/lib/BcSettlementHistory.tsx
@@ -195,6 +195,10 @@ export function SettlementHistoryDetail({
       <>
         <GridTableItem title="라이브쇼핑 고유번호" value={item.liveShopping.id} />
         <GridTableItem
+          title="라이브쇼핑명"
+          value={item.liveShopping?.liveShoppingName || ''}
+        />
+        <GridTableItem
           title="판매기간"
           value={
             <Box>

--- a/libs/hooks/src/index.ts
+++ b/libs/hooks/src/index.ts
@@ -41,6 +41,7 @@ export * from './lib/mutation/useCreateGoodsCommonInfo';
 export * from './lib/mutation/useCreateLiveShopping';
 export * from './lib/mutation/useCreateSellerContacts';
 export * from './lib/mutation/useCreateSettleBcManyMutation';
+export * from './lib/mutation/useCreateSettlementBcWithExternalItem';
 export * from './lib/mutation/useCreateSettlementMutation';
 export * from './lib/mutation/useCreateShippingGroup';
 export * from './lib/mutation/useCustomerAddressMutation';

--- a/libs/hooks/src/lib/mutation/useCreateSettlementBcWithExternalItem.tsx
+++ b/libs/hooks/src/lib/mutation/useCreateSettlementBcWithExternalItem.tsx
@@ -1,0 +1,34 @@
+import { CreateBcSettleHistoryWithExternalItemDto } from '@project-lc/shared-types';
+import { AxiosError } from 'axios';
+import { useQueryClient, useMutation, UseMutationResult } from 'react-query';
+import axios from '../../axios';
+
+export type useCreateSettlementBcWithExternalItemDto =
+  CreateBcSettleHistoryWithExternalItemDto;
+export type useCreateSettlementBcWithExternalItemRes = boolean;
+
+export const useCreateSettlementBcWithExternalItem = (): UseMutationResult<
+  useCreateSettlementBcWithExternalItemRes,
+  AxiosError,
+  useCreateSettlementBcWithExternalItemDto
+> => {
+  const queryClient = useQueryClient();
+  return useMutation<
+    useCreateSettlementBcWithExternalItemRes,
+    AxiosError,
+    useCreateSettlementBcWithExternalItemDto
+  >(
+    (dto: useCreateSettlementBcWithExternalItemDto) =>
+      axios
+        .post<useCreateSettlementBcWithExternalItemRes>(
+          '/admin/settlement/broadcaster/external-item',
+          dto,
+        )
+        .then((res) => res.data),
+    {
+      onSuccess: (data) => {
+        queryClient.invalidateQueries('AdminBroadcasterSettlementHistories');
+      },
+    },
+  );
+};

--- a/libs/nest-modules-admin/src/admin/admin.controller.ts
+++ b/libs/nest-modules-admin/src/admin/admin.controller.ts
@@ -64,6 +64,7 @@ import {
   BusinessRegistrationRejectionDto,
   ChangeSellCommissionDto,
   ConfirmHistoryDto,
+  CreateBcSettleHistoryWithExternalItemDto,
   CreateManyBroadcasterSettlementHistoryDto,
   EmailDupCheckDto,
   ExecuteSettlementDto,
@@ -177,6 +178,17 @@ export class AdminController {
     @Query(new ValidationPipe({ transform: true })) dto: FindManyDto,
   ): Promise<BroadcasterSettlementTargets> {
     return this.settlementService.findSettlementTargets(undefined, dto);
+  }
+
+  /** 방송인 외부상품으로 진행한 라이브쇼핑에 대한 정산내역 생성하기 */
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  @Post('/settlement/broadcaster/external-item')
+  @UseInterceptors(HttpCacheInterceptor)
+  @CacheClearKeys('settlement-history')
+  async createBcSettleHistoryWithExternalItem(
+    @Body(ValidationPipe) dto: CreateBcSettleHistoryWithExternalItemDto,
+  ): Promise<boolean> {
+    return this.bcSettlementHistoryService.createBcSettleHistoryWithExternalItem(dto);
   }
 
   /** 방송인 단일 정산처리 */

--- a/libs/nest-modules-liveshopping/src/live-shopping/live-shopping.service.ts
+++ b/libs/nest-modules-liveshopping/src/live-shopping/live-shopping.service.ts
@@ -170,6 +170,7 @@ export class LiveShoppingService {
         },
         liveShoppingSpecialPrices: true,
         externalGoods: true,
+        BroadcasterSettlementItems: true,
       },
     });
   }

--- a/libs/prisma-orm/prisma/migrations/20220916072830_/migration.sql
+++ b/libs/prisma-orm/prisma/migrations/20220916072830_/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE `BroadcasterSettlementItems` MODIFY `orderId` VARCHAR(191) NULL,
+    MODIFY `exportCode` VARCHAR(191) NULL;

--- a/libs/prisma-orm/prisma/schema.prisma
+++ b/libs/prisma-orm/prisma/schema.prisma
@@ -622,8 +622,8 @@ model BroadcasterSettlements {
 // 방송인 정산 내역 - 주문(출고)정보
 model BroadcasterSettlementItems {
   id                        Int     @id @default(autoincrement())
-  orderId                   String // 주문 고유번호 (퍼스트몰 fm_order.order_seq)
-  exportCode                String // 이 정산의 출고 고유번호 (퍼스트몰 fm_goods_export.export_code)
+  orderId                   String? // 주문 고유번호 (퍼스트몰 fm_order.order_seq)
+  exportCode                String? // 이 정산의 출고 고유번호 (퍼스트몰 fm_goods_export.export_code)
   amount                    Int     @default(0) // 총 정산 수익 금액
   broadcasterCommissionRate Decimal @default("0.00") @db.Decimal(10, 2) // 방송인 수수료율 (0%~100% 사이값)
 

--- a/libs/prisma-orm/prisma/seed.ts
+++ b/libs/prisma-orm/prisma/seed.ts
@@ -258,6 +258,32 @@ async function createDummyLiveShopping(
     },
   });
 }
+/** 종료된 외부상품 라이브쇼핑 생성 */
+async function createDummyPastExternalGoodsLiveShopping(
+  seller: SellerAccountType,
+  broadcaster: Broadcaster,
+): Promise<void> {
+  const startDate = new Date();
+  startDate.setDate(startDate.getDate() - 7);
+  const endDate = new Date();
+  endDate.setDate(endDate.getDate() - 6);
+  await prisma.liveShopping.create({
+    data: {
+      seller: { connect: { id: seller.id } },
+      broadcaster: { connect: { id: broadcaster.id } },
+      externalGoods: {
+        create: { name: '먹보소고기', linkUrl: 'www.google.com' },
+      },
+      liveShoppingName: '먹보소고기국밥~',
+      progress: 'confirmed',
+      broadcastStartDate: startDate.toISOString(),
+      broadcastEndDate: endDate.toISOString(),
+      sellStartDate: startDate.toISOString(),
+      sellEndDate: endDate.toISOString(),
+      broadcasterCommissionRate: '15',
+    },
+  });
+}
 
 /** 더미 방송인 주소 생성 */
 async function createDummyBroadcasterAddress(broadcaster: Broadcaster): Promise<void> {
@@ -467,6 +493,8 @@ async function main(): Promise<void> {
 
   // 테스트상품4의 라이브쇼핑 생성
   await createDummyLiveShopping(seller, testbroadcaster, goods4);
+  // 종료된 외부상품 라이브쇼핑 생성
+  await createDummyPastExternalGoodsLiveShopping(seller, testbroadcaster);
 
   // 더미 상품홍보페이지 생성
   const promotionPage = await createBroadcasterPromotionPage(testbroadcaster.id);

--- a/libs/shared-types/src/lib/dto/createBroadcasterSettlementHistory.dto.ts
+++ b/libs/shared-types/src/lib/dto/createBroadcasterSettlementHistory.dto.ts
@@ -2,6 +2,7 @@ import {
   Broadcaster,
   BroadcasterSettlementItems,
   BroadcasterSettlements,
+  LiveShopping,
   ProductPromotion,
 } from '@prisma/client';
 import { Type } from 'class-transformer';
@@ -34,4 +35,11 @@ export class CreateManyBroadcasterSettlementHistoryDto {
   @ValidateNested()
   @Type(() => CreateBroadcasterSettlementHistoryItem)
   items: Array<CreateBroadcasterSettlementHistoryItem>;
+}
+
+export class CreateBcSettleHistoryWithExternalItemDto {
+  @IsString() round: BroadcasterSettlements['round'];
+  @IsNumber() broadcasterId: Broadcaster['id'];
+  @IsNumber() amount: BroadcasterSettlementItems['amount'];
+  @IsNumber() liveShoppingId: LiveShopping['id'];
 }

--- a/libs/shared-types/src/lib/res-types/liveShoppingWithGoods.res.ts
+++ b/libs/shared-types/src/lib/res-types/liveShoppingWithGoods.res.ts
@@ -2,6 +2,7 @@ import {
   Broadcaster,
   BroadcasterChannel,
   BroadcasterPromotionPage,
+  BroadcasterSettlementItems,
   Goods,
   GoodsConfirmation,
   GoodsImages,
@@ -45,6 +46,7 @@ export interface LiveShoppingWithGoods extends LiveShopping {
   }[];
   liveShoppingSpecialPrices?: LiveShoppingSpecialPrice[];
   externalGoods?: null | LiveShoppingExternalGoods;
+  BroadcasterSettlementItems?: BroadcasterSettlementItems[];
 }
 
 export type SpecialPriceItem = Pick<


### PR DESCRIPTION
- 외부상품 판매 라이브쇼핑을 진행했던 방송인에게 정산내역을 표시하기 위해 관리자가 직접 정산내역을 생성할 수 있다

**테스트케이스**

- 관리자 센터
    - [ ]  [방송인]정산 페이지에 ‘외부상품 라이브쇼핑 정산내역 생성하기’ 버튼이 존재하고, 해당버튼을 누르면 ‘외부상품 라이브쇼핑 방송인 정산내역 생성’ 다이얼로그가 뜬다
    - 다이얼로그
        - [ ]  회차를 선택할 수 있다
        - [ ]  라이브쇼핑을 선택할 수 있다(여기에는 외부상품으로 진행된, 완료상태의 라이브쇼핑만 표시된다)
        - [ ]  라이브쇼핑을 선택하면, 해당 라이브쇼핑에서 판매했던 상품명, 정산대상 방송인(라이브쇼핑 진행한 방송인), 방송인 수수료율이 표시된다
        - [ ]  총 판매액을 입력하면 총 정산액이 계산된다
        - [ ]  값을 모두 입력하고 ‘확인’ 버튼을 누르면 해당 방송인에게 총 정산액만큼 정산했다는 내역이 생성된다. 아래 정산 완료 목록에서 확인할 수 있다
- 방송인센터
    - [ ]  관리자가 생성한 외부상품 라이브쇼핑 정산내역도 확인할 수 있다