### PR TITLE
fix : [오버레이] 랭킹 예전데이터 표시되는 문제 수정

### DIFF
--- a/apps/overlay-controller/src/lib/admin.js
+++ b/apps/overlay-controller/src/lib/admin.js
@@ -217,7 +217,9 @@ $(document).ready(function ready() {
   });
 
   $('.socket-id-button').click(function socketIdButtonClickEvent() {
-    liveShoppingId = $(this).closest('tr').children('td.liveshopping-id-cell').attr('id');
+    liveShoppingId = Number(
+      $(this).closest('tr').children('td.liveshopping-id-cell').attr('id'),
+    );
     streamerNickname = $(this).closest('tr').prop('id');
     const url = $(this).closest('tr').children('td.url-cell').attr('id');
     email = $(this).closest('tr').children('td.email-cell').attr('id');
@@ -690,6 +692,7 @@ $(document).ready(function ready() {
             nickname: customerNickname,
             message: customerMessage,
             ttsSetting,
+            liveShoppingId,
           });
         } else {
           socket.emit('get non client purchase message from admin', {

--- a/libs/nest-modules-order/src/lib/order.service.ts
+++ b/libs/nest-modules-order/src/lib/order.service.ts
@@ -349,6 +349,7 @@ export class OrderService {
       ordererEmail: orderDto.ordererEmail,
       memo: orderDto.memo,
       cashReceipts: orderDto.cashReceipts,
+      nonMemberOrderFlag,
     };
 
     // 선물하기의 경우(주문상품은 1개, 후원데이터가 존재함)
@@ -497,7 +498,7 @@ export class OrderService {
     // 구매 메시지 송출 요청
     purchaseData.forEach((data) => {
       this.logger.debug(
-        `구매 메시지 송출 이벤트 트리거 API -> Overlay - ${data.roomName} - ${data.productName} ${data.nickname}::${data.message}`,
+        `구매 메시지 송출 이벤트 트리거 API -> Overlay - ${data.roomName} (liveShoppingId: ${data.liveShoppingId}) - ${data.productName} ${data.nickname}::${data.message}`,
       );
       this.microService.emit<void, PurchaseMessage>(
         'liveshopping:overlay:purchase-msg',

--- a/libs/nest-modules-overlay/src/overlay/overlay.screen.gateway.ts
+++ b/libs/nest-modules-overlay/src/overlay/overlay.screen.gateway.ts
@@ -55,9 +55,15 @@ export class OverlayScreenGateway
 
   // 랭킹 복구
   @SubscribeMessage('get ranking')
-  async getRanking(@MessageBody() roomName: string): Promise<void> {
+  async getRanking(
+    @MessageBody()
+    { roomName, liveShoppingId }: { roomName: string; liveShoppingId: number },
+  ): Promise<void> {
     const nicknameAndPrice = [];
-    const rankings = await this.overlayService.getRanking(roomName);
+    const rankings = await this.overlayService.getRanking({
+      overlayUrl: roomName,
+      liveShoppingId,
+    });
     rankings.forEach((eachNickname) => {
       const price = Object.values(eachNickname._sum).toString();
       const { nickname } = eachNickname;
@@ -72,10 +78,16 @@ export class OverlayScreenGateway
 
   // 전체 데이터 복구
   @SubscribeMessage('get all data')
-  async getAllPurchaseMessage(@MessageBody() roomName: string): Promise<void> {
+  async getAllPurchaseMessage(
+    @MessageBody()
+    { roomName, liveShoppingId }: { roomName: string; liveShoppingId: number },
+  ): Promise<void> {
     const nicknameAndPrice = [];
     const bottomAreaTextAndNickname: string[] = [];
-    const rankings = await this.overlayService.getRanking(roomName);
+    const rankings = await this.overlayService.getRanking({
+      overlayUrl: roomName,
+      liveShoppingId,
+    });
     // const totalSold = await this.overlayService.getTotalSoldPrice();
     const messageAndNickname = await this.overlayService.getMessageAndNickname(roomName);
 

--- a/libs/nest-modules-overlay/src/overlay/overlay.service.ts
+++ b/libs/nest-modules-overlay/src/overlay/overlay.service.ts
@@ -127,13 +127,15 @@ export class OverlayService {
       productName,
       message,
       nickname: _nickname,
+      liveShoppingId,
     } = purchase;
     this.logger.debug(
-      `Purchase Message - ${overlayUrl} - ${productName} ${_nickname}::${message}`,
+      `Purchase Message - ${overlayUrl} (liveShoppingId : ${liveShoppingId}) - ${productName} ${_nickname}::${message}`,
     );
     // 하단 띠배너 응원메세지 띄울 때 사용
     // const bottomAreaTextAndNickname: string[] = [];
-    const rankings = await this.getRanking(overlayUrl);
+    const rankings = await this.getRanking({ overlayUrl, liveShoppingId });
+
     const nicknameAndPrice = rankings
       .map(({ nickname, _sum: { price } }) => ({ nickname, price }))
       .sort((a, b) => b.price - a.price);
@@ -265,13 +267,20 @@ export class OverlayService {
   }
 
   // 랭킹 받아오기
-  async getRanking(overlayUrl: string): Promise<NicknameAndPrice[]> {
+  async getRanking({
+    overlayUrl,
+    liveShoppingId,
+  }: {
+    overlayUrl: string;
+    liveShoppingId: number;
+  }): Promise<NicknameAndPrice[]> {
     const topRanks = await this.prisma.liveShoppingPurchaseMessage.groupBy({
       by: ['nickname'],
       where: {
         broadcaster: {
           overlayUrl: { contains: overlayUrl },
         },
+        liveShoppingId: Number(liveShoppingId),
         loginFlag: true,
       },
       _sum: {

--- a/libs/shared-types/src/lib/overlay/overlay-types.ts
+++ b/libs/shared-types/src/lib/overlay/overlay-types.ts
@@ -63,6 +63,8 @@ export interface PurchaseMessage {
   simpleMessageFlag?: boolean;
   /** 선물 구매 여부 */
   giftFlag?: boolean;
+  /** 라이브쇼핑 id */
+  liveShoppingId: number;
 }
 /** 시청자 닉네임과 닉네임별 구매금액 총액 */
 export interface NicknameAndPrice {


### PR DESCRIPTION
- 랭킹 계산 시, 라이브커머스 기준이 아닌, 방송인 기준으로 구매데이터를 조회하고 있었음
=> 라이브커머스 별로 랭킹을 표시하도록 수정함

- 기타 수정사항 : 주문 시 비회원구매 여부 저장하는 코드 빠진거 추가