### PR TITLE
fix : 구매확정 요청 dto에 buyConfirmSubject 값 추가

### DIFF
--- a/libs/hooks/src/lib/mutation/useOrderPurchaseConfirmMutation.tsx
+++ b/libs/hooks/src/lib/mutation/useOrderPurchaseConfirmMutation.tsx
@@ -15,9 +15,22 @@ export const useOrderPurchaseConfirmMutation = (
   options?: UseMutationOptions<boolean, AxiosError, useOrderPurchaseConfirmMutationDto>,
 ): UseMutationResult<boolean, AxiosError, useOrderPurchaseConfirmMutationDto> => {
   const queryClient = useQueryClient();
+  const appType = process.env.NEXT_PUBLIC_APP_TYPE;
+  /** 크크쇼에서 요청시 구매확정주체 = 소비자
+   * 다른데(관리자)서 요청시 구매확정주체를 Undefined로 넘김 => 구매확정주체 관리자로 처리됨
+   *
+   *  구매확정주체가 Undefined로 들어가면 Post /order/purchase-confirm 의 @Body validation 과정에서
+   * OrderPurchaseConfirmationDto.buyConfirmSubject의 기본값인 admin이 저장됨
+   */
+  const confirmSubject = appType === 'customer' ? 'customer' : undefined;
   return useMutation<boolean, AxiosError, useOrderPurchaseConfirmMutationDto>(
     (dto: useOrderPurchaseConfirmMutationDto) =>
-      axios.post<boolean>(`order/purchase-confirm`, dto).then((res) => res.data),
+      axios
+        .post<boolean>(`order/purchase-confirm`, {
+          ...dto,
+          buyConfirmSubject: confirmSubject,
+        })
+        .then((res) => res.data),
     {
       onSuccess: () => {
         queryClient.invalidateQueries(INFINITE_ORDER_LIST_QUERY_KEY);


### PR DESCRIPTION
문제상황 : 크크쇼 소비자 주문목록에서 구매확정을 해도 구매확정주체가 admin으로 찍힘

해결방법 : 크크쇼에서 소비자가 구매확정 누르는 경우에만 customer로 값 전달