### PR TITLE
fix : 관리자 주문 내보내기 시 빈 파일 다운되는 현상 수정

### DIFF
--- a/libs/components-admin/src/lib/AdminOrderList.tsx
+++ b/libs/components-admin/src/lib/AdminOrderList.tsx
@@ -1,5 +1,13 @@
 import { Box, Icon, Link, Text, useDisclosure } from '@chakra-ui/react';
-import { GridColumns, GridRowData, GridRowId, GridToolbar } from '@material-ui/data-grid';
+import {
+  GridColumns,
+  GridRowData,
+  GridRowId,
+  GridToolbarColumnsButton,
+  GridToolbarContainer,
+  GridToolbarDensitySelector,
+  GridToolbarFilterButton,
+} from '@material-ui/data-grid';
 import { ChakraDataGrid } from '@project-lc/components-core/ChakraDataGrid';
 import { OrderStatusBadge } from '@project-lc/components-shared/order/OrderStatusBadge';
 import { OrderToolbar } from '@project-lc/components-seller/kkshow-order/OrderList';
@@ -105,7 +113,6 @@ const columns: GridColumns = [
 ];
 
 export function AdminOrderList(): JSX.Element {
-  const exportManyDialog = useDisclosure();
   // 페이지당 행 select
   const rowsPerPageOptions = useRef<number[]>([10, 20, 50, 100]);
   const mapPageToNextCursor = useRef<{ [page: number]: GridRowId }>({});
@@ -114,6 +121,7 @@ export function AdminOrderList(): JSX.Element {
   // 페이지
   const [page, setPage] = useState(0);
 
+  const exportManyDialog = useDisclosure();
   const sellerOrderStates = useSellerOrderStore();
 
   const handlePageChange = (newPage: number): void => {
@@ -175,10 +183,17 @@ export function AdminOrderList(): JSX.Element {
         checkboxSelection
         selectionModel={sellerOrderStates.selectedOrders}
         onSelectionModelChange={sellerOrderStates.handleOrderSelected}
+        componentsProps={{
+          toolbar: { exportOptions: { disabledToolbarButton: true } },
+        }}
         components={{
           Toolbar: () => (
             <>
-              <GridToolbar />
+              <GridToolbarContainer>
+                <GridToolbarColumnsButton />
+                <GridToolbarFilterButton />
+                <GridToolbarDensitySelector />
+              </GridToolbarContainer>
               <OrderToolbar
                 options={[
                   {

--- a/libs/components-seller/src/lib/kkshow-order/OrderListDownloadDialog.tsx
+++ b/libs/components-seller/src/lib/kkshow-order/OrderListDownloadDialog.tsx
@@ -50,9 +50,12 @@ export function OrderListDownloadDialog({
   // 선택된 주문
   const selectedOrders = useSellerOrderStore((state) => state.selectedOrders);
   // 선택된 주문 상세 정보 조회
+  // 해당 기능은 판매자와 관리자센터 양쪽에서 사용함
+  // 로그인한 사용자가 판매자인 경우에만 해당 판매자의id를 보내서, 주문에 포함된 해당 판매자의 상품만 조회하도록 함
+  // 로그인한 사용자가 관리자인 경우에는 sellerId를 보내지 않음 -> 주문에 포함된 모든 상품 조회
   const orderDetails = useOrderDetailsForSpreadsheet({
     orderIds: selectedOrders.map((orderId) => Number(orderId)),
-    sellerId: profileData?.id,
+    sellerId: profileData && profileData.type === 'seller' ? profileData.id : undefined,
   });
 
   const disableHeaders = useOrderListDownloadStore((st) => st.disableHeaders);

--- a/libs/shreadsheet/src/spreadsheet/orderSpreadSheetGenerator.ts
+++ b/libs/shreadsheet/src/spreadsheet/orderSpreadSheetGenerator.ts
@@ -182,7 +182,7 @@ export class OrderSpreadSheetGenerator extends SpreadSheetGenerator<OrderDetailR
   protected getSheetRef(orders: OrderDetailRes[]): string {
     const lengthOfRows = orders.reduce((prev, curr) => {
       let num = 0;
-      curr.shippings.forEach((ship: any) => {
+      curr.shippings?.forEach((ship: any) => {
         ship.items.forEach((item: any) => {
           item.options.forEach(() => {
             num += 1;
@@ -215,8 +215,11 @@ export class OrderSpreadSheetGenerator extends SpreadSheetGenerator<OrderDetailR
       // 셀병합위해 사용할 주문상품옵션 순회 인덱스(해당 주문에 포함된 주문상품옵션 중 마지막 값인지 확인하기 위한 용도)
       let orderItemOptionIndex = 0;
 
-      order.shippings.forEach((ship) => {
+      // 주문에 포함된 배송비별로 주문상품표시
+      order.shippings?.forEach((ship) => {
+        // 현재 배송비에 포함된 상품id 목록
         const shipItemIdList = ship.items.map((item) => item.id);
+        // 주문상품 중 현재 배송비와 연결된 상품들
         const shippingOrderItems = order.orderItems.filter((oi) =>
           shipItemIdList.includes(oi.id),
         );


### PR DESCRIPTION
- 관리자 주문 내보내기 버튼 두개라 헷갈림 mui datagrid 내장 내보내기 버튼 삭제
- 주문 내보내기 툴바는 관리자, 판매자 두 앱에서 사용됨. 로그인한 사용자 타입이 판매자인 경우에만 sellerId를 보내서, 주문에 포함된 해당 판매자의 상품만 조회하도록 수정함