### PR TITLE
refactor : 검색 쿼리 invalidation 하는 코드 이동

### DIFF
--- a/libs/components-web-kkshow/src/lib/main/carousel/KkshowMainCarouselHeader.tsx
+++ b/libs/components-web-kkshow/src/lib/main/carousel/KkshowMainCarouselHeader.tsx
@@ -20,7 +20,7 @@ export function KkshowMainCarouselHeader({
   if (type === 'upcoming')
     return (
       <KkshowMainCarouselHeaderContainer>
-        <Heading fontSize={{ base: 'lg', md: '3xl' }}>UPCOMMING</Heading>
+        <Heading fontSize={{ base: 'lg', md: '3xl' }}>COMMING SOON</Heading>
       </KkshowMainCarouselHeaderContainer>
     );
 

--- a/libs/components-web-kkshow/src/lib/search-input/Searcher.tsx
+++ b/libs/components-web-kkshow/src/lib/search-input/Searcher.tsx
@@ -3,7 +3,6 @@ import { useKkshowSearchStore } from '@project-lc/stores';
 import { useRouter } from 'next/router';
 import { useCallback, useRef } from 'react';
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
-import { useQueryClient } from 'react-query';
 import shallow from 'zustand/shallow';
 import { FullPageSearchDrawer } from './FullPageSearchBox';
 import { DesktopSearchInputBox } from './DesktopSearchInputBox';
@@ -14,7 +13,7 @@ interface SearchForm {
 export function Searcher(): JSX.Element {
   const toast = useToast();
   const router = useRouter();
-  const queryClient = useQueryClient();
+
   const searchStore = useKkshowSearchStore(
     (s) => ({
       appendKeyword: s.appendKeyword,
@@ -35,8 +34,8 @@ export function Searcher(): JSX.Element {
   const onSubmit: SubmitHandler<SearchForm> = (formData): void => {
     if (formData.keyword) {
       searchStore.appendKeyword(formData.keyword);
+
       router.push({ pathname: '/search', query: { keyword: formData.keyword } });
-      queryClient.invalidateQueries('getSearchResults');
       searchStore.closeSearchDrawer();
     } else {
       focusOnInput();

--- a/libs/components-web-kkshow/src/lib/search/SearchPageLayout.tsx
+++ b/libs/components-web-kkshow/src/lib/search/SearchPageLayout.tsx
@@ -6,6 +6,7 @@ import { useKkshowSearchResults } from '@project-lc/hooks';
 import { SearchResult } from '@project-lc/shared-types';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import { useQueryClient } from 'react-query';
 import KkshowNavbar from '../KkshowNavbar';
 import KKshowMainExternLinks from '../main/KKshowMainExternLinks';
 
@@ -38,6 +39,7 @@ export function useSearchPageState(): {
   searchKeyword?: string;
 } {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { keyword } = router.query;
 
   const searchKeyword = keyword ? (keyword as string) : undefined;
@@ -48,7 +50,10 @@ export function useSearchPageState(): {
 
   useEffect(() => {
     setQuery(keyword ? (keyword as string) : undefined);
-  }, [keyword]);
+    if (keyword) {
+      queryClient.invalidateQueries('getSearchResults');
+    }
+  }, [keyword, queryClient]);
 
   return {
     data,


### PR DESCRIPTION
- 최초 검색시 검색결과가 있음에도 표시되지 않는 문제가 있어서 router로 페이지 이동 후 invalidation 실행하도록 코드 위치 수정함
- [크크쇼 메인 캐러셀] 문구 수정