### PR TITLE
fix : 송출컨트롤러에서 '데이터 재송출' 눌렀을 때 랭킹 갱신 오류 수정

### DIFF
--- a/apps/overlay-controller/src/lib/admin.js
+++ b/apps/overlay-controller/src/lib/admin.js
@@ -396,7 +396,7 @@ $(document).ready(function ready() {
   });
 
   $('#data-send-all').click(function dataSendAllButtonClickEvent() {
-    socket.emit('get all data', roomName);
+    socket.emit('get all data', { roomName, liveShoppingId });
   });
 
   $('.message-box-lock-button').click(function messageBoxLockButtonClickEvent() {

--- a/libs/nest-modules-overlay/src/overlay/overlay.screen.gateway.ts
+++ b/libs/nest-modules-overlay/src/overlay/overlay.screen.gateway.ts
@@ -89,7 +89,10 @@ export class OverlayScreenGateway
       liveShoppingId,
     });
     // const totalSold = await this.overlayService.getTotalSoldPrice();
-    const messageAndNickname = await this.overlayService.getMessageAndNickname(roomName);
+    const messageAndNickname = await this.overlayService.getMessageAndNickname({
+      overlayUrl: roomName,
+      liveShoppingId: Number(liveShoppingId),
+    });
 
     rankings.forEach((eachNickname) => {
       const price = Object.values(eachNickname._sum).toString();

--- a/libs/nest-modules-overlay/src/overlay/overlay.service.ts
+++ b/libs/nest-modules-overlay/src/overlay/overlay.service.ts
@@ -303,7 +303,13 @@ export class OverlayService {
   }
 
   // 닉네임과 메세지 (하단띠배너에 사용)
-  async getMessageAndNickname(overlayUrl: string): Promise<NicknameAndText[]> {
+  async getMessageAndNickname({
+    liveShoppingId,
+    overlayUrl,
+  }: {
+    liveShoppingId: number;
+    overlayUrl: string;
+  }): Promise<NicknameAndText[]> {
     const messageAndNickname = await this.prisma.liveShoppingPurchaseMessage.findMany({
       select: {
         nickname: true,
@@ -313,6 +319,7 @@ export class OverlayService {
         broadcaster: {
           overlayUrl: { contains: overlayUrl },
         },
+        liveShoppingId,
         loginFlag: true,
       },
     });


### PR DESCRIPTION
'데이터 재송출' 눌렀을 경우에도 랭킹 데이터를 다시 계산할 수 있도록 liveShoppingId를 전달하도록 수정함