### PR TITLE
feat : [크크쇼-방송인 홍보페이지] 방송내역

### DIFF
--- a/apps/web-kkshow/pages/bc/[broadcasterId].tsx
+++ b/apps/web-kkshow/pages/bc/[broadcasterId].tsx
@@ -14,6 +14,7 @@ import {
 import { SignupEventPopup } from '@project-lc/components-web-kkshow/EventPopup';
 import KkshowLayout from '@project-lc/components-web-kkshow/KkshowLayout';
 import { PromotionPageGoodsList } from '@project-lc/components-web-kkshow/promotion-page/PromotionPageGoodsList';
+import { PromotionPageVideoList } from '@project-lc/components-web-kkshow/promotion-page/PromotionPageVideoList';
 import { PromotionPageProfile } from '@project-lc/components-web-kkshow/promotion-page/PromotionPageProfile';
 import { useBroadcaster, usePromotionPage } from '@project-lc/hooks';
 import { useRouter } from 'next/router';
@@ -25,13 +26,20 @@ export function BroadcasterPromotionPage(): JSX.Element {
   const bc = useBroadcaster({ id: broadcasterId });
   const promotionPage = usePromotionPage(broadcasterId);
 
-  const tabInfo = useMemo(
+  const tabInfo: {
+    title: string;
+    isDisabled?: boolean;
+    component: JSX.Element;
+  }[] = useMemo(
     () => [
       {
         title: '상품',
         component: <PromotionPageGoodsList broadcasterId={broadcasterId} />,
       },
-      { isDisabled: true, title: '라이브방송(준비중)', component: <p>방송목록</p> },
+      {
+        title: '라이브방송 영상',
+        component: <PromotionPageVideoList broadcasterId={broadcasterId} />,
+      },
     ],
     [broadcasterId],
   );
@@ -77,7 +85,7 @@ export function BroadcasterPromotionPage(): JSX.Element {
           <Tabs variant="line" align="center" mt={30}>
             <TabList>
               {tabInfo.map((tab) => (
-                <Tab isDisabled={tab.isDisabled} key={tab.title}>
+                <Tab isDisabled={tab?.isDisabled} key={tab.title}>
                   {tab.title}
                 </Tab>
               ))}

--- a/libs/components-admin/src/lib/live-shopping/AdminLiveShoppingRegist.tsx
+++ b/libs/components-admin/src/lib/live-shopping/AdminLiveShoppingRegist.tsx
@@ -33,6 +33,7 @@ type LiveShoppingByAdminFormData = {
   externalGoods?: {
     name?: string;
     linkUrl?: string;
+    imageUrl?: string;
   };
 };
 export function AdminLiveShoppingRegist(): JSX.Element {
@@ -85,6 +86,7 @@ export function AdminLiveShoppingRegist(): JSX.Element {
       dto.externalGoods = {
         name: formData.externalGoods?.name || '',
         linkUrl: formData.externalGoods?.linkUrl || '',
+        imageUrl: formData.externalGoods?.imageUrl,
       };
     }
 
@@ -220,7 +222,7 @@ function WriteExternalGoodsSection(): JSX.Element {
   return (
     <Stack>
       <Text fontWeight="bold">3. 라이브커머스 진행할 외부 상품 정보 입력</Text>
-      <Text>상품명</Text>
+      <Text>상품명 *</Text>
       <Input
         placeholder="먹보 소고기 국밥"
         {...register('externalGoods.name', externalGoodsValueOptions)}
@@ -229,7 +231,7 @@ function WriteExternalGoodsSection(): JSX.Element {
         {errors.externalGoods?.name && errors.externalGoods.name.message}
       </ErrorText>
 
-      <Text>상품 링크(스마트스토어 등 상품 판매페이지 주소)</Text>
+      <Text>상품 링크 * (스마트스토어 등 상품 판매페이지 주소)</Text>
       <Input
         type="url"
         placeholder="https://smartstore.naver.com/mukbo_gukbap/products/6387804902"
@@ -238,6 +240,13 @@ function WriteExternalGoodsSection(): JSX.Element {
       <Text>
         {errors.externalGoods?.linkUrl && errors.externalGoods?.linkUrl.message}
       </Text>
+
+      <Text color="GrayText">상품 이미지 주소</Text>
+      <Input
+        type="url"
+        placeholder="외부상품 이미지 주소를 입력해주세요(필수 입력 아님)"
+        {...register('externalGoods.imageUrl')}
+      />
     </Stack>
   );
 }

--- a/libs/components-web-kkshow/src/lib/promotion-page/PromotionPageVideoList.tsx
+++ b/libs/components-web-kkshow/src/lib/promotion-page/PromotionPageVideoList.tsx
@@ -45,14 +45,24 @@ function PromotionPageVideoItem({
   );
   // 라이브 쇼핑명
   const liveShoppingTitle = liveShopping.liveShoppingName;
-  // 상품이미지 url (외부상품으로 진행한 경우 상품이미지가 없다)
-  const goodsImageUrl = liveShopping.goods
-    ? liveShopping.goods.image[0]?.image
-    : undefined;
-  // 상품페이지 url
-  const goodsLinkUrl = liveShopping.goods
-    ? `${getKkshowWebHost()}/goods/${liveShopping.goodsId}`
-    : liveShopping.externalGoods?.linkUrl;
+
+  const { imageUrl, linkUrl } = useMemo(() => {
+    const goodsData = {
+      imageUrl: '',
+      linkUrl: '',
+    };
+    // 크크쇼 상품으로 진행한 라이브쇼핑
+    if (liveShopping.goods) {
+      goodsData.imageUrl = liveShopping.goods.image[0]?.image;
+      goodsData.linkUrl = `${getKkshowWebHost()}/goods/${liveShopping.goodsId}`;
+    } else if (liveShopping.externalGoods) {
+      // 외부상품으로 진행한 라이브쇼핑
+      goodsData.imageUrl = liveShopping.externalGoods?.imageUrl || '';
+      goodsData.linkUrl = liveShopping.externalGoods?.linkUrl;
+    }
+    return goodsData;
+  }, [liveShopping.externalGoods, liveShopping.goods, liveShopping.goodsId]);
+
   return (
     <Center>
       <Box
@@ -71,8 +81,8 @@ function PromotionPageVideoItem({
           <Heading fontSize={{ base: 'lg', md: '2xl' }} noOfLines={2}>
             {liveShoppingTitle}
           </Heading>
-          <Link href={goodsLinkUrl} isExternal>
-            <BorderedAvatar src={goodsImageUrl} size="lg" />
+          <Link href={linkUrl} isExternal>
+            <BorderedAvatar src={imageUrl} size="lg" />
           </Link>
         </Stack>
       </Box>

--- a/libs/components-web-kkshow/src/lib/promotion-page/PromotionPageVideoList.tsx
+++ b/libs/components-web-kkshow/src/lib/promotion-page/PromotionPageVideoList.tsx
@@ -21,6 +21,10 @@ export function PromotionPageVideoList({
     if (!liveShoppingList || !liveShoppingList.length) return [];
     return liveShoppingList.filter((ls) => !!ls.liveShoppingVideo);
   }, [liveShoppingList]);
+
+  if (lsHavingVideo.length === 0) {
+    return <Center py={{ base: 10, md: 20 }}>아직 등록된 영상이 없습니다</Center>;
+  }
   return (
     <Stack>
       <SimpleGrid columns={{ base: 1, md: 2 }} spacing={10}>

--- a/libs/components-web-kkshow/src/lib/promotion-page/PromotionPageVideoList.tsx
+++ b/libs/components-web-kkshow/src/lib/promotion-page/PromotionPageVideoList.tsx
@@ -1,0 +1,81 @@
+import { Box, Center, Heading, Link, SimpleGrid, Stack } from '@chakra-ui/react';
+import BorderedAvatar from '@project-lc/components-core/BorderedAvatar';
+import EmbededVideo from '@project-lc/components-shared/EmbededVideo';
+import { useLiveShoppingList } from '@project-lc/hooks';
+import { LiveShoppingWithGoods } from '@project-lc/shared-types';
+import { getKkshowWebHost } from '@project-lc/utils';
+import { useMemo } from 'react';
+
+export interface PromotionPageVideoListProps {
+  broadcasterId: number | string;
+}
+export function PromotionPageVideoList({
+  broadcasterId,
+}: PromotionPageVideoListProps): JSX.Element {
+  const { data: liveShoppingList } = useLiveShoppingList(
+    { broadcasterId: Number(broadcasterId) },
+    { enabled: !!broadcasterId },
+  );
+
+  const lsHavingVideo = useMemo(() => {
+    if (!liveShoppingList || !liveShoppingList.length) return [];
+    return liveShoppingList.filter((ls) => !!ls.liveShoppingVideo);
+  }, [liveShoppingList]);
+  return (
+    <Stack>
+      <SimpleGrid columns={{ base: 1, md: 2 }} spacing={10}>
+        {lsHavingVideo.map((ls) => (
+          <PromotionPageVideoItem key={ls.id} liveShopping={ls} />
+        ))}
+      </SimpleGrid>
+    </Stack>
+  );
+}
+
+export default PromotionPageVideoList;
+
+function PromotionPageVideoItem({
+  liveShopping,
+}: {
+  liveShopping: LiveShoppingWithGoods;
+}): JSX.Element {
+  const identifier = liveShopping.liveShoppingVideo.youtubeUrl.replace(
+    'https://youtu.be/',
+    '',
+  );
+  // 라이브 쇼핑명
+  const liveShoppingTitle = liveShopping.liveShoppingName;
+  // 상품이미지 url (외부상품으로 진행한 경우 상품이미지가 없다)
+  const goodsImageUrl = liveShopping.goods
+    ? liveShopping.goods.image[0]?.image
+    : undefined;
+  // 상품페이지 url
+  const goodsLinkUrl = liveShopping.goods
+    ? `${getKkshowWebHost()}/goods/${liveShopping.goodsId}`
+    : liveShopping.externalGoods?.linkUrl;
+  return (
+    <Center>
+      <Box
+        rounded="2xl"
+        w="100%"
+        maxW="lg"
+        bgColor="gray.100"
+        color="blackAlpha.900"
+        boxShadow="lg"
+      >
+        <Box h={{ base: 230, md: 300 }} className="livecard-embed-container">
+          <EmbededVideo provider="youtube" identifier={identifier} />
+        </Box>
+
+        <Stack direction="row" justify="space-between" alignItems="center" p={4}>
+          <Heading fontSize={{ base: 'lg', md: '2xl' }} noOfLines={2}>
+            {liveShoppingTitle}
+          </Heading>
+          <Link href={goodsLinkUrl} isExternal>
+            <BorderedAvatar src={goodsImageUrl} size="lg" />
+          </Link>
+        </Stack>
+      </Box>
+    </Center>
+  );
+}

--- a/libs/nest-modules-liveshopping/src/live-shopping/live-shopping.service.ts
+++ b/libs/nest-modules-liveshopping/src/live-shopping/live-shopping.service.ts
@@ -65,7 +65,11 @@ export class LiveShoppingService {
         data: {
           sellerId: dto.sellerId,
           externalGoods: {
-            create: { name: dto.externalGoods.name, linkUrl: dto.externalGoods.linkUrl },
+            create: {
+              name: dto.externalGoods.name,
+              linkUrl: dto.externalGoods.linkUrl,
+              imageUrl: dto.externalGoods.imageUrl,
+            },
           },
         },
       });

--- a/libs/prisma-orm/prisma/migrations/20220923015552_/migration.sql
+++ b/libs/prisma-orm/prisma/migrations/20220923015552_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `LiveShoppingExternalGoods` ADD COLUMN `imageUrl` TEXT NULL;

--- a/libs/prisma-orm/prisma/schema.prisma
+++ b/libs/prisma-orm/prisma/schema.prisma
@@ -754,6 +754,7 @@ model LiveShoppingExternalGoods {
   id             Int          @id @default(autoincrement())
   name           String
   linkUrl        String       @db.Text // 외부 url 이 매우 긴 경우를 대비
+  imageUrl       String?      @db.Text
   liveShoppingId Int          @unique
   liveShopping   LiveShopping @relation(fields: [liveShoppingId], references: [id], onDelete: Cascade)
 }

--- a/libs/shared-types/src/lib/dto/liveShopping.dto.ts
+++ b/libs/shared-types/src/lib/dto/liveShopping.dto.ts
@@ -173,6 +173,8 @@ export class CreateLiveShoppingExternalGoodsDto {
   @IsString() name: string;
 
   @IsString() linkUrl: string;
+
+  @IsString() @IsOptional() imageUrl?: string;
 }
 
 /** 관리자로 라이브쇼핑 등록 dto


### PR DESCRIPTION
크크쇼 방송인홍보페이지의 라이브방송 탭 활성화
방송인이 진행한 라이브쇼핑 중 유튜브영상이 등록된 경우 해당 유튜브영상을 표시함

**테스트케이스**
- [ ]  해당 방송인이 진행한 라이브쇼핑의 유튜브영상과 라이브쇼핑명, 상품이미지가 표시된다
    - [ ]  데스크탑 화면에서는 유튜브 영상이 2줄로 표시된다
    - [ ]  모바일 화면에서는 유튜브 영상이 1줄로 표시된다
    - [ ]  상품이미지 클릭시 해당 상품 판매페이지로 이동한다
- [ ]  등록된 유튜브영상이 없는경우 ‘아직 등록된 영상이 없습니다’ 문구가 표시된다