### PR TITLE
feat : [방송인 - 실시간 현황판] 라이브 종료 버튼

### DIFF
--- a/apps/overlay-controller/src/lib/admin.js
+++ b/apps/overlay-controller/src/lib/admin.js
@@ -17,10 +17,7 @@ const liveShoppingStateSocket = io(
   },
 );
 liveShoppingStateSocket.on('playOutro', (roomName) => {
-  console.log({ roomName }, '종료요청 받음');
-  if (roomName) {
-    playOutro(roomName);
-  }
+  if (roomName) playOutro(roomName);
 });
 
 socket.on('creator list from server', (data) => {
@@ -33,7 +30,6 @@ socket.on('creator list from server', (data) => {
 
 /** roomName */
 function playOutro(roomName) {
-  console.log('playoutro 함수 실행', { roomName });
   socket.emit('show video from admin', { roomName, type: 'outro' });
 }
 
@@ -380,7 +376,13 @@ $(document).ready(function ready() {
 
   $('#end-time-send-button').click(function endTimeSendButtonClickEvent() {
     const selectedTime = $('#end-time-picker').val();
+    // 오버레이로 종료시간 전송
     socket.emit('get d-day', { roomName, date: selectedTime });
+    // 현황판으로 종료시간 전송 (liveShoppingId 의 현황판에서 설정된 종료시간에 따라 라이브종료버튼 활성화함)
+    liveShoppingStateSocket.emit('setLiveShoppingEndDateTime', {
+      liveShoppingId,
+      endDateTime: selectedTime,
+    });
     const sel = `현재 전송된 종료 시간: ${selectedTime}`;
     $('#etc-control-end-time').text(sel);
   });

--- a/apps/overlay-controller/src/lib/admin.js
+++ b/apps/overlay-controller/src/lib/admin.js
@@ -16,6 +16,12 @@ const liveShoppingStateSocket = io(
     withCredentials: true,
   },
 );
+liveShoppingStateSocket.on('playOutro', (roomName) => {
+  console.log({ roomName }, '종료요청 받음');
+  if (roomName) {
+    playOutro(roomName);
+  }
+});
 
 socket.on('creator list from server', (data) => {
   if (data && data.length !== 0) {
@@ -24,6 +30,12 @@ socket.on('creator list from server', (data) => {
     $('#connection-status').text('❌ 연결되지 않음');
   }
 });
+
+/** roomName */
+function playOutro(roomName) {
+  console.log('playoutro 함수 실행', { roomName });
+  socket.emit('show video from admin', { roomName, type: 'outro' });
+}
 
 $(document).ready(function ready() {
   let liveShoppingStateBoardController; // 관리자 메시지 보내기(방송인 현황판 표시) 컨트롤러, liveShoppingId 할당될때 생성
@@ -283,7 +295,8 @@ $(document).ready(function ready() {
   });
 
   $('#show-outro-video-button').click(function showOutroVideoButtonClickEvent() {
-    socket.emit('show video from admin', { roomName, type: 'outro' });
+    playOutro(roomName);
+    // socket.emit('show video from admin', { roomName, type: 'outro' });
   });
 
   $('#hide-video-button').click(function HideVideoButtonClickEvent() {

--- a/apps/overlay-controller/src/lib/admin.js
+++ b/apps/overlay-controller/src/lib/admin.js
@@ -28,7 +28,7 @@ socket.on('creator list from server', (data) => {
   }
 });
 
-/** roomName */
+/** roomName(overlayUrl)로 아웃트로 송출 이벤트 발생 */
 function playOutro(roomName) {
   socket.emit('show video from admin', { roomName, type: 'outro' });
 }
@@ -292,7 +292,6 @@ $(document).ready(function ready() {
 
   $('#show-outro-video-button').click(function showOutroVideoButtonClickEvent() {
     playOutro(roomName);
-    // socket.emit('show video from admin', { roomName, type: 'outro' });
   });
 
   $('#hide-video-button').click(function HideVideoButtonClickEvent() {

--- a/apps/web-broadcaster-center/pages/mypage/live/state/[liveShoppingId].tsx
+++ b/apps/web-broadcaster-center/pages/mypage/live/state/[liveShoppingId].tsx
@@ -12,21 +12,29 @@ export function LiveShoppingCurrentState(): JSX.Element {
     broadcasterId: profileData?.id,
   });
 
-  const { title } = useMemo(() => {
+  const { title, broadcastEndDate } = useMemo(() => {
     if (!liveShoppingList) return { title: '' };
     const currentLiveShopping = liveShoppingList.find(
       (shopping) => shopping.id === liveShoppingId,
     );
     if (!currentLiveShopping) return { title: '' };
     const liveShoppingTitle = currentLiveShopping.liveShoppingName || '';
+
     return {
       title: liveShoppingTitle,
+      broadcastEndDate: currentLiveShopping.broadcastEndDate,
     };
   }, [liveShoppingId, liveShoppingList]);
 
   if (!liveShoppingId) return <p>loading...</p>;
 
-  return <LiveShoppingCurrentStateBoard liveShoppingId={liveShoppingId} title={title} />;
+  return (
+    <LiveShoppingCurrentStateBoard
+      liveShoppingId={liveShoppingId}
+      title={title}
+      broadcastEndDate={broadcastEndDate}
+    />
+  );
 }
 
 export default LiveShoppingCurrentState;

--- a/libs/components-web-bc/src/lib/LiveShoppingCurrentStateBoard.tsx
+++ b/libs/components-web-bc/src/lib/LiveShoppingCurrentStateBoard.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  Button,
   Grid,
   GridItem,
   Heading,
@@ -17,14 +18,17 @@ import { useCallback, useMemo } from 'react';
 
 export interface LiveShoppingCurrentStateBoardProps {
   liveShoppingId: number;
+  broadcastEndDate?: Date | null;
   title: string;
 }
 
 export function LiveShoppingCurrentStateBoard({
   liveShoppingId,
   title,
+  broadcastEndDate,
 }: LiveShoppingCurrentStateBoardProps): JSX.Element {
-  const { message, alert, setAlert } = useLiveShoppingStateSubscription(liveShoppingId);
+  const { message, alert, setAlert, requestOutroPlay } =
+    useLiveShoppingStateSubscription(liveShoppingId);
   // * 후원메시지 데이터
   const { data, status, error } = usePurchaseMessages({
     liveShoppingId,
@@ -69,6 +73,13 @@ export function LiveShoppingCurrentStateBoard({
     },
   };
 
+  const handleLiveShoppingClose = (): void => {
+    console.log('컨트롤러로 종료요청 이벤트 emit');
+    requestOutroPlay();
+  };
+
+  const closeButtonDisabled = false;
+
   if (status === 'loading') return <Box>Loading...</Box>;
   if (status === 'error') {
     console.error(error);
@@ -87,6 +98,17 @@ export function LiveShoppingCurrentStateBoard({
       <Stack h="100vh" p={4}>
         {/* 라이브쇼핑명 - 제목 */}
         <Heading textAlign="center">{title}</Heading>
+
+        {/* 라이브쇼핑 종료 버튼  // TODO : 종료시간 10초전 활성화 */}
+        <Box>
+          <Button onClick={handleLiveShoppingClose} disabled={closeButtonDisabled}>
+            라이브 종료
+          </Button>
+          <Text color="GrayText" size="sm" as="span">
+            라이브쇼핑 종료 10초 전 활성화
+          </Text>
+          {broadcastEndDate}
+        </Box>
 
         {/* 관리자메시지 */}
         <SectionWithTitle variant="outlined" title="관리자 메시지">

--- a/libs/components-web-bc/src/lib/LiveShoppingCurrentStateBoard.tsx
+++ b/libs/components-web-bc/src/lib/LiveShoppingCurrentStateBoard.tsx
@@ -11,10 +11,16 @@ import {
 import { LiveShoppingPurchaseMessage } from '@prisma/client';
 import MotionBox from '@project-lc/components-core/MotionBox';
 import { SectionWithTitle } from '@project-lc/components-layout/SectionWithTitle';
-import { useLiveShoppingStateSubscription, usePurchaseMessages } from '@project-lc/hooks';
+import {
+  LIVE_SHOPPING_END_TIME_KEY,
+  useCountdown,
+  useLiveShoppingStateSubscription,
+  usePurchaseMessages,
+} from '@project-lc/hooks';
 import { getLocaleNumber } from '@project-lc/utils-frontend';
+import dayjs from 'dayjs';
 import { AnimationDefinition } from 'framer-motion/types/render/utils/animation';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 export interface LiveShoppingCurrentStateBoardProps {
   liveShoppingId: number;
@@ -27,8 +33,9 @@ export function LiveShoppingCurrentStateBoard({
   title,
   broadcastEndDate,
 }: LiveShoppingCurrentStateBoardProps): JSX.Element {
-  const { message, alert, setAlert, requestOutroPlay } =
+  const { message, alert, setAlert, requestOutroPlay, endTimeFromSocketServer } =
     useLiveShoppingStateSubscription(liveShoppingId);
+
   // * 후원메시지 데이터
   const { data, status, error } = usePurchaseMessages({
     liveShoppingId,
@@ -73,12 +80,9 @@ export function LiveShoppingCurrentStateBoard({
     },
   };
 
-  const handleLiveShoppingClose = (): void => {
-    console.log('컨트롤러로 종료요청 이벤트 emit');
+  const handleLiveShoppingClose = useCallback((): void => {
     requestOutroPlay();
-  };
-
-  const closeButtonDisabled = false;
+  }, [requestOutroPlay]);
 
   if (status === 'loading') return <Box>Loading...</Box>;
   if (status === 'error') {
@@ -99,15 +103,14 @@ export function LiveShoppingCurrentStateBoard({
         {/* 라이브쇼핑명 - 제목 */}
         <Heading textAlign="center">{title}</Heading>
 
-        {/* 라이브쇼핑 종료 버튼  // TODO : 종료시간 10초전 활성화 */}
+        {/* 라이브쇼핑 종료 버튼  */}
         <Box>
-          <Button onClick={handleLiveShoppingClose} disabled={closeButtonDisabled}>
-            라이브 종료
-          </Button>
-          <Text color="GrayText" size="sm" as="span">
-            라이브쇼핑 종료 10초 전 활성화
-          </Text>
-          {broadcastEndDate}
+          <LiveShoppingEndButton
+            onClick={handleLiveShoppingClose}
+            broadcastEndDate={broadcastEndDate}
+            endTimeFromSocketServer={endTimeFromSocketServer}
+            liveShoppingId={liveShoppingId}
+          />
         </Box>
 
         {/* 관리자메시지 */}
@@ -216,5 +219,81 @@ export function StateItem({ name, value }: { name: string; value: string }): JSX
         {value}
       </Text>
     </Stack>
+  );
+}
+
+/** 컨트롤러에서 전송받아 로컬스토리지에 저장해둔 라이브쇼핑 종료시간 찾기 */
+function findSavedLiveShoppingEndTime(liveShoppingId: number): Date | undefined {
+  const endTimeLocalStorageData = window.localStorage.getItem(LIVE_SHOPPING_END_TIME_KEY);
+  const savedEndTime: Date | undefined =
+    endTimeLocalStorageData &&
+    JSON.parse(endTimeLocalStorageData)?.liveShoppingId === liveShoppingId
+      ? JSON.parse(endTimeLocalStorageData)?.endDateTime
+      : undefined;
+
+  return savedEndTime;
+}
+
+/** 라이브쇼핑 종료하기 버튼 - 종료시간을 전달받아 카운트다운 타이머를 실행하고, 남은 방송시간에 따라 버튼 disabled 여부를 결정한다 */
+function LiveShoppingEndButton({
+  onClick,
+  broadcastEndDate,
+  endTimeFromSocketServer,
+  liveShoppingId,
+}: {
+  onClick: () => void;
+  liveShoppingId: number;
+  broadcastEndDate?: Date | null;
+  endTimeFromSocketServer: string | undefined;
+}): JSX.Element {
+  const [outroButtonDisabled, setOutroButtonDisabled] = useState<boolean>(true);
+
+  const { startCountdown, clearTimer, seconds } = useCountdown();
+
+  // 방송종료시간이 변경되는 경우 남은방송시간 계산 타이머 재설정
+  useEffect(() => {
+    // 종료시간 변경될때마다 outroButtonDisabled값을 true(버튼 비활성화)로 초기화한다
+    setOutroButtonDisabled(true);
+
+    /**
+     * 방송 종료시간 가져오기
+     * 1. 컨트롤러에서 전송받은 종료시간(컨트롤러에서 전송하지 않으면 존재하지 않음)
+     * 2. 로컬스토리지에 저장된, 컨트롤러에서 전송받은 종료시간(현황판 새로고침하면 값이 사라져서 로컬스토리지에 저장해둠)
+     * 3. 컨트롤러에서 종료시간 전송받지 않은 경우 라이브쇼핑에 저장된 종료시간
+     * 4. 아무 값도 없는경우 현재를 종료시간으로 설정하여 타이머 작동 안시킴
+     */
+    const savedEndTime = findSavedLiveShoppingEndTime(liveShoppingId);
+    const now = new Date();
+    const realEndTime = dayjs(
+      endTimeFromSocketServer || savedEndTime || broadcastEndDate || now,
+    );
+
+    // 방송종료시간 - 현재시간 = 남은 방송 시간(초)로 카운트다운 타이머 실행
+    const remainingBroadcastSeconds = realEndTime.diff(now, 'second');
+    startCountdown(remainingBroadcastSeconds);
+  }, [
+    broadcastEndDate,
+    clearTimer,
+    endTimeFromSocketServer,
+    liveShoppingId,
+    startCountdown,
+  ]);
+
+  // 남은 방송시간이 10초 이하인 경우 버튼 활성화
+  useEffect(() => {
+    if (seconds <= 10) {
+      setOutroButtonDisabled(false);
+    }
+  }, [seconds, clearTimer]);
+
+  return (
+    <Button
+      onClick={onClick}
+      disabled={outroButtonDisabled}
+      colorScheme={outroButtonDisabled ? undefined : 'red'}
+    >
+      라이브 종료하기
+      {outroButtonDisabled && <Text>(라이브방송 종료시간 10초 전 활성화됩니다)</Text>}
+    </Button>
   );
 }

--- a/libs/hooks/src/lib/useCountdown.tsx
+++ b/libs/hooks/src/lib/useCountdown.tsx
@@ -39,17 +39,23 @@ export function useCountdown(): UseCountdownResult {
 
   const clearTimer = useCallback(() => {
     if (intervalRef.current) clearInterval(intervalRef.current);
-    setSeconds(0);
   }, []);
 
   useEffect(() => {
-    if (seconds < 0) clearTimer();
+    if (seconds < 0) {
+      clearTimer();
+      setSeconds(0);
+    }
   }, [clearTimer, seconds]);
 
-  const startCountdown = useCallback((startSecond: number) => {
-    setSeconds(startSecond);
-    intervalRef.current = setInterval(intervalCallbackRef.current, 1000);
-  }, []);
+  const startCountdown = useCallback(
+    (startSecond: number) => {
+      clearTimer();
+      setSeconds(startSecond);
+      intervalRef.current = setInterval(intervalCallbackRef.current, 1000);
+    },
+    [clearTimer],
+  );
 
   return {
     startCountdown,

--- a/libs/nest-modules-liveshopping/src/live-shopping/live-shopping-state.gateway.ts
+++ b/libs/nest-modules-liveshopping/src/live-shopping/live-shopping-state.gateway.ts
@@ -60,4 +60,13 @@ export class LiveShoppingStateGateway {
     const roomId = liveShoppingId.toString();
     this.socket.to(roomId).emit('purchaseMessageUpdated');
   }
+
+  @SubscribeMessage('setLiveShoppingEndDateTime')
+  setLiveShoppingEndDateTime(
+    @MessageBody()
+    { liveShoppingId, endDateTime }: { liveShoppingId: number; endDateTime: string },
+  ): void {
+    const roomId = liveShoppingId.toString();
+    this.socket.to(roomId).emit('endDateTimeChanged', endDateTime);
+  }
 }

--- a/libs/nest-modules-liveshopping/src/live-shopping/live-shopping-state.gateway.ts
+++ b/libs/nest-modules-liveshopping/src/live-shopping/live-shopping-state.gateway.ts
@@ -10,7 +10,7 @@ import { corsOptions } from '@project-lc/nest-core';
 import { WsGuard } from '@project-lc/nest-modules-authguard';
 import {
   AdminMessage,
-  LiveShoppingStateClientToServerEvents,
+  LiveShoppingStateServerSubscribeEvents,
   LiveShoppingStateServerToClientEvents,
 } from '@project-lc/shared-types';
 import { Server, Socket } from 'socket.io';
@@ -22,7 +22,7 @@ import { Server, Socket } from 'socket.io';
 export class LiveShoppingStateGateway {
   @WebSocketServer()
   socket: Server<
-    LiveShoppingStateClientToServerEvents,
+    LiveShoppingStateServerSubscribeEvents,
     LiveShoppingStateServerToClientEvents
   >;
 
@@ -35,6 +35,12 @@ export class LiveShoppingStateGateway {
     const roomId = liveShoppingId.toString();
     client.join(roomId);
     this.socket.to(roomId).emit('subscribed', true);
+  }
+
+  @SubscribeMessage('requestOutroPlay')
+  requestOutroPlay(@MessageBody() roomName?: string): void {
+    // 오버레이 컨트롤러에서만 구독하는 메시지이므로 특정 roomId로 보내지 않았음
+    this.socket.emit('playOutro', roomName);
   }
 
   @SubscribeMessage('createAdminMessage')

--- a/libs/shared-types/src/lib/event-types/live-shopping-state.event-type.ts
+++ b/libs/shared-types/src/lib/event-types/live-shopping-state.event-type.ts
@@ -8,10 +8,22 @@ export interface LiveShoppingStateServerToClientEvents {
   adminMessageCreated: (data: AdminMessage) => void;
   adminAlertCreated: () => void;
   purchaseMessageUpdated: () => void;
+  playOutro: (roomName?: string) => void;
 }
 
-export interface LiveShoppingStateClientToServerEvents {
+/** LiveShoppingStateGateway 에서 구독하는 메시지(@SubscribeMessage) 타입 */
+export interface LiveShoppingStateServerSubscribeEvents
+  extends LiveShoppingStateBoardToServerEvents,
+    OverlayControllerToServerEvents {}
+
+/** 현황판에서 emit */
+export interface LiveShoppingStateBoardToServerEvents {
   subscribe: (liveShoppingId: number) => void;
+  requestOutroPlay: (roomName?: string) => void;
+}
+
+/** 오버레이 컨트롤러에서 emit */
+export interface OverlayControllerToServerEvents {
   createAdminMessage: (data: AdminMessage) => void;
   createAdminAlert: (liveShoppingId: number) => void;
   updatePurchaseMessage: (liveShoppingId: number) => void;

--- a/libs/shared-types/src/lib/event-types/live-shopping-state.event-type.ts
+++ b/libs/shared-types/src/lib/event-types/live-shopping-state.event-type.ts
@@ -28,5 +28,11 @@ export interface OverlayControllerToServerEvents {
   createAdminMessage: (data: AdminMessage) => void;
   createAdminAlert: (liveShoppingId: number) => void;
   updatePurchaseMessage: (liveShoppingId: number) => void;
-  setLiveShoppingEndDateTime: ({ liveShoppingId: number, endDateTime: string }) => void;
+  setLiveShoppingEndDateTime: ({
+    liveShoppingId,
+    endDateTime,
+  }: {
+    liveShoppingId: number;
+    endDateTime: string;
+  }) => void;
 }

--- a/libs/shared-types/src/lib/event-types/live-shopping-state.event-type.ts
+++ b/libs/shared-types/src/lib/event-types/live-shopping-state.event-type.ts
@@ -8,6 +8,7 @@ export interface LiveShoppingStateServerToClientEvents {
   adminMessageCreated: (data: AdminMessage) => void;
   adminAlertCreated: () => void;
   purchaseMessageUpdated: () => void;
+  endDateTimeChanged: (endDateTime: string) => void;
   playOutro: (roomName?: string) => void;
 }
 
@@ -27,4 +28,5 @@ export interface OverlayControllerToServerEvents {
   createAdminMessage: (data: AdminMessage) => void;
   createAdminAlert: (liveShoppingId: number) => void;
   updatePurchaseMessage: (liveShoppingId: number) => void;
+  setLiveShoppingEndDateTime: ({ liveShoppingId: number, endDateTime: string }) => void;
 }


### PR DESCRIPTION
실시간 현황판에 '라이브 종료하기' 버튼 추가

현황판에서 오버레이 컨트롤러로 아웃트로 송출 이벤트 발생 
-> 이 때 컨트롤러에서는 기존에 존재하는 오버레이 아웃트로 송출 이벤트를 발생하는 방식으로 동작함

**테스트케이스**

- [ ]  현황판에 ‘라이브방송 종료하기’ 버튼이 존재한다
    - [ ]  설정된 방송종료 10초전 활성화된다
    - [ ]  종료하기 버튼을 누르면 방송이 종료된다(아웃트로 영상 송출, 라이브 배너 화면이 내려감)