### PR TITLE
fix : [관리자] 정산 탭 눌렀을때 client 오류

### DIFF
--- a/libs/components-admin/src/lib/SettlementTargetList.tsx
+++ b/libs/components-admin/src/lib/SettlementTargetList.tsx
@@ -243,19 +243,19 @@ function SettlementItemInfoDialog({
         items: selectedSettleItem.items.map((item) => {
           let whiletrueCommissionRate: string | null;
           let broadcasterCommissionRate: string | null;
-          if (item.orderItem.support.liveShopping) {
+          if (item.orderItem.support?.liveShopping) {
             whiletrueCommissionRate =
-              item.orderItem.support.liveShopping?.whiletrueCommissionRate.toString() ||
+              item.orderItem.support?.liveShopping?.whiletrueCommissionRate.toString() ||
               null;
             broadcasterCommissionRate =
-              item.orderItem.support.liveShopping?.broadcasterCommissionRate.toString() ||
+              item.orderItem.support?.liveShopping?.broadcasterCommissionRate.toString() ||
               null;
-          } else if (item.orderItem.support.productPromotion) {
+          } else if (item.orderItem.support?.productPromotion) {
             whiletrueCommissionRate =
-              item.orderItem.support.productPromotion?.whiletrueCommissionRate.toString() ||
+              item.orderItem.support?.productPromotion?.whiletrueCommissionRate.toString() ||
               null;
             broadcasterCommissionRate =
-              item.orderItem.support.productPromotion?.broadcasterCommissionRate.toString() ||
+              item.orderItem.support?.productPromotion?.broadcasterCommissionRate.toString() ||
               null;
           } else {
             whiletrueCommissionRate =
@@ -282,13 +282,13 @@ function SettlementItemInfoDialog({
             price:
               Number(item.orderItemOption.discountPrice) * item.orderItemOption.quantity,
             pricePerPiece: Number(item.orderItemOption.discountPrice),
-            sellType: item.orderItem.support.liveShopping
-              ? SellType.liveShopping
-              : item.orderItem.support.productPromotion
-              ? SellType.productPromotion
+            sellType: item.orderItem.support?.liveShopping
+              ? SellType?.liveShopping
+              : item.orderItem.support?.productPromotion
+              ? SellType?.productPromotion
               : SellType.normal,
-            liveShoppingId: item.orderItem.support.liveShopping?.id,
-            productPromotionId: item.orderItem.support.productPromotion?.id,
+            liveShoppingId: item.orderItem.support?.liveShopping?.id,
+            productPromotionId: item.orderItem.support?.productPromotion?.id,
             broadcasterCommissionRate,
             broadcasterCommission,
             whiletrueCommissionRate,
@@ -381,10 +381,10 @@ function SettlementItemOptionDetail({
 
   // 판매 유형
   const sellType = useMemo<'라이브쇼핑' | '상품홍보' | '기본판매'>(() => {
-    if (item.orderItem.support.liveShopping) return '라이브쇼핑';
-    if (item.orderItem.support.productPromotion) return '상품홍보';
+    if (item.orderItem.support?.liveShopping) return '라이브쇼핑';
+    if (item.orderItem.support?.productPromotion) return '상품홍보';
     return '기본판매';
-  }, [item.orderItem.support.liveShopping, item.orderItem.support.productPromotion]);
+  }, [item.orderItem.support?.liveShopping, item.orderItem.support?.productPromotion]);
 
   return (
     <Grid
@@ -461,31 +461,32 @@ function SettlementItemOptionDetail({
 
       <GridItem>판매 수수료</GridItem>
       <GridItem color="green.500">
-        {item.orderItem.support.liveShopping && (
+        {item.orderItem.support?.liveShopping && (
           <CommissionInfo
             totalPrice={totalPrice}
             broadcasterCommissionRate={
-              item.orderItem.support.liveShopping?.broadcasterCommissionRate
+              item.orderItem.support?.liveShopping?.broadcasterCommissionRate
             }
             whiletrueCommissionRate={
-              item.orderItem.support.liveShopping?.whiletrueCommissionRate
+              item.orderItem.support?.liveShopping?.whiletrueCommissionRate
             }
           />
         )}
-        {item.orderItem.support.productPromotion && (
+        {item.orderItem.support?.productPromotion && (
           <CommissionInfo
             totalPrice={totalPrice}
             broadcasterCommissionRate={
-              item.orderItem.support.productPromotion?.broadcasterCommissionRate
+              item.orderItem.support?.productPromotion?.broadcasterCommissionRate
             }
             whiletrueCommissionRate={
-              item.orderItem.support.productPromotion?.whiletrueCommissionRate
+              item.orderItem.support?.productPromotion?.whiletrueCommissionRate
             }
           />
         )}
         {item.orderItem.channel === SellType.normal &&
           !(
-            item.orderItem.support.liveShopping || item.orderItem.support.productPromotion
+            item.orderItem.support?.liveShopping ||
+            item.orderItem.support?.productPromotion
           ) && (
             <Box>
               <Text>
@@ -509,7 +510,6 @@ function SettlementItemOptionDetail({
           <Text>{settlementTarget?.seller?.name}</Text>
           <Text>{settlementTarget?.seller?.sellerShop?.shopName}</Text>
         </Box>
-        ?
       </GridItem>
 
       <GridItem>판매자 정산정보</GridItem>

--- a/libs/components-admin/src/lib/SettlementTargetList.tsx
+++ b/libs/components-admin/src/lib/SettlementTargetList.tsx
@@ -67,7 +67,7 @@ export function SettlementTargetList(): JSX.Element | null {
       {
         header: '판매자명',
         render: (target: SellerSettlementTarget) => (
-          <Td w="100px">{target.seller.sellerShop.shopName}</Td>
+          <Td w="100px">{target?.seller?.sellerShop?.shopName}</Td>
         ),
       },
       {
@@ -117,8 +117,8 @@ export function SettlementTargetList(): JSX.Element | null {
       {
         header: '정산계좌',
         render: (target: SellerSettlementTarget) => {
-          if (!target.seller.sellerSettlementAccount) return <Td>등록안함</Td>;
-          return <Td>{target.seller.sellerSettlementAccount?.[0].bank}</Td>;
+          if (!target?.seller?.sellerSettlementAccount) return <Td>등록안함</Td>;
+          return <Td>{target?.seller?.sellerSettlementAccount?.[0].bank}</Td>;
         },
       },
       {
@@ -215,8 +215,8 @@ function SettlementItemInfoDialog({
   const executeDialog = useDisclosure();
 
   const isAbleToSettle =
-    (selectedSettleItem.seller.sellerSettlementAccount || []).length > 0
-      ? !!selectedSettleItem.seller.sellerSettlementAccount?.[0]
+    (selectedSettleItem?.seller?.sellerSettlementAccount || []).length > 0
+      ? !!selectedSettleItem?.seller?.sellerSettlementAccount?.[0]
       : false;
 
   const [round, setRound] = useState<'1' | '2'>('1');
@@ -226,11 +226,11 @@ function SettlementItemInfoDialog({
 
   const executeSettlement = useCreateSettlementMutation();
   const onConfirm = async (): Promise<void> => {
-    if (!selectedSettleItem.sellerId) return undefined;
+    if (!selectedSettleItem?.sellerId) return undefined;
     if (!selectedSettleItem.exportCode) return undefined;
     return executeSettlement
       .mutateAsync({
-        sellerId: selectedSettleItem.sellerId,
+        sellerId: selectedSettleItem?.sellerId,
         round,
         buyer: selectedSettleItem.order.ordererName,
         recipient: selectedSettleItem.order.recipientName,
@@ -375,8 +375,8 @@ function SettlementItemOptionDetail({
 
   // 정산 정보를 등록했는 지 여부
   const isAbleToSettle =
-    (settlementTarget.seller.sellerSettlementAccount || []).length > 0
-      ? !!settlementTarget.seller.sellerSettlementAccount?.[0]
+    (settlementTarget?.seller?.sellerSettlementAccount || []).length > 0
+      ? !!settlementTarget?.seller?.sellerSettlementAccount?.[0]
       : false;
 
   // 판매 유형
@@ -505,10 +505,11 @@ function SettlementItemOptionDetail({
       <GridItem>판매자</GridItem>
       <GridItem>
         <Box>
-          <Text>{settlementTarget.seller?.email}</Text>
-          <Text>{settlementTarget.seller?.name}</Text>
-          <Text>{settlementTarget.seller?.sellerShop?.shopName}</Text>
+          <Text>{settlementTarget?.seller?.email}</Text>
+          <Text>{settlementTarget?.seller?.name}</Text>
+          <Text>{settlementTarget?.seller?.sellerShop?.shopName}</Text>
         </Box>
+        ?
       </GridItem>
 
       <GridItem>판매자 정산정보</GridItem>

--- a/libs/components-seller/src/lib/ExportDialog.tsx
+++ b/libs/components-seller/src/lib/ExportDialog.tsx
@@ -78,7 +78,17 @@ export function ExportDialog({
       if (isValid) {
         formMethods.setValue(`${orderShippingIdx}.orderId`, orderId);
         const dto = formMethods.getValues(fieldID);
-        const realDto = { ...dto, items: dto.items.filter((x) => !!x.quantity) };
+
+        // 출고처리할 상품의 판매자id 조회 => export.sellerId로 저장
+        const itemIds = dto.items.map((i) => i.orderItemId);
+        const sellerId = order.orderItems.find((oi) => itemIds.includes(oi.id))?.goods
+          ?.sellerId;
+
+        const realDto = {
+          ...dto,
+          sellerId,
+          items: dto.items.filter((x) => !!x.quantity),
+        };
         // 보낼 수량이 0개 인지 체크
         if (realDto.items.every((o) => Number(o.quantity) === 0)) {
           toast({
@@ -92,7 +102,7 @@ export function ExportDialog({
         }
       }
     },
-    [exportOrder, formMethods, onExportFail, onExportSuccess, toast],
+    [exportOrder, formMethods, onExportFail, onExportSuccess, order, toast],
   );
 
   /** 합포장 출고처리가 가능한지 여부 */

--- a/libs/components-seller/src/lib/ExportManyDialog.tsx
+++ b/libs/components-seller/src/lib/ExportManyDialog.tsx
@@ -113,7 +113,13 @@ export function ExportManyDialog({
     const dto: CreateKkshowExportDto[] = [];
     selectedKeys.forEach((k) => {
       const data = formData[Number(k)];
-      const realData = { ...data, items: data.items.filter((x) => !!x.quantity) };
+      const sellerId = orders.find((o) => o.id === data.orderId)?.orderItems[0]?.goods
+        ?.sellerId;
+      const realData = {
+        ...data,
+        items: data.items.filter((x) => !!x.quantity),
+        sellerId,
+      };
       dto.push(realData);
     });
     const realDto = dto.filter((d) =>

--- a/libs/components-seller/src/lib/ExportManyDialog.tsx
+++ b/libs/components-seller/src/lib/ExportManyDialog.tsx
@@ -85,9 +85,17 @@ export function ExportManyDialog({
       if (isValid) {
         formMethods.setValue(`${orderIdx}.orderId`, orderId);
         const dto = formMethods.getValues(fieldID);
+
+        // 출고처리할 상품의 판매자id 조회 => export.sellerId로 저장
+        const itemIds = dto.items.map((i) => i.orderItemId);
+        const sellerId = orders
+          .find((o) => o.id === orderId)
+          ?.orderItems.find((oi) => itemIds.includes(oi.id))?.goods?.sellerId;
+
         // options배열, items의 빈 값 정리
         const realDto = {
           ...dto,
+          sellerId,
           items: dto.items.filter((v) => !!v),
           exportOptions: dto.items.filter((x) => !!x.quantity),
         };
@@ -104,7 +112,7 @@ export function ExportManyDialog({
         }
       }
     },
-    [exportOrder, formMethods, onExportFail, onExportSuccess, toast],
+    [exportOrder, formMethods, onExportFail, onExportSuccess, orders, toast],
   );
 
   /** 폼제출 핸들러 -> 일괄 출고 처리 API 요청 */

--- a/libs/components-seller/src/lib/kkshow-order/ReExportDialog.tsx
+++ b/libs/components-seller/src/lib/kkshow-order/ReExportDialog.tsx
@@ -94,8 +94,14 @@ export function ReExportDialog({
   const exportOrder = useExportOrderMutation();
 
   const processReExport = (data: ReExportData): void => {
+    // 출고처리할 상품의 판매자id 조회 => export.sellerId로 저장
+    const itemIds = data.items.map((i) => i.orderItemId);
+    const sellerId = order.orderItems.find((oi) => itemIds.includes(oi.id))?.goods
+      ?.sellerId;
+
     const dto = {
       ...data,
+      sellerId,
       exchangeExportedFlag: true, // 재출고 처리
       exchangeId: exchangeData.id, // 재출고와 연결할 교환요청 고유번호
     };


### PR DESCRIPTION
원인 : 
정산대상목록(Export 출고데이터)에 sellerId 값이 없는 경우 연결된 판매자의 상점명을 표시할 수 없어서 오류가 났음

해결방안:
- seller?.sellerShop 과 같이 해당 값이 있는 경우에만 표시하도록 수정함
- 판매자센터에서 판매자가 출고를 처리했든, 관리자가 출고를 처리했든 상관없이 해당 상품의 판매자를 출고데이터의 sellerId 값으로 저장함